### PR TITLE
feat: MVP of ABI generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Build files
+/target
+Cargo.lock
+
+# Code Editor related files
+.idea
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "cargo-near"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/near/cargo-near"
+description = """
+Cargo extension for building Rust smart contracts on NEAR.
+"""
+
+[dependencies]
+anyhow = "1.0"
+cargo_metadata = "0.14"
+clap = { version = "3.2", features = ["derive", "env"] }
+colored = "2.0"
+env_logger = "0.9"
+near-sdk = { git = "https://github.com/near/near-sdk-rs.git", branch = "daniyar/abi-macro", features = ["abi"] }
+log = "0.4"
+prettyplease = "0.1"
+tempfile = "3.3"
+toml = "0.5"
+serde_json = "1.0"
+symbolic-debuginfo = "8.8"
+syn = "1.0"
+quote = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ cargo_metadata = "0.14"
 clap = { version = "3.2", features = ["derive", "env"] }
 colored = "2.0"
 env_logger = "0.9"
-near-sdk = { git = "https://github.com/near/near-sdk-rs.git", ref = "9ab6df8ed35e67c247299059d8277c2170a0a91b", features = ["abi"] }
+near-sdk = { git = "https://github.com/near/near-sdk-rs.git", rev = "9ab6df8ed35e67c247299059d8277c2170a0a91b", features = ["abi"] }
 log = "0.4"
 prettyplease = "0.1"
 toml = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ cargo_metadata = "0.14"
 clap = { version = "3.2", features = ["derive", "env"] }
 colored = "2.0"
 env_logger = "0.9"
-near-sdk = { git = "https://github.com/near/near-sdk-rs.git", branch = "daniyar/abi-macro", features = ["abi"] }
+near-sdk = { git = "https://github.com/near/near-sdk-rs.git", ref = "9ab6df8ed35e67c247299059d8277c2170a0a91b", features = ["abi"] }
 log = "0.4"
 prettyplease = "0.1"
 tempfile = "3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ env_logger = "0.9"
 near-sdk = { git = "https://github.com/near/near-sdk-rs.git", ref = "9ab6df8ed35e67c247299059d8277c2170a0a91b", features = ["abi"] }
 log = "0.4"
 prettyplease = "0.1"
-tempfile = "3.3"
 toml = "0.5"
 serde_json = "1.0"
 symbolic-debuginfo = "8.8"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # cargo-near
 Cargo extension for building Rust smart contracts on NEAR
+
+To install:
+```
+cargo install --path .
+```
+
+To generate ABI for a contract (while standing in the directory containing contract's Cargo.toml):
+```
+cargo near abi
+```

--- a/README.md
+++ b/README.md
@@ -10,3 +10,8 @@ To generate ABI for a contract (while standing in the directory containing contr
 ```
 cargo near abi
 ```
+
+Or explicitly specify path to the Cargo manifest:
+```
+cargo near abi --manifest-path path/to/Cargo.toml
+```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ To install:
 cargo install --path .
 ```
 
-To generate ABI for a contract (while standing in the directory containing contract's Cargo.toml):
+To generate ABI for a contract (while in the directory containing contract's Cargo.toml):
 ```
 cargo near abi
 ```

--- a/src/abi/generation.rs
+++ b/src/abi/generation.rs
@@ -1,0 +1,149 @@
+use crate::cargo::manifest::CargoManifestPath;
+use quote::{format_ident, quote};
+use std::path::{Path, PathBuf};
+use std::{collections::HashSet, fs};
+use toml::value;
+
+pub(crate) fn generate_toml(manifest_path: &CargoManifestPath) -> anyhow::Result<String> {
+    let original_cargo_toml = fs::read_to_string(&manifest_path.path)?;
+    let original_cargo_toml: toml::value::Table = toml::from_str(&original_cargo_toml)?;
+
+    let mut near_sdk = original_cargo_toml
+        .get("dependencies")
+        .ok_or_else(|| anyhow::anyhow!("[dependencies] section not found"))?
+        .get("near-sdk")
+        .ok_or_else(|| anyhow::anyhow!("near-sdk dependency not found"))?
+        .as_table()
+        .ok_or_else(|| anyhow::anyhow!("near-sdk dependency should be a table"))?
+        .clone();
+
+    let cargo_toml = include_str!("../../templates/_Cargo.toml");
+    let mut cargo_toml: toml::value::Table = toml::from_str(cargo_toml)?;
+    let deps = cargo_toml
+        .get_mut("dependencies")
+        .expect("[dependencies] section specified in the template")
+        .as_table_mut()
+        .expect("[dependencies] is a table specified in the template");
+
+    // Make near-sdk dependency use default features
+    near_sdk.remove("default-features");
+    near_sdk.remove("optional");
+    near_sdk.insert(
+        "features".to_string(),
+        value::Value::Array(vec![value::Value::String("abi".to_string())]),
+    );
+
+    // Convert NEAR SDK path to absolute
+    if let Some(near_sdk_path) = near_sdk.get_mut("path") {
+        let path = near_sdk_path
+            .as_str()
+            .expect("NEAR SDK path should be a string");
+        let path = PathBuf::from(path);
+        *near_sdk_path = value::Value::String(path.canonicalize()?.to_string_lossy().into());
+    }
+
+    deps.insert("near-sdk".into(), near_sdk.into());
+
+    let cargo_toml = toml::to_string(&cargo_toml)?;
+
+    log::debug!("Cargo.toml contents:\n{}", &cargo_toml);
+
+    Ok(cargo_toml)
+}
+
+pub(crate) fn generate_build_rs(dylib_path: &Path) -> anyhow::Result<String> {
+    let dylib_dir = dylib_path.parent().ok_or_else(|| {
+        anyhow::anyhow!(
+            "Unable to infer the directory containing dylib file: {}",
+            dylib_path.display()
+        )
+    })?;
+    let dylib_name = dylib_path
+        .file_stem()
+        .ok_or_else(|| anyhow::anyhow!("Generated dylib is not a file: {}", dylib_path.display()))?
+        .to_str()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Unable to infer the directory containing dylib file: {}",
+                dylib_path.display()
+            )
+        })?;
+
+    let dylib_name = if let Some(dylib_name_stripped) = dylib_name.strip_prefix("lib") {
+        dylib_name_stripped
+    } else {
+        anyhow::bail!(
+            "Expected the generated dylib file to start with 'lib', but got '{}'",
+            dylib_name
+        );
+    };
+
+    let cargo_link_lib = format!("cargo:rustc-link-lib=dylib={}", &dylib_name);
+    let cargo_link_search = format!("cargo:rustc-link-search=all={}", dylib_dir.display());
+
+    let build_rs = quote! {
+        fn main() {
+            println!(#cargo_link_lib);
+            println!(#cargo_link_search);
+        }
+    }
+    .to_string();
+    let build_rs_file = syn::parse_file(&build_rs).unwrap();
+    let build_rs = prettyplease::unparse(&build_rs_file);
+
+    log::debug!("build.rs contents:\n{}", &build_rs);
+
+    Ok(build_rs)
+}
+
+pub(crate) fn generate_main_rs(dylib_path: &Path) -> anyhow::Result<String> {
+    let dylib_file_contents = fs::read(&dylib_path)?;
+    let object = symbolic_debuginfo::Object::parse(&dylib_file_contents)?;
+    log::debug!(
+        "A dylib was built at {:?} with format {} for architecture {}",
+        &dylib_path,
+        &object.file_format(),
+        &object.arch()
+    );
+    let near_abi_symbols = object
+        .symbols()
+        .flat_map(|sym| sym.name)
+        .filter(|sym_name| sym_name.starts_with("__near_abi_"))
+        .map(|sym_name| sym_name.to_string())
+        .collect::<HashSet<_>>();
+    log::debug!("Detected NEAR ABI symbols: {:?}", &near_abi_symbols);
+
+    let near_abi_function_defs = near_abi_symbols.iter().map(|s| {
+        let name = format_ident!("{}", s);
+        quote! {
+            fn #name() -> near_sdk::__private::AbiRoot;
+        }
+    });
+    let near_abi_function_invocations = near_abi_symbols.iter().map(|s| {
+        let name = format_ident!("{}", s);
+        quote! {
+            #name()
+        }
+    });
+
+    let main_rs = quote! {
+        extern "Rust" {
+            #(#near_abi_function_defs)*
+        }
+
+        fn main() -> Result<(), std::io::Error> {
+            let root_abis = unsafe { vec![#(#near_abi_function_invocations),*] };
+            let combined_root_abi = near_sdk::__private::AbiRoot::combine(root_abis);
+            let contents = serde_json::to_string_pretty(&combined_root_abi)?;
+            print!("{}", contents);
+            Ok(())
+        }
+    }
+    .to_string();
+    let main_rs_file = syn::parse_file(&main_rs).unwrap();
+    let main_rs = prettyplease::unparse(&main_rs_file);
+
+    log::debug!("main.rs contents:\n{}", &main_rs);
+
+    Ok(main_rs)
+}

--- a/src/abi/generation.rs
+++ b/src/abi/generation.rs
@@ -38,7 +38,7 @@ pub(crate) fn generate_toml(manifest_path: &CargoManifestPath) -> anyhow::Result
         let path = near_sdk_path
             .as_str()
             .expect("NEAR SDK path should be a string");
-        let path = PathBuf::from(path);
+        let path = manifest_path.directory()?.join(PathBuf::from(path));
         *near_sdk_path = value::Value::String(path.canonicalize()?.to_string_lossy().into());
     }
 

--- a/src/abi/mod.rs
+++ b/src/abi/mod.rs
@@ -1,0 +1,70 @@
+use crate::cargo::{manifest::CargoManifestPath, metadata::CrateMetadata};
+use crate::util;
+use near_sdk::__private::{AbiMetadata, AbiRoot};
+use std::collections::HashMap;
+use std::{fs, path::PathBuf};
+
+mod generation;
+
+const ABI_FILE: &str = "abi.json";
+
+/// ABI generation result.
+pub(crate) struct AbiResult {
+    /// Path to the resulting ABI file.
+    pub path: PathBuf,
+}
+
+pub(crate) fn execute(manifest_path: &CargoManifestPath) -> anyhow::Result<AbiResult> {
+    let tmp_dir = tempfile::Builder::new()
+        .prefix("cargo-contract_")
+        .tempdir()?;
+    log::debug!(
+        "Using temp Cargo workspace at '{}'",
+        tmp_dir.path().display()
+    );
+
+    let crate_metadata = CrateMetadata::collect(manifest_path)?;
+    let dylib_path = util::compile_dylib_project(manifest_path)?;
+
+    let cargo_toml = generation::generate_toml(manifest_path)?;
+    fs::write(tmp_dir.path().join("Cargo.toml"), cargo_toml)?;
+
+    let build_rs = generation::generate_build_rs(&dylib_path)?;
+    fs::write(tmp_dir.path().join("build.rs"), build_rs)?;
+
+    let main_rs = generation::generate_main_rs(&dylib_path)?;
+    fs::write(tmp_dir.path().join("main.rs"), main_rs)?;
+
+    let target_dir_arg = format!(
+        "--target-dir={}",
+        crate_metadata.target_directory.to_string_lossy()
+    );
+    let stdout = util::invoke_cargo(
+        "run",
+        &["--package", "near-abi-gen", "--release", &target_dir_arg],
+        Some(tmp_dir.path()),
+        vec![(
+            "LD_LIBRARY_PATH",
+            &dylib_path.parent().unwrap().to_string_lossy(),
+        )],
+    )?;
+
+    let mut near_abi: AbiRoot = serde_json::from_slice(&stdout)?;
+    let metadata = extract_metadata(&crate_metadata);
+    near_abi.metadata = metadata;
+    let near_abi_json = serde_json::to_string_pretty(&near_abi)?;
+    let out_path_abi = crate_metadata.target_directory.join(ABI_FILE);
+    fs::write(&out_path_abi, near_abi_json)?;
+
+    Ok(AbiResult { path: out_path_abi })
+}
+
+fn extract_metadata(crate_metadata: &CrateMetadata) -> AbiMetadata {
+    let package = &crate_metadata.root_package;
+    AbiMetadata {
+        name: Some(package.name.clone()),
+        version: Some(package.version.to_string()),
+        authors: package.authors.clone(),
+        other: HashMap::new(),
+    }
+}

--- a/src/cargo/manifest.rs
+++ b/src/cargo/manifest.rs
@@ -1,0 +1,37 @@
+use std::path::{Path, PathBuf};
+
+const MANIFEST_FILE_NAME: &str = "Cargo.toml";
+
+/// Path to a `Cargo.toml` file
+#[derive(Clone, Debug)]
+pub struct CargoManifestPath {
+    /// Absolute path to the manifest file
+    pub path: PathBuf,
+}
+
+impl CargoManifestPath {
+    /// The directory path of the manifest path, if there is one.
+    pub fn directory(&self) -> anyhow::Result<&Path> {
+        self.path.parent().ok_or_else(|| {
+            anyhow::anyhow!("Unable to infer the directory containing Cargo.toml file")
+        })
+    }
+}
+
+impl TryFrom<PathBuf> for CargoManifestPath {
+    type Error = anyhow::Error;
+
+    fn try_from(manifest_path: PathBuf) -> Result<Self, Self::Error> {
+        if let Some(file_name) = manifest_path.file_name() {
+            if file_name != MANIFEST_FILE_NAME {
+                anyhow::bail!("Manifest file must be a Cargo.toml")
+            }
+        }
+        let canonical_manifest_path = manifest_path.canonicalize().map_err(|err| {
+            anyhow::anyhow!("Failed to canonicalize {:?}: {:?}", manifest_path, err)
+        })?;
+        Ok(CargoManifestPath {
+            path: canonical_manifest_path,
+        })
+    }
+}

--- a/src/cargo/metadata.rs
+++ b/src/cargo/metadata.rs
@@ -1,0 +1,66 @@
+use crate::cargo::manifest::CargoManifestPath;
+use anyhow::{Context, Result};
+use cargo_metadata::{MetadataCommand, Package};
+use std::path::PathBuf;
+
+/// Relevant metadata obtained from Cargo.toml.
+#[derive(Debug)]
+pub(crate) struct CrateMetadata {
+    pub root_package: Package,
+    pub target_directory: PathBuf,
+}
+
+impl CrateMetadata {
+    /// Parses the contract manifest and returns relevant metadata.
+    pub fn collect(manifest_path: &CargoManifestPath) -> Result<Self> {
+        let (metadata, root_package) = get_cargo_metadata(manifest_path)?;
+        let mut target_directory = metadata.target_directory.as_path().join("near");
+
+        // Normalize the package and lib name.
+        let package_name = root_package.name.replace('-', "_");
+
+        let absolute_manifest_path = manifest_path.directory()?;
+        let absolute_workspace_root = metadata.workspace_root.canonicalize()?;
+        if absolute_manifest_path != absolute_workspace_root {
+            // If the contract is a package in a workspace, we use the package name
+            // as the name of the sub-folder where we put the `.contract` bundle.
+            target_directory = target_directory.join(package_name);
+        }
+
+        let crate_metadata = CrateMetadata {
+            root_package,
+            target_directory: target_directory.into(),
+        };
+        Ok(crate_metadata)
+    }
+}
+
+/// Get the result of `cargo metadata`, together with the root package id.
+fn get_cargo_metadata(
+    manifest_path: &CargoManifestPath,
+) -> Result<(cargo_metadata::Metadata, Package)> {
+    log::info!(
+        "Fetching cargo metadata for {}",
+        manifest_path.path.to_string_lossy()
+    );
+    let mut cmd = MetadataCommand::new();
+    let metadata = cmd
+        .manifest_path(&manifest_path.path)
+        .exec()
+        .context("Error invoking `cargo metadata`")?;
+    let root_package_id = metadata
+        .resolve
+        .as_ref()
+        .and_then(|resolve| resolve.root.as_ref())
+        .context("Cannot infer the root project id")?
+        .clone();
+    // Find the root package by id in the list of packages. It is logical error if the root
+    // package is not found in the list.
+    let root_package = metadata
+        .packages
+        .iter()
+        .find(|package| package.id == root_package_id)
+        .expect("The package is not found in the `cargo metadata` output")
+        .clone();
+    Ok((metadata, root_package))
+}

--- a/src/cargo/mod.rs
+++ b/src/cargo/mod.rs
@@ -1,0 +1,2 @@
+pub mod manifest;
+pub mod metadata;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,70 @@
+use cargo::manifest::CargoManifestPath;
+use clap::{AppSettings, Args, Parser, Subcommand};
+use colored::Colorize;
+use std::path::PathBuf;
+
+mod abi;
+mod cargo;
+mod util;
+
+#[derive(Debug, Parser)]
+#[clap(bin_name = "cargo")]
+pub(crate) enum Opts {
+    #[clap(name = "near")]
+    #[clap(setting = AppSettings::DeriveDisplayOrder)]
+    Near(NearArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct NearArgs {
+    #[clap(subcommand)]
+    cmd: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Generates ABI for the contract
+    #[clap(name = "abi")]
+    Abi(AbiCommand),
+}
+
+#[derive(Debug, clap::Args)]
+#[clap(name = "abi")]
+pub struct AbiCommand {
+    /// Path to the `Cargo.toml` of the contract to build
+    #[clap(long, parse(from_os_str))]
+    manifest_path: Option<PathBuf>,
+}
+
+fn main() {
+    env_logger::init();
+
+    let Opts::Near(args) = Opts::parse();
+    match exec(args.cmd) {
+        Ok(()) => {}
+        Err(err) => {
+            eprintln!(
+                "{} {}",
+                "ERROR:".bright_red().bold(),
+                format!("{:?}", err).bright_red()
+            );
+            std::process::exit(1);
+        }
+    }
+}
+
+fn exec(cmd: Command) -> anyhow::Result<()> {
+    match &cmd {
+        Command::Abi(abi) => {
+            let manifest_path = abi
+                .manifest_path
+                .clone()
+                .unwrap_or_else(|| "Cargo.toml".into());
+            let manifest_path = CargoManifestPath::try_from(manifest_path)?;
+
+            let result = abi::execute(&manifest_path)?;
+            println!("ABI successfully generated at {}", result.path.display());
+            Ok(())
+        }
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,108 @@
+use anyhow::{Context, Result};
+use cargo_metadata::Message;
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::cargo::manifest::CargoManifestPath;
+
+/// Invokes `cargo` with the subcommand `command`, the supplied `args` and set `env` variables.
+///
+/// If `working_dir` is set, cargo process will be spawned in the specified directory.
+///
+/// Returns execution standard output as a byte array.
+pub(crate) fn invoke_cargo<I, S, P>(
+    command: &str,
+    args: I,
+    working_dir: Option<P>,
+    env: Vec<(&str, &str)>,
+) -> Result<Vec<u8>>
+where
+    I: IntoIterator<Item = S> + std::fmt::Debug,
+    S: AsRef<OsStr>,
+    P: AsRef<Path>,
+{
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+    let mut cmd = Command::new(cargo);
+
+    env.iter().for_each(|(env_key, env_val)| {
+        cmd.env(env_key, env_val);
+    });
+
+    if let Some(path) = working_dir {
+        log::debug!("Setting cargo working dir to '{}'", path.as_ref().display());
+        cmd.current_dir(path);
+    }
+
+    cmd.arg(command);
+    cmd.args(args);
+
+    log::info!("Invoking cargo: {:?}", cmd);
+
+    let child = cmd
+        // capture the stdout to return from this function as bytes
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .context(format!("Error executing `{:?}`", cmd))?;
+    let output = child.wait_with_output()?;
+
+    if output.status.success() {
+        Ok(output.stdout)
+    } else {
+        anyhow::bail!(
+            "`{:?}` failed with exit code: {:?}",
+            cmd,
+            output.status.code()
+        );
+    }
+}
+
+fn build_cargo_project(manifest_path: &CargoManifestPath) -> anyhow::Result<Vec<Message>> {
+    let output = invoke_cargo(
+        "build",
+        &["--release", "--message-format=json"],
+        manifest_path.directory().ok(),
+        vec![],
+    )?;
+
+    let reader = std::io::BufReader::new(output.as_slice());
+    Ok(Message::parse_stream(reader).map(|m| m.unwrap()).collect())
+}
+
+/// Builds the cargo project with manifest located at `manifest_path` and returns the path to the generated dynamic lib.
+pub(crate) fn compile_dylib_project(manifest_path: &CargoManifestPath) -> anyhow::Result<PathBuf> {
+    let messages = build_cargo_project(manifest_path)?;
+    // We find the last compiler artifact message which should contain information about the
+    // resulting .so file
+    let compile_artifact = messages
+        .iter()
+        .filter_map(|m| match m {
+            cargo_metadata::Message::CompilerArtifact(artifact) => Some(artifact),
+            _ => None,
+        })
+        .last()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Cargo failed to produce any compilation artifacts. \
+                 Please check that your project contains a NEAR smart contract."
+            )
+        })?;
+    // The project could have generated many auxiliary files, we are only interested in .so files
+    let so_files = compile_artifact
+        .filenames
+        .iter()
+        .cloned()
+        .filter(|f| f.as_str().ends_with(".so"))
+        .collect::<Vec<_>>();
+    match so_files.as_slice() {
+        [] => Err(anyhow::anyhow!(
+            "Compilation resulted in no '.so' target files. \
+                 Please check that your project contains a NEAR smart contract."
+        )),
+        [file] => Ok(file.to_owned().into_std_path_buf()),
+        _ => Err(anyhow::anyhow!(
+            "Compilation resulted in more than one '.so' target file: {:?}",
+            so_files
+        )),
+    }
+}

--- a/templates/_Cargo.toml
+++ b/templates/_Cargo.toml
@@ -11,3 +11,6 @@ path = "main.rs"
 
 [dependencies]
 serde_json = "1.0"
+
+[workspace]
+members = []

--- a/templates/_Cargo.toml
+++ b/templates/_Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "near-abi-gen"
+version = "0.1.0"
+edition = "2021"
+publish = false
+build = "build.rs"
+
+[[bin]]
+name = "near-abi-gen"
+path = "main.rs"
+
+[dependencies]
+serde_json = "1.0"


### PR DESCRIPTION
This iteration of cargo-near follows the new approach with dynamic linking to a shared library that I presented before.

~A couple of places presume ELF (filtering by `.so` suffix, stripping `lib` prefix from the shared library), but I think with minimal tweaks the same will work for MachO and PE.~ UPD: made some tweaks, works on Linux & macOS (M1, but should not matter I think). I don't have easy access to a Windows machine so that would have to be done a bit later.

`prettyprint` and `syn` dependencies could be removed, but I thought generating readable code would be nice (especially since I am logging it for visibility).