### PR TITLE
feat: optimize ABI generation time

### DIFF
--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -15,7 +15,7 @@ cargo_metadata = "0.14"
 clap = { version = "3.2", features = ["derive", "env"] }
 colored = "2.0"
 env_logger = "0.9"
-near-sdk = { git = "https://github.com/near/near-sdk-rs.git", rev = "11f60860fd6c34e9d27f37bb1ff9930c2aaa42e3", features = ["abi"] }
+near-sdk = { git = "https://github.com/near/near-sdk-rs.git", rev = "83df045aded3e1b14c372ebc36a53ca71cfb4f07", features = ["abi"] }
 log = "0.4"
 prettyplease = "0.1"
 toml = "0.5"

--- a/cargo-near/src/abi/generation.rs
+++ b/cargo-near/src/abi/generation.rs
@@ -26,7 +26,6 @@ pub(crate) fn generate_toml(manifest_path: &CargoManifestPath) -> anyhow::Result
         .expect("[dependencies] is a table specified in the template");
 
     // Make near-sdk dependency not use default features to save on compilation time, but ensure `abi` is enabled
-    near_sdk.remove("default-features");
     near_sdk.remove("optional");
     near_sdk.insert("default-features".to_string(), value::Value::Boolean(false));
     near_sdk.insert(

--- a/cargo-near/src/abi/generation.rs
+++ b/cargo-near/src/abi/generation.rs
@@ -25,9 +25,10 @@ pub(crate) fn generate_toml(manifest_path: &CargoManifestPath) -> anyhow::Result
         .as_table_mut()
         .expect("[dependencies] is a table specified in the template");
 
-    // Make near-sdk dependency use default features
+    // Make near-sdk dependency not use default features to save on compilation time, but ensure `abi` is enabled
     near_sdk.remove("default-features");
     near_sdk.remove("optional");
+    near_sdk.insert("default-features".to_string(), value::Value::Boolean(false));
     near_sdk.insert(
         "features".to_string(),
         value::Value::Array(vec![value::Value::String("abi".to_string())]),

--- a/cargo-near/src/abi/mod.rs
+++ b/cargo-near/src/abi/mod.rs
@@ -38,7 +38,7 @@ pub(crate) fn execute(manifest_path: &CargoManifestPath) -> anyhow::Result<AbiRe
 
     let stdout = util::invoke_cargo(
         "run",
-        &["--package", "near-abi-gen", "--release"],
+        &["--package", "near-abi-gen"],
         Some(near_abi_gen_dir),
         vec![(
             "LD_LIBRARY_PATH",

--- a/cargo-near/src/util.rs
+++ b/cargo-near/src/util.rs
@@ -93,9 +93,13 @@ where
 fn build_cargo_project(manifest_path: &CargoManifestPath) -> anyhow::Result<Vec<Message>> {
     let output = invoke_cargo(
         "build",
-        &["--release", "--message-format=json"],
+        &["--message-format=json"],
         manifest_path.directory().ok(),
-        vec![],
+        vec![
+            ("CARGO_PROFILE_DEV_OPT_LEVEL", "0"),
+            ("CARGO_PROFILE_DEV_DEBUG", "0"),
+            ("CARGO_PROFILE_DEV_LTO", "off"),
+        ],
     )?;
 
     let reader = std::io::BufReader::new(output.as_slice());

--- a/cargo-near/templates/_Cargo.toml
+++ b/cargo-near/templates/_Cargo.toml
@@ -9,6 +9,11 @@ build = "build.rs"
 name = "near-abi-gen"
 path = "main.rs"
 
+[profile.dev]
+opt-level = 0
+debug = 0
+lto = "off"
+
 [dependencies]
 serde_json = "1.0"
 

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 anyhow = "1.0"
 cargo-near = { path = "../cargo-near" }
 function_name = "0.3"
-near-sdk = { git = "https://github.com/near/near-sdk-rs.git", rev = "11f60860fd6c34e9d27f37bb1ff9930c2aaa42e3", features = ["abi"] }
+near-sdk = { git = "https://github.com/near/near-sdk-rs.git", rev = "83df045aded3e1b14c372ebc36a53ca71cfb4f07", features = ["abi"] }
 prettyplease = "0.1"
 proc-macro2 = "1.0"
 schemars = "0.8"


### PR DESCRIPTION
Fixes #8 

This PR introduces three compilation time improvements:
1. Removes `nearcore` crate dependencies from the generated abigen crates (reduces compilation time from 22.5s to 10.5s on `abi` example in NEAR SDK).
2. Makes the generated abigen crates use `dev` profile with disabled optimizations and disabled LTO (reduces compilation town from 10.5s further to 9.5s)
3. Makes the original (user-written) crate use `dev` profile with disabled optimizations and disabled LTO through cargo envvars (reduces dylib compilation time from 25s to 21.5s).