### PR TITLE
split CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: tests
+name: CI
 
 on:
   push:
@@ -23,6 +23,7 @@ jobs:
           echo "::set-output name=tests::[$INTEGRATION_TESTS]"
       
   integration-test:
+    name: "${{ matrix.test }} (${{ matrix.platform }}, ${{ matrix.toolchain }}"
     runs-on: ${{ matrix.platform }}
     needs: test-prep
     strategy:
@@ -44,7 +45,7 @@ jobs:
       - name: Run tests
         run: cargo test --verbose --package cargo-near-integration-tests -- ${{ matrix.test }}
 
-  non-integration-test:
+  tests:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
@@ -64,46 +65,35 @@ jobs:
       - name: Run tests
         run: cargo test --verbose --workspace --exclude cargo-near-integration-tests
 
-  lint:
-    name: Clippy and fmt
+  fmt:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v2
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          components: rustfmt, clippy
-
       - name: Check Formatting
         run: cargo fmt -- --check
+
+  clippy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v2
 
       - name: Check Clippy
         run: cargo clippy --tests -- -Dclippy::all
 
   audit:
-    name: Audit
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v2
 
-      - name: Install Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-
-      - name: Install Audit
+      - name: Install Audit Tool
         run: cargo install cargo-audit
 
-      - name: Run Audit
-        uses: actions-rs/cargo@v1
-        with:
-          command: audit
-          args: --ignore RUSTSEC-2020-0071
+      - name: Run Audit Tool
+        run: cargo audit --ignore RUSTSEC-2020-0071

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,6 @@ jobs:
         uses: actions/checkout@v2
 
       - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: cargo-near-cache-ubuntu
 
       - name: Get all tests
         id: get-tests
@@ -56,14 +54,6 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
 
       - uses: Swatinem/rust-cache@v2
-        if: ${{ matrix.platform }} == "ubuntu-latest"
-        with:
-          shared-key: cargo-near-cache-ubuntu
-
-      - uses: Swatinem/rust-cache@v2
-        if: ${{ matrix.platform }} == "macos-latest"
-        with:
-          shared-key: cargo-near-cache-macos
 
       - name: Run tests
         run: cargo test --verbose --package cargo-near-integration-tests -- ${{ matrix.test.units }}
@@ -86,14 +76,6 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
 
       - uses: Swatinem/rust-cache@v2
-        if: ${{ matrix.platform }} == "ubuntu-latest"
-        with:
-          shared-key: cargo-near-cache-ubuntu
-
-      - uses: Swatinem/rust-cache@v2
-        if: ${{ matrix.platform }} == "macos-latest"
-        with:
-          shared-key: cargo-near-cache-macos
 
       - name: Run tests
         run: cargo test --verbose --workspace --exclude cargo-near-integration-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,10 @@ on:
     branches: [ main ]
   pull_request:
 
+concurrency: 
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         run: cargo test --verbose --workspace --exclude cargo-near-integration-tests
 
   integration-test:
-    name: "tests batch #${{ matrix.batch }} (${{ matrix.platform }}, ${{ matrix.toolchain }})"
+    name: "test batch #${{ matrix.batch }} (${{ matrix.platform }}, ${{ matrix.toolchain }})"
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
@@ -52,9 +52,11 @@ jobs:
               > tests
           share=$((`wc -l < tests` / 5))
           units=$(tail -n +$(((share*(${{ matrix.batch }}-1))+1)) tests | head -n +$share | tr '\n' ' ')
-          cargo test --verbose --package cargo-near-integration-tests -- $units
+          cmd="cargo test --verbose --package cargo-near-integration-tests -- $units"
+          echo " \$ $cmd"
+          eval $cmd
 
-  fmt:
+  lint:
     runs-on: ubuntu-latest
 
     steps:
@@ -63,13 +65,6 @@ jobs:
 
       - name: Check Formatting
         run: cargo fmt -- --check
-
-  clippy:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout Sources
-        uses: actions/checkout@v2
 
       - name: Check Clippy
         run: cargo clippy --tests -- -Dclippy::all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Cargo NEAR Checks And Tests
+name: CI
 
 on:
   push:
@@ -19,7 +19,7 @@ jobs:
         id: get-tests
         run: |
           INTEGRATION_TESTS=$(
-            cargo test -p cargo-near-integration-tests -- --list --format terse \
+            cargo test --package cargo-near-integration-tests -- --list --format terse \
               | grep ': test$' | sed 's/\(.*\): .*$/\1,/'
           )
           echo "::set-output name=tests::[$INTEGRATION_TESTS]"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v2
 
-      - uses: Swatinem/rust-cache
+      - uses: Swatinem/rust-cache@v2
         shared-key: cargo-near-cache
 
       - name: Get all tests
@@ -54,7 +54,7 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
 
-      - uses: Swatinem/rust-cache
+      - uses: Swatinem/rust-cache@v2
         shared-key: cargo-near-cache
 
       - name: Run tests
@@ -77,7 +77,7 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
 
-      - uses: Swatinem/rust-cache
+      - uses: Swatinem/rust-cache@v2
         shared-key: cargo-near-cache
 
       - name: Run tests
@@ -100,7 +100,7 @@ jobs:
       - name: Checkout Sources
         uses: actions/checkout@v2
 
-      - uses: Swatinem/rust-cache
+      - uses: Swatinem/rust-cache@v2
 
       - name: Check Clippy
         run: cargo clippy --tests -- -Dclippy::all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         id: get-tests
         run: |
           cargo test --package cargo-near-integration-tests -- --list --format terse > tests
-          INTEGRATION_TESTS=$( (grep ': test$' | sed 's/\(.*\): .*$/\1,/') < tests )
+          INTEGRATION_TESTS="$( (grep ': test$' | sed 's/\(.*\): .*$/"\1",/' | tr -d '\n') < tests )"
           echo "::set-output name=tests::[$INTEGRATION_TESTS]"
       
   integration-test:
@@ -62,7 +62,7 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
 
       - name: Run tests
-        run: cargo test --verbose --exclude cargo-near-integration-tests
+        run: cargo test --verbose --workspace --exclude cargo-near-integration-tests
 
   lint:
     name: Clippy and fmt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,54 +6,104 @@ on:
   pull_request:
 
 jobs:
-  test:
+  test-prep:
+    runs-on: ubuntu-latest
+    outputs:
+      tests: ${{ steps.get-tests.outputs.tests }}
+
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v2
+
+      - name: Get all tests
+        id: get-tests
+        run: |
+          INTEGRATION_TESTS=$(
+            cargo test -p cargo-near-integration-tests -- --list --format terse \
+              | grep ': test$' | sed 's/\(.*\): .*$/\1,/'
+          )
+          echo "::set-output name=tests::[$INTEGRATION_TESTS]"
+      
+  integration-test:
     runs-on: ${{ matrix.platform }}
-    name: "${{ matrix.platform }} ${{ matrix.toolchain }}"
+    needs: test-prep
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest]
         toolchain: [stable, 1.56.0]
+        test: ${{ fromJson(needs.test-prep.outputs.tests) }}
+
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v2
+
       - name: "Install ${{ matrix.toolchain }} toolchain"
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
+
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --verbose --package cargo-near-integration-tests -- ${{ matrix.test }}
+
+  non-integration-test:
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest]
+        toolchain: [stable, 1.56.0]
+
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v2
+
+      - name: "Install ${{ matrix.toolchain }} toolchain"
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.toolchain }}
+
+      - name: Run tests
+        run: cargo test --verbose --exclude cargo-near-integration-tests
 
   lint:
     name: Clippy and fmt
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v2
+
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
-        with: 
+        with:
           profile: minimal
           toolchain: stable
           components: rustfmt, clippy
+
       - name: Check Formatting
         run: cargo fmt -- --check
+
       - name: Check Clippy
         run: cargo clippy --tests -- -Dclippy::all
 
   audit:
     name: Audit
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v2
+
       - name: Install Toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
+
       - name: Install Audit
         run: cargo install cargo-audit
+
       - name: Run Audit
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest]
+        platform: [macos-latest, ubuntu-latest]
         toolchain: [stable, 1.56.0]
 
     steps:
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest]
+        platform: [macos-latest, ubuntu-latest]
         toolchain: [stable, 1.56.0]
         batch: [1, 2, 3, 4, 5]
 
@@ -48,8 +48,8 @@ jobs:
       - name: Run tests
         run: |
           cargo test --package cargo-near-integration-tests -- --list --format terse \
-              | grep ': test$' | sed 's/\(.*\): .*$/\1/' \
-              > tests
+            | grep ': test$' | sed 's/\(.*\): .*$/\1/' \
+            > tests
           share=$((`wc -l < tests` / 5))
           units=$(tail -n +$(((share*(${{ matrix.batch }}-1))+1)) tests | head -n +$share | tr '\n' ' ')
           cmd="cargo test --verbose --package cargo-near-integration-tests -- $units"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: cargo-near-cache
+          shared-key: cargo-near-cache-ubuntu
 
       - name: Get all tests
         id: get-tests
@@ -56,8 +56,14 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
 
       - uses: Swatinem/rust-cache@v2
+        if: ${{ matrix.platform }} == "ubuntu-latest"
         with:
-          shared-key: cargo-near-cache
+          shared-key: cargo-near-cache-ubuntu
+
+      - uses: Swatinem/rust-cache@v2
+        if: ${{ matrix.platform }} == "macos-latest"
+        with:
+          shared-key: cargo-near-cache-macos
 
       - name: Run tests
         run: cargo test --verbose --package cargo-near-integration-tests -- ${{ matrix.test.units }}
@@ -80,8 +86,14 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
 
       - uses: Swatinem/rust-cache@v2
+        if: ${{ matrix.platform }} == "ubuntu-latest"
         with:
-          shared-key: cargo-near-cache
+          shared-key: cargo-near-cache-ubuntu
+
+      - uses: Swatinem/rust-cache@v2
+        if: ${{ matrix.platform }} == "macos-latest"
+        with:
+          shared-key: cargo-near-cache-macos
 
       - name: Run tests
         run: cargo test --verbose --workspace --exclude cargo-near-integration-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         platform: [macos-latest, ubuntu-latest]
         toolchain: [stable, 1.56.0]
-        batch: [1, 2, 3, 4, 5]
+        batch: [1, 2, 3]
 
     steps:
       - name: Checkout Sources
@@ -50,7 +50,7 @@ jobs:
           cargo test --package cargo-near-integration-tests -- --list --format terse \
             | grep ': test$' | sed 's/\(.*\): .*$/\1/' \
             > tests
-          share=$((`wc -l < tests` / 5))
+          share=$((`wc -l < tests` / 3))
           units=$(tail -n +$(((share*(${{ matrix.batch }}-1))+1)) tests | head -n +$share | tr '\n' ' ')
           cmd="cargo test --verbose --package cargo-near-integration-tests -- $units"
           echo " \$ $cmd"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,26 +10,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  tests:
-    runs-on: ${{ matrix.platform }}
-    strategy:
-      matrix:
-        platform: [macos-latest, ubuntu-latest]
-        toolchain: [stable, 1.56.0]
+  # tests:
+  #   runs-on: ${{ matrix.platform }}
+  #   strategy:
+  #     matrix:
+  #       platform: [macos-latest, ubuntu-latest]
+  #       toolchain: [stable, 1.56.0]
 
-    steps:
-      - name: Checkout Sources
-        uses: actions/checkout@v2
+  #   steps:
+  #     - name: Checkout Sources
+  #       uses: actions/checkout@v2
 
-      - name: "Install ${{ matrix.toolchain }} toolchain"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.toolchain }}
+  #     - name: "Install ${{ matrix.toolchain }} toolchain"
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         profile: minimal
+  #         toolchain: ${{ matrix.toolchain }}
 
-      - name: Run tests
-        run: cargo test --verbose --workspace --exclude cargo-near-integration-tests
-
+  #     - name: Run tests
+  #       run: cargo test --verbose --workspace --exclude cargo-near-integration-tests
   integration-test:
     name: "test batch #${{ matrix.batch }} (${{ matrix.platform }}, ${{ matrix.toolchain }})"
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,28 @@ on:
   pull_request:
 
 jobs:
+  tests:
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest]
+        toolchain: [stable, 1.56.0]
+
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v2
+
+      - name: "Install ${{ matrix.toolchain }} toolchain"
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.toolchain }}
+
+      - name: Run tests
+        run: cargo test --verbose --workspace --exclude cargo-near-integration-tests
+
   integration-test:
-    name: "tests (batch #${{ matrix.batch }}) (${{ matrix.platform }}, ${{ matrix.toolchain }}"
+    name: "tests batch #${{ matrix.batch }} (${{ matrix.platform }}, ${{ matrix.toolchain }})"
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
@@ -33,26 +53,6 @@ jobs:
           share=$((`wc -l < tests` / 5))
           units=$(tail -n +$(((share*(${{ matrix.batch }}-1))+1)) tests | head -n +$share | tr '\n' ' ')
           cargo test --verbose --package cargo-near-integration-tests -- $units
-
-  tests:
-    runs-on: ${{ matrix.platform }}
-    strategy:
-      matrix:
-        platform: [ubuntu-latest, macos-latest]
-        toolchain: [stable, 1.56.0]
-
-    steps:
-      - name: Checkout Sources
-        uses: actions/checkout@v2
-
-      - name: "Install ${{ matrix.toolchain }} toolchain"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.toolchain }}
-
-      - name: Run tests
-        run: cargo test --verbose --workspace --exclude cargo-near-integration-tests
 
   fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,8 @@ jobs:
         uses: actions/checkout@v2
 
       - uses: Swatinem/rust-cache@v2
-        shared-key: cargo-near-cache
+        with:
+          shared-key: cargo-near-cache
 
       - name: Get all tests
         id: get-tests
@@ -55,7 +56,8 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
 
       - uses: Swatinem/rust-cache@v2
-        shared-key: cargo-near-cache
+        with:
+          shared-key: cargo-near-cache
 
       - name: Run tests
         run: cargo test --verbose --package cargo-near-integration-tests -- ${{ matrix.test.units }}
@@ -78,7 +80,8 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
 
       - uses: Swatinem/rust-cache@v2
-        shared-key: cargo-near-cache
+        with:
+          shared-key: cargo-near-cache
 
       - name: Run tests
         run: cargo test --verbose --workspace --exclude cargo-near-integration-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: CI
+name: tests
 
 on:
   push:
@@ -18,10 +18,8 @@ jobs:
       - name: Get all tests
         id: get-tests
         run: |
-          INTEGRATION_TESTS=$(
-            cargo test --package cargo-near-integration-tests -- --list --format terse \
-              | grep ': test$' | sed 's/\(.*\): .*$/\1,/'
-          )
+          cargo test --package cargo-near-integration-tests -- --list --format terse > tests
+          INTEGRATION_TESTS=$( (grep ': test$' | sed 's/\(.*\): .*$/\1,/') < tests )
           echo "::set-output name=tests::[$INTEGRATION_TESTS]"
       
   integration-test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   test-prep:
     runs-on: ubuntu-latest
     outputs:
-      tests: ${{ steps.get-tests.outputs.tests }}
+      test-batches: ${{ steps.get-tests.outputs.test-batches }}
 
     steps:
       - name: Checkout Source
@@ -21,19 +21,28 @@ jobs:
       - name: Get all tests
         id: get-tests
         run: |
-          cargo test --package cargo-near-integration-tests -- --list --format terse > tests
-          INTEGRATION_TESTS="$( (grep ': test$' | sed 's/\(.*\): .*$/"\1",/' | tr -d '\n') < tests )"
-          echo "::set-output name=tests::[$INTEGRATION_TESTS]"
+          cargo test --package cargo-near-integration-tests -- --list --format terse \
+            | grep ': test$' | sed 's/\(.*\): .*$/\1/' \
+            > tests
+          total=$((`wc -l < tests`));share=$((total / 5))
+          TEST_BATCHES="$(
+            c=0; i=0; until [ $c -gt $total ]; do
+              tests=$(tail -n +$c tests | head -n +$share | sed 's/$/ /g' | tr -d '\n')
+              : $((i+=1,c+=share))
+              echo "{\"batch\":$i,\"units\":\"$tests\"},"
+            done
+          )"
+          echo "::set-output name=test-batches::[$TEST_BATCHES]"
 
   integration-test:
-    name: "${{ matrix.test }} (${{ matrix.platform }}, ${{ matrix.toolchain }}"
+    name: "tests (batch #${{ matrix.test.batch }}) (${{ matrix.platform }}, ${{ matrix.toolchain }}"
     runs-on: ${{ matrix.platform }}
     needs: test-prep
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest]
         toolchain: [stable, 1.56.0]
-        test: ${{ fromJson(needs.test-prep.outputs.tests) }}
+        test: ${{ fromJson(needs.test-prep.outputs.test-batches) }}
 
     steps:
       - name: Checkout Sources
@@ -49,7 +58,7 @@ jobs:
         shared-key: cargo-near-cache
 
       - name: Run tests
-        run: cargo test --verbose --package cargo-near-integration-tests -- ${{ matrix.test }}
+        run: cargo test --verbose --package cargo-near-integration-tests -- ${{ matrix.test.units }}
 
   tests:
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,6 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v2
 
-      - uses: Swatinem/rust-cache@v2
-
       - name: Get all tests
         id: get-tests
         run: |
@@ -53,8 +51,6 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
 
-      - uses: Swatinem/rust-cache@v2
-
       - name: Run tests
         run: cargo test --verbose --package cargo-near-integration-tests -- ${{ matrix.test.units }}
 
@@ -75,8 +71,6 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
 
-      - uses: Swatinem/rust-cache@v2
-
       - name: Run tests
         run: cargo test --verbose --workspace --exclude cargo-near-integration-tests
 
@@ -96,8 +90,6 @@ jobs:
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v2
-
-      - uses: Swatinem/rust-cache@v2
 
       - name: Check Clippy
         run: cargo clippy --tests -- -Dclippy::all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,13 +15,16 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v2
 
+      - uses: Swatinem/rust-cache
+        shared-key: cargo-near-cache
+
       - name: Get all tests
         id: get-tests
         run: |
           cargo test --package cargo-near-integration-tests -- --list --format terse > tests
           INTEGRATION_TESTS="$( (grep ': test$' | sed 's/\(.*\): .*$/"\1",/' | tr -d '\n') < tests )"
           echo "::set-output name=tests::[$INTEGRATION_TESTS]"
-      
+
   integration-test:
     name: "${{ matrix.test }} (${{ matrix.platform }}, ${{ matrix.toolchain }}"
     runs-on: ${{ matrix.platform }}
@@ -41,6 +44,9 @@ jobs:
         with:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
+
+      - uses: Swatinem/rust-cache
+        shared-key: cargo-near-cache
 
       - name: Run tests
         run: cargo test --verbose --package cargo-near-integration-tests -- ${{ matrix.test }}
@@ -62,6 +68,9 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
 
+      - uses: Swatinem/rust-cache
+        shared-key: cargo-near-cache
+
       - name: Run tests
         run: cargo test --verbose --workspace --exclude cargo-near-integration-tests
 
@@ -81,6 +90,8 @@ jobs:
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v2
+
+      - uses: Swatinem/rust-cache
 
       - name: Check Clippy
         run: cargo clippy --tests -- -Dclippy::all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,40 +6,14 @@ on:
   pull_request:
 
 jobs:
-  test-prep:
-    runs-on: ubuntu-latest
-    outputs:
-      test-batches: ${{ steps.get-tests.outputs.test-batches }}
-
-    steps:
-      - name: Checkout Source
-        uses: actions/checkout@v2
-
-      - name: Get all tests
-        id: get-tests
-        run: |
-          cargo test --package cargo-near-integration-tests -- --list --format terse \
-            | grep ': test$' | sed 's/\(.*\): .*$/\1/' \
-            > tests
-          total=$((`wc -l < tests`));share=$((total / 5))
-          TEST_BATCHES="$(
-            c=0; i=0; until [ $c -gt $total ]; do
-              tests=$(tail -n +$c tests | head -n +$share | sed 's/$/ /g' | tr -d '\n')
-              : $((i+=1,c+=share))
-              echo "{\"batch\":$i,\"units\":\"$tests\"},"
-            done
-          )"
-          echo "::set-output name=test-batches::[$TEST_BATCHES]"
-
   integration-test:
-    name: "tests (batch #${{ matrix.test.batch }}) (${{ matrix.platform }}, ${{ matrix.toolchain }}"
+    name: "tests (batch #${{ matrix.batch }}) (${{ matrix.platform }}, ${{ matrix.toolchain }}"
     runs-on: ${{ matrix.platform }}
-    needs: test-prep
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest]
         toolchain: [stable, 1.56.0]
-        test: ${{ fromJson(needs.test-prep.outputs.test-batches) }}
+        batch: [1, 2, 3, 4, 5]
 
     steps:
       - name: Checkout Sources
@@ -52,7 +26,13 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
 
       - name: Run tests
-        run: cargo test --verbose --package cargo-near-integration-tests -- ${{ matrix.test.units }}
+        run: |
+          cargo test --package cargo-near-integration-tests -- --list --format terse \
+              | grep ': test$' | sed 's/\(.*\): .*$/\1/' \
+              > tests
+          share=$((`wc -l < tests` / 5))
+          units=$(tail -n +$(((share*(${{ matrix.batch }}-1))+1)) tests | head -n +$share | tr '\n' ' ')
+          cargo test --verbose --package cargo-near-integration-tests -- $units
 
   tests:
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
Current CI runs use upwards of an hour to complete. — https://github.com/near/cargo-near/actions/runs/2872416612

This is an attempt at cutting that time by using multiple nodes to run the tests in parallel.