### PR TITLE
cargo check msrv

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Get MSRV
         run: |
-          RUST_MSRV="$(cat cargo-near/Cargo.toml | sed -n 's/rust-version\s*=\s*"\(.*\)"/\1/p')"
+          RUST_MSRV="$(cat cargo-near/Cargo.toml | sed -n 's/rust-version *= *"\(.*\)"/\1/p')"
           echo "RUST_MSRV=$RUST_MSRV" >> $GITHUB_ENV
 
       - name: "Install ${{ env.RUST_MSRV }} toolchain (MSRV)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,30 @@ on:
   pull_request:
 
 jobs:
+  msrv-check:
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest]
+
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v2
+
+      - name: Get MSRV
+        run: |
+          RUST_MSRV="$(cat cargo-near/Cargo.toml | sed -n 's/rust-version\s*=\s*"\(.*\)"/\1/p')"
+          echo "RUST_MSRV=$RUST_MSRV" >> $GITHUB_ENV
+
+      - name: "Install ${{ env.RUST_MSRV }} toolchain (MSRV)"
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_MSRV }}
+
+      - name: Cargo check
+        run: cargo check -p cargo-near
+
   tests:
     runs-on: ${{ matrix.platform }}
     strategy:

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cargo-near"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.56.0"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/near/cargo-near"


### PR DESCRIPTION
Context: #24. Supersedes #26.

Ensures `cargo-near` remains compilable with the MSRV.