### PR TITLE
feat: add binary serialization formats and compression when embedding

### DIFF
--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -24,3 +24,4 @@ symbolic-debuginfo = "8.8"
 schemars = "0.8"
 near-abi = { version = "0.1.0-pre.0", features = ["__chunked-entries"] }
 libloading = "0.7.3"
+zstd = "0.11"

--- a/cargo-near/src/abi.rs
+++ b/cargo-near/src/abi.rs
@@ -82,7 +82,10 @@ pub(crate) fn write_to_file(
     };
     let near_abi_compressed = match compression {
         AbiCompression::NoOp => near_abi_serialized,
-        AbiCompression::Zstd => zstd::encode_all(near_abi_serialized.as_slice(), 0)?,
+        AbiCompression::Zstd => zstd::encode_all(
+            near_abi_serialized.as_slice(),
+            *zstd::compression_level_range().end(),
+        )?,
     };
 
     let out_path_abi = crate_metadata.target_directory.join(format!(

--- a/cargo-near/src/abi.rs
+++ b/cargo-near/src/abi.rs
@@ -79,7 +79,7 @@ fn abi_file_extension(format: AbiFormat, compression: AbiCompression) -> &'stati
         AbiCompression::NoOp => match format {
             AbiFormat::Json | AbiFormat::JsonMin => "json",
         },
-        AbiCompression::Zstd => "bin",
+        AbiCompression::Zstd => "zst",
     }
 }
 

--- a/cargo-near/src/abi.rs
+++ b/cargo-near/src/abi.rs
@@ -143,7 +143,7 @@ pub(crate) fn run(args: AbiCommand) -> anyhow::Result<()> {
             .unwrap_or_else(|| crate_metadata.target_directory.clone()),
     )?;
 
-    let format = if args.no_pretty {
+    let format = if args.compact_abi {
         AbiFormat::JsonMin
     } else {
         AbiFormat::Json

--- a/cargo-near/src/build.rs
+++ b/cargo-near/src/build.rs
@@ -69,26 +69,29 @@ pub(crate) fn run(args: BuildCommand) -> anyhow::Result<()> {
 
     // todo! if we embedded, check that the binary exports the __contract_abi symbol
     println!("{}", "Contract Successfully Built!".green().bold());
-    println!(
-        "   -       Binary: {}",
+    let mut messages = Vec::new();
+    messages.push((
+        "Binary",
         wasm_artifact
             .path
             .display()
             .to_string()
             .bright_yellow()
-            .bold()
-    );
+            .bold(),
+    ));
     if let Some(abi_path) = pretty_abi_path {
-        println!(
-            "   -          ABI: {}",
-            abi_path.display().to_string().yellow().bold()
-        );
+        messages.push(("ABI", abi_path.display().to_string().yellow().bold()));
     }
     if let Some(abi_path) = min_abi_path {
-        println!(
-            "   - Embedded ABI: {}",
-            abi_path.display().to_string().yellow().bold()
-        );
+        messages.push((
+            "Embedded ABI",
+            abi_path.display().to_string().yellow().bold(),
+        ));
+    }
+
+    let max_width = messages.iter().map(|(h, _)| h.len()).max().unwrap();
+    for (header, message) in messages {
+        println!("  - {:>width$}: {}", header, message, width = max_width);
     }
 
     Ok(())

--- a/cargo-near/src/build.rs
+++ b/cargo-near/src/build.rs
@@ -32,7 +32,8 @@ pub(crate) fn run(args: BuildCommand) -> anyhow::Result<()> {
 
     let mut abi_path = None;
     if !args.no_abi {
-        let AbiResult { path } = abi::write_to_file(&crate_metadata, args.doc)?;
+        let AbiResult { path } =
+            abi::write_to_file(&crate_metadata, args.doc, args.format, args.compression)?;
         abi_path.replace(util::copy(&path, &out_dir)?);
     }
 

--- a/cargo-near/src/build.rs
+++ b/cargo-near/src/build.rs
@@ -69,8 +69,7 @@ pub(crate) fn run(args: BuildCommand) -> anyhow::Result<()> {
 
     // todo! if we embedded, check that the binary exports the __contract_abi symbol
     println!("{}", "Contract Successfully Built!".green().bold());
-    let mut messages = Vec::new();
-    messages.push((
+    let mut messages = vec![(
         "Binary",
         wasm_artifact
             .path
@@ -78,7 +77,7 @@ pub(crate) fn run(args: BuildCommand) -> anyhow::Result<()> {
             .to_string()
             .bright_yellow()
             .bold(),
-    ));
+    )];
     if let Some(abi_path) = pretty_abi_path {
         messages.push(("ABI", abi_path.display().to_string().yellow().bold()));
     }

--- a/cargo-near/src/build.rs
+++ b/cargo-near/src/build.rs
@@ -1,4 +1,4 @@
-use crate::abi::AbiResult;
+use crate::abi::{AbiCompression, AbiFormat, AbiResult};
 use crate::cargo::{manifest::CargoManifestPath, metadata::CrateMetadata};
 use crate::{abi, util, BuildCommand};
 use colored::Colorize;
@@ -30,14 +30,30 @@ pub(crate) fn run(args: BuildCommand) -> anyhow::Result<()> {
         cargo_args.push("--release");
     }
 
-    let mut abi_path = None;
+    let mut pretty_abi_path = None;
+    let mut min_abi_path = None;
     if !args.no_abi {
-        let AbiResult { path } =
-            abi::write_to_file(&crate_metadata, args.doc, args.format, args.compression)?;
-        abi_path.replace(util::copy(&path, &out_dir)?);
+        let contract_abi = abi::generate_abi(&crate_metadata, args.doc)?;
+        let AbiResult { path } = abi::write_to_file(
+            &contract_abi,
+            &crate_metadata,
+            AbiFormat::Json,
+            AbiCompression::NoOp,
+        )?;
+        pretty_abi_path.replace(util::copy(&path, &out_dir)?);
+
+        if args.embed_abi {
+            let AbiResult { path } = abi::write_to_file(
+                &contract_abi,
+                &crate_metadata,
+                AbiFormat::JsonMin,
+                AbiCompression::Zstd,
+            )?;
+            min_abi_path.replace(util::copy(&path, &out_dir)?);
+        }
     }
 
-    if let (true, Some(abi_path)) = (args.embed_abi, &abi_path) {
+    if let (true, Some(abi_path)) = (args.embed_abi, &min_abi_path) {
         cargo_args.extend(&["--features", "near-sdk/__abi-embed"]);
         build_env.push(("CARGO_NEAR_ABI_PATH", abi_path.to_str().unwrap()));
     }
@@ -54,7 +70,7 @@ pub(crate) fn run(args: BuildCommand) -> anyhow::Result<()> {
     // todo! if we embedded, check that the binary exports the __contract_abi symbol
     println!("{}", "Contract Successfully Built!".green().bold());
     println!(
-        "   - Binary: {}",
+        "   -       Binary: {}",
         wasm_artifact
             .path
             .display()
@@ -62,9 +78,15 @@ pub(crate) fn run(args: BuildCommand) -> anyhow::Result<()> {
             .bright_yellow()
             .bold()
     );
-    if let Some(abi_path) = abi_path {
+    if let Some(abi_path) = pretty_abi_path {
         println!(
-            "   -    ABI: {}",
+            "   -          ABI: {}",
+            abi_path.display().to_string().yellow().bold()
+        );
+    }
+    if let Some(abi_path) = min_abi_path {
+        println!(
+            "   - Embedded ABI: {}",
             abi_path.display().to_string().yellow().bold()
         );
     }

--- a/cargo-near/src/lib.rs
+++ b/cargo-near/src/lib.rs
@@ -1,4 +1,4 @@
-use clap::{AppSettings, Args, Parser, Subcommand};
+use clap::{AppSettings, Args, Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 
 mod abi;
@@ -47,6 +47,12 @@ pub struct AbiCommand {
     /// Path to the `Cargo.toml` of the contract to build
     #[clap(long, parse(from_os_str), value_name = "PATH")]
     pub manifest_path: Option<PathBuf>,
+    /// Serialization format to use
+    #[clap(long, value_enum, default_value = "json")]
+    pub format: AbiFormat,
+    /// Compression algorithm to use
+    #[clap(long, value_enum, default_value = "no-op")]
+    pub compression: AbiCompression,
 }
 
 #[derive(Debug, clap::Args)]
@@ -70,6 +76,24 @@ pub struct BuildCommand {
     /// Path to the `Cargo.toml` of the contract to build
     #[clap(long, parse(from_os_str), value_name = "PATH")]
     pub manifest_path: Option<PathBuf>,
+    /// Serialization format to use
+    #[clap(long, value_enum, default_value = "json-min")]
+    pub format: AbiFormat,
+    /// Compression algorithm to use
+    #[clap(long, value_enum, default_value = "zstd")]
+    pub compression: AbiCompression,
+}
+
+#[derive(Clone, Debug, ValueEnum)]
+pub enum AbiFormat {
+    Json,
+    JsonMin,
+}
+
+#[derive(Clone, Debug, ValueEnum)]
+pub enum AbiCompression {
+    NoOp,
+    Zstd,
 }
 
 pub fn exec(cmd: NearCommand) -> anyhow::Result<()> {

--- a/cargo-near/src/lib.rs
+++ b/cargo-near/src/lib.rs
@@ -1,4 +1,4 @@
-use clap::{AppSettings, Args, Parser, Subcommand, ValueEnum};
+use clap::{AppSettings, Args, Parser, Subcommand};
 use std::path::PathBuf;
 
 mod abi;
@@ -47,12 +47,9 @@ pub struct AbiCommand {
     /// Path to the `Cargo.toml` of the contract to build
     #[clap(long, parse(from_os_str), value_name = "PATH")]
     pub manifest_path: Option<PathBuf>,
-    /// Serialization format to use
-    #[clap(long, value_enum, default_value = "json")]
-    pub format: AbiFormat,
-    /// Compression algorithm to use
-    #[clap(long, value_enum, default_value = "no-op")]
-    pub compression: AbiCompression,
+    /// Do not prettify ABI (will generate minified JSON)
+    #[clap(long)]
+    pub no_pretty: bool,
 }
 
 #[derive(Debug, clap::Args)]
@@ -76,24 +73,6 @@ pub struct BuildCommand {
     /// Path to the `Cargo.toml` of the contract to build
     #[clap(long, parse(from_os_str), value_name = "PATH")]
     pub manifest_path: Option<PathBuf>,
-    /// Serialization format to use
-    #[clap(long, value_enum, default_value = "json-min")]
-    pub format: AbiFormat,
-    /// Compression algorithm to use
-    #[clap(long, value_enum, default_value = "zstd")]
-    pub compression: AbiCompression,
-}
-
-#[derive(Clone, Debug, ValueEnum)]
-pub enum AbiFormat {
-    Json,
-    JsonMin,
-}
-
-#[derive(Clone, Debug, ValueEnum)]
-pub enum AbiCompression {
-    NoOp,
-    Zstd,
 }
 
 pub fn exec(cmd: NearCommand) -> anyhow::Result<()> {

--- a/cargo-near/src/lib.rs
+++ b/cargo-near/src/lib.rs
@@ -47,9 +47,9 @@ pub struct AbiCommand {
     /// Path to the `Cargo.toml` of the contract to build
     #[clap(long, parse(from_os_str), value_name = "PATH")]
     pub manifest_path: Option<PathBuf>,
-    /// Do not prettify ABI (will generate minified JSON)
+    /// Generate compact (minified) JSON
     #[clap(long)]
-    pub no_pretty: bool,
+    pub compact_abi: bool,
 }
 
 #[derive(Debug, clap::Args)]

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -27,8 +27,7 @@ macro_rules! generate_abi {
             manifest_path: Some(cargo_path),
             doc: false,
             out_dir: None,
-            format: cargo_near::AbiFormat::Json,
-            compression: cargo_near::AbiCompression::NoOp
+            no_pretty: false
         }))?;
 
         let abi_root: near_abi::AbiRoot =

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -27,6 +27,8 @@ macro_rules! generate_abi {
             manifest_path: Some(cargo_path),
             doc: false,
             out_dir: None,
+            format: cargo_near::AbiFormat::Json,
+            compression: cargo_near::AbiCompression::NoOp
         }))?;
 
         let abi_root: near_abi::AbiRoot =

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -27,7 +27,7 @@ macro_rules! generate_abi {
             manifest_path: Some(cargo_path),
             doc: false,
             out_dir: None,
-            no_pretty: false
+            compact_abi: false
         }))?;
 
         let abi_root: near_abi::AbiRoot =

--- a/integration-tests/templates/_Cargo.toml
+++ b/integration-tests/templates/_Cargo.toml
@@ -12,7 +12,7 @@ schemars = "0.8"
 
 [dependencies.near-sdk]
 git = "https://github.com/near/near-sdk-rs.git"
-rev = "03bab8db6145e038626c4b15b34b0bd8a33fba44"
+rev = "dbaf9697fa09aaa0dde730af1c42ec632d5716a7"
 features = ["abi"]
 
 [workspace]

--- a/integration-tests/templates/_Cargo_no_abi_feature.toml
+++ b/integration-tests/templates/_Cargo_no_abi_feature.toml
@@ -12,7 +12,7 @@ schemars = "0.8"
 
 [dependencies.near-sdk]
 git = "https://github.com/near/near-sdk-rs.git"
-rev = "03bab8db6145e038626c4b15b34b0bd8a33fba44"
+rev = "dbaf9697fa09aaa0dde730af1c42ec632d5716a7"
 
 [workspace]
 members = []

--- a/integration-tests/templates/sdk-dependency/_Cargo_explicit.toml
+++ b/integration-tests/templates/sdk-dependency/_Cargo_explicit.toml
@@ -12,7 +12,7 @@ schemars = "0.8"
 
 [dependencies.near-sdk]
 git = "https://github.com/near/near-sdk-rs.git"
-rev = "03bab8db6145e038626c4b15b34b0bd8a33fba44"
+rev = "dbaf9697fa09aaa0dde730af1c42ec632d5716a7"
 features = ["abi"]
 
 [workspace]

--- a/integration-tests/templates/sdk-dependency/_Cargo_multiple_features.toml
+++ b/integration-tests/templates/sdk-dependency/_Cargo_multiple_features.toml
@@ -12,7 +12,7 @@ schemars = "0.8"
 
 [dependencies.near-sdk]
 git = "https://github.com/near/near-sdk-rs.git"
-rev = "03bab8db6145e038626c4b15b34b0bd8a33fba44"
+rev = "dbaf9697fa09aaa0dde730af1c42ec632d5716a7"
 features = ["abi", "unstable"]
 
 [workspace]

--- a/integration-tests/templates/sdk-dependency/_Cargo_no_default_features.toml
+++ b/integration-tests/templates/sdk-dependency/_Cargo_no_default_features.toml
@@ -12,7 +12,7 @@ schemars = "0.8"
 
 [dependencies.near-sdk]
 git = "https://github.com/near/near-sdk-rs.git"
-rev = "03bab8db6145e038626c4b15b34b0bd8a33fba44"
+rev = "dbaf9697fa09aaa0dde730af1c42ec632d5716a7"
 default-features = false
 features = ["abi"]
 

--- a/integration-tests/templates/sdk-dependency/_Cargo_patch.toml
+++ b/integration-tests/templates/sdk-dependency/_Cargo_patch.toml
@@ -12,7 +12,7 @@ serde = { version = "1", features = ["derive"] }
 schemars = "0.8"
 
 [patch.crates-io]
-near-sdk = { git = "https://github.com/near/near-sdk-rs.git", rev = "03bab8db6145e038626c4b15b34b0bd8a33fba44" }
+near-sdk = { git = "https://github.com/near/near-sdk-rs.git", rev = "dbaf9697fa09aaa0dde730af1c42ec632d5716a7" }
 
 [workspace]
 members = []

--- a/integration-tests/templates/sdk-dependency/_Cargo_platform_specific.toml
+++ b/integration-tests/templates/sdk-dependency/_Cargo_platform_specific.toml
@@ -12,12 +12,12 @@ schemars = "0.8"
 
 [target.'cfg(windows)'.dependencies.near-sdk]
 git = "https://github.com/near/near-sdk-rs.git"
-rev = "03bab8db6145e038626c4b15b34b0bd8a33fba44"
+rev = "dbaf9697fa09aaa0dde730af1c42ec632d5716a7"
 features = ["abi"]
 
 [target.'cfg(unix)'.dependencies.near-sdk]
 git = "https://github.com/near/near-sdk-rs.git"
-rev = "03bab8db6145e038626c4b15b34b0bd8a33fba44"
+rev = "dbaf9697fa09aaa0dde730af1c42ec632d5716a7"
 features = ["abi"]
 
 [workspace]

--- a/integration-tests/templates/sdk-dependency/_Cargo_renamed.toml
+++ b/integration-tests/templates/sdk-dependency/_Cargo_renamed.toml
@@ -13,7 +13,7 @@ schemars = "0.8"
 [dependencies.near]
 package = "near-sdk"
 git = "https://github.com/near/near-sdk-rs.git"
-rev = "03bab8db6145e038626c4b15b34b0bd8a33fba44"
+rev = "dbaf9697fa09aaa0dde730af1c42ec632d5716a7"
 features = ["abi"]
 
 [workspace]

--- a/integration-tests/tests/cargo/mod.rs
+++ b/integration-tests/tests/cargo/mod.rs
@@ -19,7 +19,7 @@ fn clone_git_repo(version: &str) -> anyhow::Result<TempDir> {
 #[test]
 #[named]
 fn test_dependency_local_path() -> anyhow::Result<()> {
-    let near_sdk_dir = clone_git_repo("03bab8db6145e038626c4b15b34b0bd8a33fba44")?;
+    let near_sdk_dir = clone_git_repo("dbaf9697fa09aaa0dde730af1c42ec632d5716a7")?;
     let near_sdk_dep_path = near_sdk_dir.path().join("near-sdk");
 
     // near-sdk = { path = "::path::", features = ["abi"] }
@@ -40,7 +40,7 @@ fn test_dependency_local_path() -> anyhow::Result<()> {
 #[test]
 #[named]
 fn test_dependency_local_path_with_version() -> anyhow::Result<()> {
-    let near_sdk_dir = clone_git_repo("03bab8db6145e038626c4b15b34b0bd8a33fba44")?;
+    let near_sdk_dir = clone_git_repo("dbaf9697fa09aaa0dde730af1c42ec632d5716a7")?;
     let near_sdk_dep_path = near_sdk_dir.path().join("near-sdk");
 
     // near-sdk = { path = "::path::", version = "4.1.0-pre.2", features = ["abi"] }
@@ -172,7 +172,7 @@ fn test_dependency_patch() -> anyhow::Result<()> {
     // near-sdk = { version = "4.1.0-pre.2", features = ["abi"] }
     //
     // [patch.crates-io]
-    // near-sdk = { git = "https://github.com/near/near-sdk-rs.git", rev = "03bab8db6145e038626c4b15b34b0bd8a33fba44" }
+    // near-sdk = { git = "https://github.com/near/near-sdk-rs.git", rev = "dbaf9697fa09aaa0dde730af1c42ec632d5716a7" }
     let abi_root = generate_abi_fn! {
         with Cargo "/templates/sdk-dependency/_Cargo_patch.toml";
 


### PR DESCRIPTION
Still WIP, opening for visibility.

Table below shows some tests that I have done. Cell values are the size of the abi file after serialization+compression in bytes.
<table>
<tr>
	<td> ser+comp / contract
	<td> abi
	<td> ft
	<td> nft
<tr>
	<td> JSON (min)
	<td> 1694
	<td> 4834
	<td> 7148
<tr>
	<td> JSON (min)+snap
	<td> 672
	<td> 1265
	<td> 1590
<tr>
	<td> JSON (min)+zstd
	<td> 498
	<td> 914
	<td> 1113
<tr>
	<td> CBOR
	<td> 1379
	<td> 3991
	<td> 5842
<tr>
	<td> CBOR+snap
	<td> 602
	<td> 1239
	<td> 1580
<tr>
	<td> CBOR+zstd
	<td> 480
	<td> 909
	<td> 1132
</table>