### PR TITLE
abi: paint build reports

### DIFF
--- a/cargo-near/src/abi/mod.rs
+++ b/cargo-near/src/abi/mod.rs
@@ -114,7 +114,7 @@ pub(crate) fn run(args: AbiCommand) -> anyhow::Result<()> {
 
     let abi_path = util::copy(&path, &out_dir)?;
 
-    println!("ABI successfully generated at {}", abi_path.display());
+    println!("ABI successfully generated at `{}`", abi_path.display());
 
     Ok(())
 }

--- a/cargo-near/src/build.rs
+++ b/cargo-near/src/build.rs
@@ -1,6 +1,7 @@
 use crate::abi::AbiResult;
 use crate::cargo::{manifest::CargoManifestPath, metadata::CrateMetadata};
 use crate::{abi, util, BuildCommand};
+use colored::Colorize;
 use std::io::BufRead;
 
 const COMPILATION_TARGET: &str = "wasm32-unknown-unknown";
@@ -57,10 +58,21 @@ pub(crate) fn run(args: BuildCommand) -> anyhow::Result<()> {
     wasm_artifact.path = util::copy(&wasm_artifact.path, &out_dir)?;
 
     // todo! if we embedded, check that the binary exports the __contract_abi symbol
-    println!("Contract Successfully Built!");
-    println!("   - Binary: {}", wasm_artifact.path.display());
+    println!("{}", "Contract Successfully Built!".green().bold());
+    println!(
+        "   - Binary: {}",
+        wasm_artifact
+            .path
+            .display()
+            .to_string()
+            .bright_yellow()
+            .bold()
+    );
     if let Some(abi_path) = abi_path {
-        println!("   -    ABI: {}", abi_path.display());
+        println!(
+            "   -    ABI: {}",
+            abi_path.display().to_string().yellow().bold()
+        );
     }
 
     Ok(())


### PR DESCRIPTION
Based off #31

- `cargo near build`
  
  #### #31 at fork
  
  <img width="588" alt="CleanShot 2022-08-26 at 12 27 54@2x" src="https://user-images.githubusercontent.com/16881812/186858577-91e90114-bf19-4cb1-84dc-c12ee9ec03a1.png">
  
  #### Colorized
  
  <img width="585" alt="CleanShot 2022-08-26 at 12 29 07@2x" src="https://user-images.githubusercontent.com/16881812/186858890-d2ab0abc-790c-4218-a054-0bd6e784a662.png">

- Not sure what `cargo near abi` would look like, went with the back ticked version in this PR.

  #### #31 at fork
  <img width="699" alt="CleanShot 2022-08-26 at 12 31 19@2x" src="https://user-images.githubusercontent.com/16881812/186859358-3ebcee23-3529-48a0-902b-63ca6636d965.png">

  #### Colorized
  <img width="708" alt="CleanShot 2022-08-26 at 12 32 35@2x" src="https://user-images.githubusercontent.com/16881812/186859556-d231ddbe-137c-4592-bef0-a00a50935d7f.png">
  
  #### Backticked
  <img width="717" alt="CleanShot 2022-08-26 at 12 33 08@2x" src="https://user-images.githubusercontent.com/16881812/186859669-5cbd93cb-7883-4c9c-bc5f-ef0b03e4a90a.png"> 