### PR TITLE
use shared target folder for faster CI

### DIFF
--- a/cargo-near/src/abi.rs
+++ b/cargo-near/src/abi.rs
@@ -4,8 +4,6 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 
-const ABI_FILE: &str = "abi.json";
-
 /// ABI generation result.
 pub(crate) struct AbiResult {
     /// Path to the resulting ABI file.
@@ -56,7 +54,9 @@ pub(crate) fn write_to_file(
         strip_docs(&mut contract_abi);
     }
     let near_abi_json = serde_json::to_string(&contract_abi)?;
-    let out_path_abi = crate_metadata.target_directory.join(ABI_FILE);
+    let out_path_abi = crate_metadata
+        .target_directory
+        .join(crate_metadata.root_package.name.replace('-', "_") + "_abi.json");
     fs::write(&out_path_abi, near_abi_json)?;
 
     Ok(AbiResult { path: out_path_abi })

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -21,6 +21,8 @@ macro_rules! generate_abi {
         let lib_rs_path = src_dir.join("lib.rs");
         fs::write(lib_rs_path, lib_rs)?;
 
+        std::env::set_var("CARGO_TARGET_DIR", workspace_dir.join("target"));
+
         cargo_near::exec(cargo_near::NearCommand::Abi(cargo_near::AbiCommand {
             manifest_path: Some(cargo_path),
             doc: false,

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -28,7 +28,7 @@ macro_rules! generate_abi {
         }))?;
 
         let abi_root: near_abi::AbiRoot =
-            serde_json::from_slice(&fs::read(workspace_dir.join(function_name!()).join("target").join("near").join("abi.json"))?)?;
+        serde_json::from_slice(&fs::read(workspace_dir.join("target").join("near").join(format!("{}_abi.json", function_name!())))?)?;
         abi_root
     }};
     (with Cargo $cargo_path:expr; $($code:tt)*) => {


### PR DESCRIPTION
Tracking issue: https://github.com/near/cargo-near/issues/41

Supersedes #24.

Current integration tests generate isolated projects with distinct target folders despite compiling ~99% of the same artifacts.

Causing current CI runs to run upwards of an hour.

With this patch, CI completes in under 10 minutes.

---

Based on #35, because in my tests, leaving the codegen in caused inconsistent results, ~didn't bother investigating why. https://github.com/near/cargo-near/runs/8050886022?check_suite_focus=true~

I eventually looked into it. See #40 for an alternative that merges straight into the main branch.