### PR TITLE
alt: shared target folder for faster CI

### DIFF
--- a/cargo-near/src/abi/mod.rs
+++ b/cargo-near/src/abi/mod.rs
@@ -42,10 +42,13 @@ pub(crate) fn execute(
         "run",
         &["--package", "near-abi-gen"],
         Some(near_abi_gen_dir),
-        vec![(
-            "LD_LIBRARY_PATH",
-            &dylib_path.parent().unwrap().to_string_lossy(),
-        )],
+        vec![
+            (
+                "LD_LIBRARY_PATH",
+                &dylib_path.parent().unwrap().to_string_lossy(),
+            ),
+            ("CARGO_TARGET_DIR", "target"),
+        ],
     )?;
 
     let mut contract_abi = near_abi::__private::ChunkedAbiEntry::combine(

--- a/cargo-near/src/cargo/metadata.rs
+++ b/cargo-near/src/cargo/metadata.rs
@@ -21,7 +21,9 @@ impl CrateMetadata {
 
         let absolute_manifest_path = manifest_path.directory()?;
         let absolute_workspace_root = metadata.workspace_root.canonicalize()?;
-        if absolute_manifest_path != absolute_workspace_root {
+        if std::env::var("CARGO_NEAR_FORCE_WORKSPACE").map_or(false, |v| v == "1")
+            || absolute_manifest_path != absolute_workspace_root
+        {
             // If the contract is a package in a workspace, we use the package name
             // as the name of the sub-folder where we put the `.contract` bundle.
             target_directory = target_directory.join(package_name);

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -21,13 +21,16 @@ macro_rules! generate_abi {
         let lib_rs_path = src_dir.join("lib.rs");
         fs::write(lib_rs_path, lib_rs)?;
 
+        std::env::set_var("CARGO_TARGET_DIR", workspace_dir.join("target"));
+        std::env::set_var("CARGO_NEAR_FORCE_WORKSPACE", "1");
+
         cargo_near::exec(cargo_near::NearCommand::Abi(cargo_near::AbiCommand {
             manifest_path: Some(cargo_path),
             doc: false,
         }))?;
 
         let abi_root: near_abi::AbiRoot =
-            serde_json::from_slice(&fs::read(workspace_dir.join(function_name!()).join("target").join("near").join("abi.json"))?)?;
+            serde_json::from_slice(&fs::read(workspace_dir.join("target").join("near").join(function_name!()).join("abi.json"))?)?;
         abi_root
     }};
     (with Cargo $cargo_path:expr; $($code:tt)*) => {


### PR DESCRIPTION
Tracking issue: https://github.com/near/cargo-near/issues/41

Alternative to #39.

Current integration tests generate isolated projects with distinct target folders despite compiling ~99% of the same artifacts.

Causing current CI runs to run upwards of an hour.

With this patch, CI completes in under 40 minutes.