### PR TITLE
alt: shared target folder for faster CI

### DIFF
--- a/cargo-near/src/cargo/metadata.rs
+++ b/cargo-near/src/cargo/metadata.rs
@@ -22,7 +22,9 @@ impl CrateMetadata {
 
         let absolute_manifest_dir = manifest_path.directory()?;
         let absolute_workspace_root = metadata.workspace_root.canonicalize()?;
-        if absolute_manifest_dir != absolute_workspace_root {
+        if std::env::var("CARGO_NEAR_FORCE_WORKSPACE").map_or(false, |v| v == "1")
+            || absolute_manifest_dir != absolute_workspace_root
+        {
             // If the contract is a package in a workspace, we use the package name
             // as the name of the sub-folder where we put the `.contract` bundle.
             target_directory = target_directory.join(package_name);

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -21,6 +21,9 @@ macro_rules! generate_abi {
         let lib_rs_path = src_dir.join("lib.rs");
         fs::write(lib_rs_path, lib_rs)?;
 
+        std::env::set_var("CARGO_TARGET_DIR", workspace_dir.join("target"));
+        std::env::set_var("CARGO_NEAR_FORCE_WORKSPACE", "1");
+
         cargo_near::exec(cargo_near::NearCommand::Abi(cargo_near::AbiCommand {
             manifest_path: Some(cargo_path),
             doc: false,
@@ -28,7 +31,7 @@ macro_rules! generate_abi {
         }))?;
 
         let abi_root: near_abi::AbiRoot =
-            serde_json::from_slice(&fs::read(workspace_dir.join(function_name!()).join("target").join("near").join("abi.json"))?)?;
+        serde_json::from_slice(&fs::read(workspace_dir.join("target").join("near").join(function_name!()).join("abi.json"))?)?;
         abi_root
     }};
     (with Cargo $cargo_path:expr; $($code:tt)*) => {


### PR DESCRIPTION
Tracking issue: #41

Merges the techniques in #39 and #40.

Keeping the fast run time, but without needing to rename the `abi.json` file.