### PR TITLE
update near-sdk in integration tests to pre-released version

### DIFF
--- a/integration-tests/templates/_Cargo.toml
+++ b/integration-tests/templates/_Cargo.toml
@@ -7,13 +7,9 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
+near-sdk = { version = "4.1.0-pre.3", features = ["abi"] }
 serde = { version = "1", features = ["derive"] }
 schemars = "0.8"
-
-[dependencies.near-sdk]
-git = "https://github.com/near/near-sdk-rs.git"
-rev = "dbaf9697fa09aaa0dde730af1c42ec632d5716a7"
-features = ["abi"]
 
 [workspace]
 members = []

--- a/integration-tests/templates/_Cargo_no_abi_feature.toml
+++ b/integration-tests/templates/_Cargo_no_abi_feature.toml
@@ -7,12 +7,9 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
+near-sdk = { version = "4.1.0-pre.3" }
 serde = { version = "1", features = ["derive"] }
 schemars = "0.8"
-
-[dependencies.near-sdk]
-git = "https://github.com/near/near-sdk-rs.git"
-rev = "dbaf9697fa09aaa0dde730af1c42ec632d5716a7"
 
 [workspace]
 members = []

--- a/integration-tests/templates/sdk-dependency/_Cargo_explicit.toml
+++ b/integration-tests/templates/sdk-dependency/_Cargo_explicit.toml
@@ -11,8 +11,7 @@ serde = { version = "1", features = ["derive"] }
 schemars = "0.8"
 
 [dependencies.near-sdk]
-git = "https://github.com/near/near-sdk-rs.git"
-rev = "dbaf9697fa09aaa0dde730af1c42ec632d5716a7"
+version = "4.1.0-pre.3"
 features = ["abi"]
 
 [workspace]

--- a/integration-tests/templates/sdk-dependency/_Cargo_local_path_with_version.toml
+++ b/integration-tests/templates/sdk-dependency/_Cargo_local_path_with_version.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = { path = "::path::", version = "4.1.0-pre.2", features = ["abi"] }
+near-sdk = { path = "::path::", version = "4.1.0-pre.3", features = ["abi"] }
 serde = { version = "1", features = ["derive"] }
 schemars = "0.8"
 

--- a/integration-tests/templates/sdk-dependency/_Cargo_multiple_features.toml
+++ b/integration-tests/templates/sdk-dependency/_Cargo_multiple_features.toml
@@ -7,13 +7,9 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
+near-sdk = { version = "4.1.0-pre.3", features = ["abi", "unstable"] }
 serde = { version = "1", features = ["derive"] }
 schemars = "0.8"
-
-[dependencies.near-sdk]
-git = "https://github.com/near/near-sdk-rs.git"
-rev = "dbaf9697fa09aaa0dde730af1c42ec632d5716a7"
-features = ["abi", "unstable"]
 
 [workspace]
 members = []

--- a/integration-tests/templates/sdk-dependency/_Cargo_no_default_features.toml
+++ b/integration-tests/templates/sdk-dependency/_Cargo_no_default_features.toml
@@ -7,14 +7,9 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
+near-sdk = { version = "4.1.0-pre.3", default-features = false, features = ["abi"] }
 serde = { version = "1", features = ["derive"] }
 schemars = "0.8"
-
-[dependencies.near-sdk]
-git = "https://github.com/near/near-sdk-rs.git"
-rev = "dbaf9697fa09aaa0dde730af1c42ec632d5716a7"
-default-features = false
-features = ["abi"]
 
 [workspace]
 members = []

--- a/integration-tests/templates/sdk-dependency/_Cargo_patch.toml
+++ b/integration-tests/templates/sdk-dependency/_Cargo_patch.toml
@@ -7,12 +7,12 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = { version = "4.1.0-pre.2", features = ["abi"] }
+near-sdk = { version = "4.1.0-pre.3", features = ["abi"] }
 serde = { version = "1", features = ["derive"] }
 schemars = "0.8"
 
 [patch.crates-io]
-near-sdk = { git = "https://github.com/near/near-sdk-rs.git", rev = "dbaf9697fa09aaa0dde730af1c42ec632d5716a7" }
+near-sdk = { git = "https://github.com/near/near-sdk-rs.git", rev = "792d5eb26d26a0878dbf59e304afa4e19540c317" }
 
 [workspace]
 members = []

--- a/integration-tests/templates/sdk-dependency/_Cargo_platform_specific.toml
+++ b/integration-tests/templates/sdk-dependency/_Cargo_platform_specific.toml
@@ -11,14 +11,10 @@ serde = { version = "1", features = ["derive"] }
 schemars = "0.8"
 
 [target.'cfg(windows)'.dependencies.near-sdk]
-git = "https://github.com/near/near-sdk-rs.git"
-rev = "dbaf9697fa09aaa0dde730af1c42ec632d5716a7"
-features = ["abi"]
+near-sdk = { version = "4.1.0-pre.3", features = ["abi"] }
 
 [target.'cfg(unix)'.dependencies.near-sdk]
-git = "https://github.com/near/near-sdk-rs.git"
-rev = "dbaf9697fa09aaa0dde730af1c42ec632d5716a7"
-features = ["abi"]
+near-sdk = { version = "4.1.0-pre.3", features = ["abi"] }
 
 [workspace]
 members = []

--- a/integration-tests/templates/sdk-dependency/_Cargo_renamed.toml
+++ b/integration-tests/templates/sdk-dependency/_Cargo_renamed.toml
@@ -11,10 +11,7 @@ serde = { version = "1", features = ["derive"] }
 schemars = "0.8"
 
 [dependencies.near]
-package = "near-sdk"
-git = "https://github.com/near/near-sdk-rs.git"
-rev = "dbaf9697fa09aaa0dde730af1c42ec632d5716a7"
-features = ["abi"]
+near = { version = "4.1.0-pre.3", package = "near-sdk", features = ["abi"] }
 
 [workspace]
 members = []

--- a/integration-tests/tests/cargo/mod.rs
+++ b/integration-tests/tests/cargo/mod.rs
@@ -19,7 +19,7 @@ fn clone_git_repo(version: &str) -> anyhow::Result<TempDir> {
 #[test]
 #[named]
 fn test_dependency_local_path() -> anyhow::Result<()> {
-    let near_sdk_dir = clone_git_repo("dbaf9697fa09aaa0dde730af1c42ec632d5716a7")?;
+    let near_sdk_dir = clone_git_repo("792d5eb26d26a0878dbf59e304afa4e19540c317")?;
     let near_sdk_dep_path = near_sdk_dir.path().join("near-sdk");
 
     // near-sdk = { path = "::path::", features = ["abi"] }
@@ -40,10 +40,10 @@ fn test_dependency_local_path() -> anyhow::Result<()> {
 #[test]
 #[named]
 fn test_dependency_local_path_with_version() -> anyhow::Result<()> {
-    let near_sdk_dir = clone_git_repo("dbaf9697fa09aaa0dde730af1c42ec632d5716a7")?;
+    let near_sdk_dir = clone_git_repo("792d5eb26d26a0878dbf59e304afa4e19540c317")?;
     let near_sdk_dep_path = near_sdk_dir.path().join("near-sdk");
 
-    // near-sdk = { path = "::path::", version = "4.1.0-pre.2", features = ["abi"] }
+    // near-sdk = { path = "::path::", version = "4.1.0-pre.3", features = ["abi"] }
     let abi_root = generate_abi_fn! {
         with Cargo "/templates/sdk-dependency/_Cargo_local_path_with_version.toml",
         and vars HashMap::from([("path", near_sdk_dep_path.to_str().unwrap())]);
@@ -62,7 +62,7 @@ fn test_dependency_local_path_with_version() -> anyhow::Result<()> {
 #[named]
 fn test_dependency_explicit() -> anyhow::Result<()> {
     // [dependencies.near-sdk]
-    // version = "4.1.0-pre.2"
+    // version = "4.1.0-pre.3"
     // features = ["abi"]
     let abi_root = generate_abi_fn! {
         with Cargo "/templates/sdk-dependency/_Cargo_explicit.toml";
@@ -80,7 +80,7 @@ fn test_dependency_explicit() -> anyhow::Result<()> {
 #[test]
 #[named]
 fn test_dependency_no_default_features() -> anyhow::Result<()> {
-    // near-sdk = { version = "4.1.0-pre.2", default-features = false, features = ["abi"] }
+    // near-sdk = { version = "4.1.0-pre.3", default-features = false, features = ["abi"] }
     let abi_root = generate_abi_fn! {
         with Cargo "/templates/sdk-dependency/_Cargo_no_default_features.toml";
 
@@ -97,7 +97,7 @@ fn test_dependency_no_default_features() -> anyhow::Result<()> {
 #[test]
 #[named]
 fn test_dependency_multiple_features() -> anyhow::Result<()> {
-    // near-sdk = { version = "4.1.0-pre.2", features = ["abi", "unstable"] }
+    // near-sdk = { version = "4.1.0-pre.3", features = ["abi", "unstable"] }
     let abi_root = generate_abi_fn! {
         with Cargo "/templates/sdk-dependency/_Cargo_multiple_features.toml";
 
@@ -117,10 +117,10 @@ fn test_dependency_multiple_features() -> anyhow::Result<()> {
 #[named]
 fn test_dependency_platform_specific() -> anyhow::Result<()> {
     // [target.'cfg(windows)'.dependencies]
-    // near-sdk = { version = "4.1.0-pre.2", features = ["abi"] }
+    // near-sdk = { version = "4.1.0-pre.3", features = ["abi"] }
     //
     // [target.'cfg(unix)'.dependencies]
-    // near-sdk = { version = "4.1.0-pre.2", features = ["abi"] }
+    // near-sdk = { version = "4.1.0-pre.3", features = ["abi"] }
     let abi_root = generate_abi_fn! {
         with Cargo "/templates/sdk-dependency/_Cargo_platform_specific.toml";
 
@@ -139,7 +139,7 @@ fn test_dependency_platform_specific() -> anyhow::Result<()> {
 #[test]
 #[named]
 fn test_dependency_renamed() -> anyhow::Result<()> {
-    // near = { version = "4.1.0-pre.2", package = "near-sdk", features = ["abi"] }
+    // near = { version = "4.1.0-pre.3", package = "near-sdk", features = ["abi"] }
     let abi_root = generate_abi! {
         with Cargo "/templates/sdk-dependency/_Cargo_renamed.toml";
 
@@ -169,10 +169,10 @@ fn test_dependency_renamed() -> anyhow::Result<()> {
 #[named]
 fn test_dependency_patch() -> anyhow::Result<()> {
     // [dependencies]
-    // near-sdk = { version = "4.1.0-pre.2", features = ["abi"] }
+    // near-sdk = { version = "4.1.0-pre.3", features = ["abi"] }
     //
     // [patch.crates-io]
-    // near-sdk = { git = "https://github.com/near/near-sdk-rs.git", rev = "dbaf9697fa09aaa0dde730af1c42ec632d5716a7" }
+    // near-sdk = { git = "https://github.com/near/near-sdk-rs.git", rev = "792d5eb26d26a0878dbf59e304afa4e19540c317" }
     let abi_root = generate_abi_fn! {
         with Cargo "/templates/sdk-dependency/_Cargo_patch.toml";
 


### PR DESCRIPTION
This should effectively match the state it was in before ABI PRs were merged in. But with the version update.