### PR TITLE
report cargo stdout errors immediately

### DIFF
--- a/cargo-near/src/util/mod.rs
+++ b/cargo-near/src/util/mod.rs
@@ -1,6 +1,5 @@
 use crate::cargo::manifest::CargoManifestPath;
 use anyhow::{Context, Result};
-use cargo_metadata::diagnostic::DiagnosticLevel;
 use cargo_metadata::{Artifact, Message};
 use std::collections::HashSet;
 use std::ffi::OsStr;
@@ -86,9 +85,7 @@ where
                 Message::CompilerArtifact(artifact) => {
                     artifacts.push(artifact);
                 }
-                Message::CompilerMessage(message)
-                    if message.message.level == DiagnosticLevel::Error =>
-                {
+                Message::CompilerMessage(message) => {
                     if let Some(msg) = message.message.rendered {
                         for line in msg.lines() {
                             eprintln!(" │ {}", line);


### PR DESCRIPTION
Context: https://github.com/near/cargo-near/pull/63#issuecomment-1278800638

Skips the message parsing redundancy and stdout buffer.

<img width="591" alt="CleanShot 2022-10-15 at 11 50 03@2x" src="https://user-images.githubusercontent.com/16881812/195975854-5f99b8f2-fd69-4c65-9bcd-f825ac714b94.png">
