### PR TITLE
Deduplicate warnings

### DIFF
--- a/cargo-near/src/abi.rs
+++ b/cargo-near/src/abi.rs
@@ -27,6 +27,7 @@ pub(crate) enum AbiCompression {
 pub(crate) fn generate_abi(
     crate_metadata: &CrateMetadata,
     generate_docs: bool,
+    hide_warnings: bool,
 ) -> anyhow::Result<AbiRoot> {
     let root_node = crate_metadata
         .raw_metadata
@@ -82,6 +83,7 @@ pub(crate) fn generate_abi(
             ("CARGO_PROFILE_DEV_LTO", "off"),
         ],
         util::dylib_extension(),
+        hide_warnings,
     )?;
 
     let mut contract_abi = util::handle_step("Extracting ABI...", || {
@@ -181,7 +183,7 @@ pub(crate) fn run(args: AbiCommand) -> anyhow::Result<()> {
     } else {
         AbiFormat::Json
     };
-    let contract_abi = generate_abi(&crate_metadata, args.doc)?;
+    let contract_abi = generate_abi(&crate_metadata, args.doc, false)?;
     let AbiResult { path } =
         write_to_file(&contract_abi, &crate_metadata, format, AbiCompression::NoOp)?;
 

--- a/cargo-near/src/build.rs
+++ b/cargo-near/src/build.rs
@@ -38,7 +38,7 @@ pub(crate) fn run(args: BuildCommand) -> anyhow::Result<()> {
     let mut pretty_abi_path = None;
     let mut min_abi_path = None;
     if !args.no_abi {
-        let contract_abi = abi::generate_abi(&crate_metadata, args.doc)?;
+        let contract_abi = abi::generate_abi(&crate_metadata, args.doc, true)?;
         let AbiResult { path } = abi::write_to_file(
             &contract_abi,
             &crate_metadata,
@@ -71,6 +71,7 @@ pub(crate) fn run(args: BuildCommand) -> anyhow::Result<()> {
         &cargo_args,
         build_env,
         "wasm",
+        false,
     )?;
 
     wasm_artifact.path = util::copy(&wasm_artifact.path, &out_dir)?;

--- a/cargo-near/src/util/mod.rs
+++ b/cargo-near/src/util/mod.rs
@@ -158,7 +158,12 @@ pub(crate) fn compile_project(
     args: &[&str],
     env: Vec<(&str, &str)>,
     artifact_extension: &str,
+    hide_warnings: bool,
 ) -> anyhow::Result<CompilationArtifact> {
+    if hide_warnings {
+        env::set_var("RUSTFLAGS", "-Awarnings");
+    }
+
     let artifacts = invoke_cargo(
         "build",
         [&["--message-format=json"], args].concat(),

--- a/cargo-near/src/util/mod.rs
+++ b/cargo-near/src/util/mod.rs
@@ -156,12 +156,12 @@ pub struct CompilationArtifact {
 pub(crate) fn compile_project(
     manifest_path: &CargoManifestPath,
     args: &[&str],
-    env: Vec<(&str, &str)>,
+    mut env: Vec<(&str, &str)>,
     artifact_extension: &str,
     hide_warnings: bool,
 ) -> anyhow::Result<CompilationArtifact> {
     if hide_warnings {
-        env::set_var("RUSTFLAGS", "-Awarnings");
+        env.push(("RUSTFLAGS", "-Awarnings"));
     }
 
     let artifacts = invoke_cargo(

--- a/cargo-near/src/util/mod.rs
+++ b/cargo-near/src/util/mod.rs
@@ -1,7 +1,7 @@
 use crate::cargo::manifest::CargoManifestPath;
 use anyhow::{Context, Result};
 use cargo_metadata::{Artifact, Message};
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::ffi::OsStr;
 use std::fs;
 use std::io::{BufRead, BufReader};
@@ -31,23 +31,24 @@ pub(crate) const fn dylib_extension() -> &'static str {
 /// If `working_dir` is set, cargo process will be spawned in the specified directory.
 ///
 /// Returns execution standard output as a byte array.
-pub(crate) fn invoke_cargo<I, S, P>(
+pub(crate) fn invoke_cargo<A, P, E, S, EK, EV>(
     command: &str,
-    args: I,
+    args: A,
     working_dir: Option<P>,
-    env: Vec<(&str, &str)>,
+    env: E,
 ) -> Result<Vec<Artifact>>
 where
-    I: IntoIterator<Item = S>,
-    S: AsRef<OsStr>,
+    A: IntoIterator<Item = S>,
     P: AsRef<Path>,
+    E: IntoIterator<Item = (EK, EV)>,
+    S: AsRef<OsStr>,
+    EK: AsRef<OsStr>,
+    EV: AsRef<OsStr>,
 {
     let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
     let mut cmd = Command::new(cargo);
 
-    env.iter().for_each(|(env_key, env_val)| {
-        cmd.env(env_key, env_val);
-    });
+    cmd.envs(env);
 
     if let Some(path) = working_dir {
         log::debug!("Setting cargo working dir to '{}'", path.as_ref().display());
@@ -160,15 +161,34 @@ pub(crate) fn compile_project(
     artifact_extension: &str,
     hide_warnings: bool,
 ) -> anyhow::Result<CompilationArtifact> {
+    let mut final_env = BTreeMap::new();
+
     if hide_warnings {
         env.push(("RUSTFLAGS", "-Awarnings"));
+    }
+
+    for (key, value) in env {
+        match key {
+            "RUSTFLAGS" => {
+                let rustflags: &mut String = final_env
+                    .entry(key)
+                    .or_insert_with(|| std::env::var(key).unwrap_or_default());
+                if !rustflags.is_empty() {
+                    rustflags.push(' ');
+                }
+                rustflags.push_str(value);
+            }
+            _ => {
+                final_env.insert(key, value.to_string());
+            }
+        }
     }
 
     let artifacts = invoke_cargo(
         "build",
         [&["--message-format=json"], args].concat(),
         manifest_path.directory().ok(),
-        env,
+        final_env.iter(),
     )?;
 
     // We find the last compiler artifact message which should contain information about the


### PR DESCRIPTION
Fixes #67

Hides warnings at the ABI generation stage only when building contracts


| Before | After |
| :-: | :-: |
| <img width="656" alt="CleanShot 2022-10-15 at 11 57 47@2x" src="https://user-images.githubusercontent.com/16881812/195976122-1141a1a4-5202-46fa-a6c3-f8eda064c3b0.png"> | <img width="664" alt="CleanShot 2022-10-15 at 11 55 35@2x" src="https://user-images.githubusercontent.com/16881812/195976036-b73c53f9-e7d2-430b-9fc9-730f6f4b59e2.png"> |