### PR TITLE
replace error text with symbol

### DIFF
--- a/cargo-near/src/main.rs
+++ b/cargo-near/src/main.rs
@@ -9,7 +9,7 @@ fn main() {
     match cargo_near::exec(args.cmd) {
         Ok(()) => {}
         Err(err) => {
-            eprintln!("{} {:?}", "error:".bright_red().bold(), err);
+            eprintln!(" {} {:?}", "✗".bright_red().bold(), err);
             std::process::exit(1);
         }
     }


### PR DESCRIPTION
Context: https://github.com/near/cargo-near/pull/69#pullrequestreview-1143536734

- Step Contextualized

  <img width="407" alt="CleanShot 2022-10-18 at 12 07 05@2x" src="https://user-images.githubusercontent.com/16881812/196373274-c27e9151-da86-499d-9358-b55b4a50caab.png">

  ---

- `cargo` runs

  <img width="664" alt="CleanShot 2022-10-18 at 12 08 09@2x" src="https://user-images.githubusercontent.com/16881812/196373456-ec209275-9296-4fba-921e-b1a87a348ab4.png">

  ---

- Generic

  <img width="405" alt="CleanShot 2022-10-18 at 12 10 37@2x" src="https://user-images.githubusercontent.com/16881812/196374124-86d8acdc-2efc-4ea3-8e1f-c0abe8c64bbd.png">