### PR TITLE
CI: run matrix paths independently

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ jobs:
   msrv-check:
     runs-on: ${{ matrix.platform }}
     strategy:
+      fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest]
 
@@ -33,6 +34,7 @@ jobs:
   tests:
     runs-on: ${{ matrix.platform }}
     strategy:
+      fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest]
 


### PR DESCRIPTION
GitHub's matrix behavior is a little weird. By default, when one path causes an execution to fail, GitHub auto-cancels all other executions from the same matrix.

Example: https://github.com/near/cargo-near/actions/runs/3271855547/attempts/2

<img width="430" alt="CleanShot 2022-10-18 at 13 39 59@2x" src="https://user-images.githubusercontent.com/16881812/196395323-9a73438f-ec16-4bce-8771-052a5c901fc0.png">

Ideally, we should test each one independently, and get all the possible errors/successes all at once, instead of incrementally.