### PR TITLE
only accept UTF-8 inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,6 +493,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "camino",
  "cargo-near",
  "clap",
  "function_name",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,6 +473,7 @@ name = "cargo-near"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "camino",
  "cargo_metadata",
  "clap",
  "colored",

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["development-tools", "development-tools::cargo-plugins", "developm
 
 [dependencies]
 anyhow = "1.0"
+camino = "1.1.1"
 cargo_metadata = "0.14"
 clap = { version = "3.2", features = ["derive", "env"] }
 colored = "2.0"

--- a/cargo-near/src/abi.rs
+++ b/cargo-near/src/abi.rs
@@ -1,15 +1,15 @@
 use crate::cargo::{manifest::CargoManifestPath, metadata::CrateMetadata};
 use crate::{util, AbiCommand};
+use camino::Utf8PathBuf;
 use colored::Colorize;
 use near_abi::AbiRoot;
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
 
 /// ABI generation result.
 pub(crate) struct AbiResult {
     /// Path to the resulting ABI file.
-    pub path: PathBuf,
+    pub path: Utf8PathBuf,
 }
 
 #[derive(Clone, Debug)]
@@ -172,11 +172,11 @@ pub(crate) fn run(args: AbiCommand) -> anyhow::Result<()> {
         )?)
     })?;
 
-    let out_dir = util::force_canonicalize_dir(
-        &args
-            .out_dir
-            .unwrap_or_else(|| crate_metadata.target_directory.clone()),
-    )?;
+    let out_dir = args
+        .out_dir
+        .map_or(Ok(crate_metadata.target_directory.clone()), |out_dir| {
+            util::force_canonicalize_dir(&out_dir)
+        })?;
 
     let format = if args.compact_abi {
         AbiFormat::JsonMin
@@ -190,10 +190,7 @@ pub(crate) fn run(args: AbiCommand) -> anyhow::Result<()> {
     let abi_path = util::copy(&path, &out_dir)?;
 
     util::print_success("ABI Successfully Generated!");
-    eprintln!(
-        "     - ABI: {}",
-        abi_path.display().to_string().yellow().bold()
-    );
+    eprintln!("     - ABI: {}", abi_path.to_string().yellow().bold());
 
     Ok(())
 }

--- a/cargo-near/src/cargo/manifest.rs
+++ b/cargo-near/src/cargo/manifest.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use camino::{Utf8Path, Utf8PathBuf};
 
 const MANIFEST_FILE_NAME: &str = "Cargo.toml";
 
@@ -6,39 +6,35 @@ const MANIFEST_FILE_NAME: &str = "Cargo.toml";
 #[derive(Clone, Debug)]
 pub struct CargoManifestPath {
     /// Absolute path to the manifest file
-    pub path: PathBuf,
+    pub path: Utf8PathBuf,
 }
 
 impl CargoManifestPath {
     /// The directory path of the manifest path, if there is one.
-    pub fn directory(&self) -> anyhow::Result<&Path> {
+    pub fn directory(&self) -> anyhow::Result<&Utf8Path> {
         self.path.parent().ok_or_else(|| {
             anyhow::anyhow!("Unable to infer the directory containing Cargo.toml file")
         })
     }
 }
 
-impl TryFrom<PathBuf> for CargoManifestPath {
+impl TryFrom<Utf8PathBuf> for CargoManifestPath {
     type Error = anyhow::Error;
 
-    fn try_from(manifest_path: PathBuf) -> Result<Self, Self::Error> {
+    fn try_from(manifest_path: Utf8PathBuf) -> Result<Self, Self::Error> {
         if let Some(file_name) = manifest_path.file_name() {
             if file_name != MANIFEST_FILE_NAME {
                 anyhow::bail!("the manifest-path must be a path to a Cargo.toml file")
             }
         }
-        let canonical_manifest_path =
-            manifest_path
-                .canonicalize()
-                .map_err(|err| match err.kind() {
-                    std::io::ErrorKind::NotFound => {
-                        anyhow::anyhow!(
-                            "manifest path `{}` does not exist",
-                            manifest_path.display()
-                        )
-                    }
-                    _ => err.into(),
-                })?;
+        let canonical_manifest_path = manifest_path.canonicalize_utf8().map_err(|err| match err
+            .kind()
+        {
+            std::io::ErrorKind::NotFound => {
+                anyhow::anyhow!("manifest path `{}` does not exist", manifest_path)
+            }
+            _ => err.into(),
+        })?;
         Ok(CargoManifestPath {
             path: canonical_manifest_path,
         })

--- a/cargo-near/src/cargo/metadata.rs
+++ b/cargo-near/src/cargo/metadata.rs
@@ -1,4 +1,5 @@
 use crate::cargo::manifest::CargoManifestPath;
+use crate::util;
 use anyhow::{Context, Result};
 use camino::Utf8PathBuf;
 use cargo_metadata::{MetadataCommand, Package};
@@ -16,7 +17,8 @@ impl CrateMetadata {
     /// Parses the contract manifest and returns relevant metadata.
     pub fn collect(manifest_path: CargoManifestPath) -> Result<Self> {
         let (metadata, root_package) = get_cargo_metadata(&manifest_path)?;
-        let mut target_directory = metadata.target_directory.as_path().join("near");
+        let mut target_directory =
+            util::force_canonicalize_dir(&metadata.target_directory.as_path().join("near"))?;
 
         // Normalize the package and lib name.
         let package_name = root_package.name.replace('-', "_");

--- a/cargo-near/src/cargo/metadata.rs
+++ b/cargo-near/src/cargo/metadata.rs
@@ -1,13 +1,13 @@
 use crate::cargo::manifest::CargoManifestPath;
 use anyhow::{Context, Result};
+use camino::Utf8PathBuf;
 use cargo_metadata::{MetadataCommand, Package};
-use std::path::PathBuf;
 
 /// Relevant metadata obtained from Cargo.toml.
 #[derive(Debug)]
 pub(crate) struct CrateMetadata {
     pub root_package: Package,
-    pub target_directory: PathBuf,
+    pub target_directory: Utf8PathBuf,
     pub manifest_path: CargoManifestPath,
     pub raw_metadata: cargo_metadata::Metadata,
 }
@@ -22,7 +22,7 @@ impl CrateMetadata {
         let package_name = root_package.name.replace('-', "_");
 
         let absolute_manifest_dir = manifest_path.directory()?;
-        let absolute_workspace_root = metadata.workspace_root.canonicalize()?;
+        let absolute_workspace_root = metadata.workspace_root.canonicalize_utf8()?;
         if absolute_manifest_dir != absolute_workspace_root {
             // If the contract is a package in a workspace, we use the package name
             // as the name of the sub-folder where we put the `.contract` bundle.
@@ -31,7 +31,7 @@ impl CrateMetadata {
 
         let crate_metadata = CrateMetadata {
             root_package,
-            target_directory: target_directory.into(),
+            target_directory,
             manifest_path,
             raw_metadata: metadata,
         };
@@ -43,10 +43,7 @@ impl CrateMetadata {
 fn get_cargo_metadata(
     manifest_path: &CargoManifestPath,
 ) -> Result<(cargo_metadata::Metadata, Package)> {
-    log::info!(
-        "Fetching cargo metadata for {}",
-        manifest_path.path.to_string_lossy()
-    );
+    log::info!("Fetching cargo metadata for {}", manifest_path.path);
     let mut cmd = MetadataCommand::new();
     let metadata = cmd
         .manifest_path(&manifest_path.path)

--- a/cargo-near/src/lib.rs
+++ b/cargo-near/src/lib.rs
@@ -1,5 +1,5 @@
+use camino::Utf8PathBuf;
 use clap::{AppSettings, Args, Parser, Subcommand};
-use std::path::PathBuf;
 
 mod abi;
 mod build;
@@ -40,11 +40,11 @@ pub struct AbiCommand {
     #[clap(long)]
     pub compact_abi: bool,
     /// Copy final artifacts to the this directory
-    #[clap(long, parse(from_os_str), value_name = "PATH")]
-    pub out_dir: Option<PathBuf>,
+    #[clap(long, parse(from_str), value_name = "PATH")]
+    pub out_dir: Option<Utf8PathBuf>,
     /// Path to the `Cargo.toml` of the contract to build
-    #[clap(long, parse(from_os_str), value_name = "PATH")]
-    pub manifest_path: Option<PathBuf>,
+    #[clap(long, parse(from_str), value_name = "PATH")]
+    pub manifest_path: Option<Utf8PathBuf>,
 }
 
 #[derive(Debug, clap::Args)]
@@ -63,11 +63,11 @@ pub struct BuildCommand {
     #[clap(long, conflicts_with_all = &["doc", "embed-abi"])]
     pub no_abi: bool,
     /// Copy final artifacts to the this directory
-    #[clap(long, parse(from_os_str), value_name = "PATH")]
-    pub out_dir: Option<PathBuf>,
+    #[clap(long, parse(from_str), value_name = "PATH")]
+    pub out_dir: Option<Utf8PathBuf>,
     /// Path to the `Cargo.toml` of the contract to build
-    #[clap(long, parse(from_os_str), value_name = "PATH")]
-    pub manifest_path: Option<PathBuf>,
+    #[clap(long, parse(from_str), value_name = "PATH")]
+    pub manifest_path: Option<Utf8PathBuf>,
 }
 
 pub fn exec(cmd: NearCommand) -> anyhow::Result<()> {

--- a/cargo-near/src/util/mod.rs
+++ b/cargo-near/src/util/mod.rs
@@ -211,8 +211,8 @@ pub(crate) fn compile_project(
                 .map(|e| e == artifact_extension)
                 .unwrap_or(false)
         })
-        .collect::<Vec<_>>();
-    let mut dylib_files_iter = dylib_files.into_iter();
+        .collect();
+    let mut dylib_files_iter = Vec::into_iter(dylib_files);
     match (dylib_files_iter.next(), dylib_files_iter.next()) {
         (None, None) => Err(anyhow::anyhow!(
             "Compilation resulted in no '.{}' target files. \

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -10,6 +10,7 @@ near-abi = "0.1.0-pre.0"
 [dev-dependencies]
 anyhow = "1.0"
 borsh = "0.9"
+camino = "1.1.1"
 cargo-near = { path = "../cargo-near" }
 clap = "3.2"
 function_name = "0.3"

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 macro_rules! invoke_cargo_near {
     ($(Cargo: $cargo_path:expr;)? $(Vars: $cargo_vars:expr;)? Opts: $cli_opts:expr; Code: $($code:tt)*) => {{
-        let manifest_dir: std::path::PathBuf = env!("CARGO_MANIFEST_DIR").into();
+        let manifest_dir: camino::Utf8PathBuf = env!("CARGO_MANIFEST_DIR").into();
         let workspace_dir = manifest_dir.parent().unwrap().join("target").join("_abi-integration-tests");
         let crate_dir = workspace_dir.join(function_name!());
         let src_dir = crate_dir.join("src");


### PR DESCRIPTION
Neither `cargo` nor `rustc` support non-utf8 names/paths.

| `rustc` | `cargo` |
| :-: | :-: |
| <img width="359" alt="CleanShot 2022-10-19 at 17 10 42@2x" src="https://user-images.githubusercontent.com/16881812/196700352-6d1a22b0-277f-482d-bcb2-f7c9c8855eba.png"> | <img width="422" alt="CleanShot 2022-10-19 at 17 07 30@2x" src="https://user-images.githubusercontent.com/16881812/196699637-ce90215f-c7fe-4bc9-a8b4-8bd8e03a63ba.png"> |

And while `cargo-near` currently accepts non-utf8 inputs, it panics at a `fs` operation.

<img width="335" alt="CleanShot 2022-10-19 at 17 46 31@2x" src="https://user-images.githubusercontent.com/16881812/196709244-3a9c7f72-969d-411e-b829-967ac33d0894.png">

This patch pre-emptively returns a helpful error.

<img width="470" alt="CleanShot 2022-10-19 at 17 49 13@2x" src="https://user-images.githubusercontent.com/16881812/196709966-175498e2-aa86-456c-bad9-81b2d92ad657.png">