### PR TITLE
indent errors

### DIFF
--- a/cargo-near/src/main.rs
+++ b/cargo-near/src/main.rs
@@ -9,7 +9,12 @@ fn main() {
     match cargo_near::exec(args.cmd) {
         Ok(()) => {}
         Err(err) => {
-            eprintln!(" {} {:?}", "✗".bright_red().bold(), err);
+            let err = format!("{:?}", err);
+            let mut err_lines = err.lines();
+            eprintln!(" {} {}", "✗".bright_red().bold(), err_lines.next().unwrap());
+            for line in err_lines {
+                eprintln!("   {}", line);
+            }
             std::process::exit(1);
         }
     }


### PR DESCRIPTION
Keeping in line with the rest of the styling.

| Before | After |
| :-: | :-: |
| <img width="494" alt="CleanShot 2022-10-20 at 05 32 40@2x" src="https://user-images.githubusercontent.com/16881812/196835149-90ce9e6e-9ad9-4fc2-b490-ad0af49dc34e.png"> | <img width="494" alt="CleanShot 2022-10-20 at 05 31 07@2x" src="https://user-images.githubusercontent.com/16881812/196835084-61c251ff-5b07-499b-a87e-c0a48b11343c.png"> |