### PR TITLE
create the target/near directory, if it doesn't already exist

### DIFF
--- a/cargo-near/src/cargo/metadata.rs
+++ b/cargo-near/src/cargo/metadata.rs
@@ -21,7 +21,8 @@ impl CrateMetadata {
         metadata.target_directory = util::force_canonicalize_dir(&metadata.target_directory)?;
         metadata.workspace_root = metadata.workspace_root.canonicalize_utf8()?;
 
-        let mut target_directory = metadata.target_directory.join("near");
+        let mut target_directory =
+            util::force_canonicalize_dir(&metadata.target_directory.join("near"))?;
 
         // Normalize the package and lib name.
         let package_name = root_package.name.replace('-', "_");


### PR DESCRIPTION
This should've been a part of #75.

`target/near` should be created at this stage if it doesn't already exist.