### PR TITLE
chore: release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2022-11-10
+
 Highlight: We revised the overall experience of the CLI, making it more accessible, robust, and easier to understand.
 
 - The minimum supported version of the SDK for this release is `4.1.0`.
@@ -26,5 +28,6 @@ Highlight: We revised the overall experience of the CLI, making it more accessib
 
 > Release Page: <https://github.com/near/cargo-near/releases/tag/v0.2.0>
 
-[unreleased]: https://github.com/near/cargo-near/compare/v0.2.0...HEAD
+[unreleased]: https://github.com/near/cargo-near/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/near/cargo-near/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/near/cargo-near/releases/tag/v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bs58",

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.56.0"


### PR DESCRIPTION
> Following https://github.com/near/cargo-near/pull/90, PRs like these, once merged into master, automatically trigger a release.

Scheduled release: 10-11-2022

Changes:

 - The minimum supported version of the SDK for this release is `4.1.0`.
 - Upgraded the `near-abi` version to `0.3.0`. <https://github.com/near/cargo-near/pull/83> 
 - The exported and embedded ABI now includes build information. <https://github.com/near/cargo-near/pull/55> 
 - When building a contract, the exported ABI now also includes the code hash of the built contract. <https://github.com/near/cargo-near/pull/55> 
 - Fixed a situation where `cargo-near` could potentially run into segfaults when working with incompatible versions of the SDK. <https://github.com/near/cargo-near/pull/74> 
 - `cargo-near` now only accepts valid UTF-8 input from the CLI, and will error out if it encounters invalid UTF-8. <https://github.com/near/cargo-near/pull/76> 
 - `cargo-near` no longer requires explicitly activating the `abi` feature for the SDK. <https://github.com/near/cargo-near/pull/85> 
 - Fixed a bug where `cargo-near` exports an empty ABI file when the target directory is explicitly specified. <https://github.com/near/cargo-near/pull/75> 
 - Introduced build stages with a neat report interface. <https://github.com/near/cargo-near/pull/59>, <https://github.com/near/cargo-near/pull/63>, <https://github.com/near/cargo-near/pull/69> 
 - Added the `--color` flag to control the color output. <https://github.com/near/cargo-near/pull/86>
 - Ensured all forwarded `cargo` output retains colors in it's report, maintaining tooling familiarity. <https://github.com/near/cargo-near/pull/66> 
 - Removed the buffering that made `cargo`'s `stdout` lag behind its `stderr`. <https://github.com/near/cargo-near/pull/65> 
 - When building contracts, `cargo`'s warnings are only emitted at the build stage, and not duplicated. <https://github.com/near/cargo-near/pull/68> 
 - Introduced the automated publishing workflow. <https://github.com/near/cargo-near/pull/90>