### PR TITLE
Make build , abi and util modules public 

### DIFF
--- a/cargo-near/src/build.rs
+++ b/cargo-near/src/build.rs
@@ -1,5 +1,6 @@
 use crate::abi::{AbiCompression, AbiFormat, AbiResult};
 use crate::cargo::{manifest::CargoManifestPath, metadata::CrateMetadata};
+use crate::util::CompilationArtifact;
 use crate::{abi, util, BuildCommand};
 use colored::Colorize;
 use near_abi::BuildInfo;
@@ -8,7 +9,7 @@ use std::io::BufRead;
 
 const COMPILATION_TARGET: &str = "wasm32-unknown-unknown";
 
-pub fn run(args: BuildCommand) -> anyhow::Result<()> {
+pub fn run(args: BuildCommand) -> anyhow::Result<CompilationArtifact> {
     args.color.apply();
 
     util::handle_step("Checking the host environment...", || {
@@ -106,5 +107,5 @@ pub fn run(args: BuildCommand) -> anyhow::Result<()> {
         eprintln!("     - {:>width$}: {}", header, message, width = max_width);
     }
 
-    Ok(())
+    Ok(wasm_artifact)
 }

--- a/cargo-near/src/build.rs
+++ b/cargo-near/src/build.rs
@@ -8,7 +8,7 @@ use std::io::BufRead;
 
 const COMPILATION_TARGET: &str = "wasm32-unknown-unknown";
 
-pub(crate) fn run(args: BuildCommand) -> anyhow::Result<()> {
+pub fn run(args: BuildCommand) -> anyhow::Result<()> {
     args.color.apply();
 
     util::handle_step("Checking the host environment...", || {

--- a/cargo-near/src/lib.rs
+++ b/cargo-near/src/lib.rs
@@ -6,7 +6,7 @@ use clap::{AppSettings, Args, Parser, Subcommand};
 pub mod abi;
 pub mod build;
 mod cargo;
-mod util;
+pub mod util;
 
 #[derive(Debug, Parser)]
 #[clap(bin_name = "cargo", version, about)]

--- a/cargo-near/src/lib.rs
+++ b/cargo-near/src/lib.rs
@@ -3,8 +3,8 @@ use std::{env, str::FromStr};
 use camino::Utf8PathBuf;
 use clap::{AppSettings, Args, Parser, Subcommand};
 
-mod abi;
-mod build;
+pub mod abi;
+pub mod build;
 mod cargo;
 mod util;
 

--- a/cargo-near/src/lib.rs
+++ b/cargo-near/src/lib.rs
@@ -131,6 +131,6 @@ impl ColorPreference {
 pub fn exec(cmd: NearCommand) -> anyhow::Result<()> {
     match cmd {
         NearCommand::Abi(args) => abi::run(args),
-        NearCommand::Build(args) => build::run(args),
+        NearCommand::Build(args) => build::run(args).map(|_| ()),
     }
 }


### PR DESCRIPTION
The build module was made public  to access run method which  helps in resolving [issue  ](https://github.com/near/workspaces-rs/issues/230 issue by replacing ) in [workspace-rs](https://github.com/near/workspaces-rs)
by replacing existing build logic with cargo-nears build logic.

