### PR TITLE
chore: release v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "atty",
  "bs58 0.4.0",

--- a/cargo-near/CHANGELOG.md
+++ b/cargo-near/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.0](https://github.com/near/cargo-near/compare/cargo-near-v0.3.1...cargo-near-v0.4.0) - 2023-10-01
+
+### Other
+- [**breaking**] Re-implemented cargo-near to use interactive-clap and near-cli-rs features ([#103](https://github.com/near/cargo-near/pull/103))

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.70.0"


### PR DESCRIPTION
## 🤖 New release
* `cargo-near`: 0.3.1 -> 0.4.0 (⚠️ API breaking changes)

### ⚠️ `cargo-near` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.23.0/src/lints/enum_missing.ron

Failed in:
  enum cargo_near::NearCommand, previously in file /tmp/.tmpO8FnGy/cargo-near/src/lib.rs:26
  enum cargo_near::ColorPreference, previously in file /tmp/.tmpO8FnGy/cargo-near/src/lib.rs:88

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.23.0/src/lints/function_missing.ron

Failed in:
  function cargo_near::exec, previously in file /tmp/.tmpO8FnGy/cargo-near/src/lib.rs:131
  function cargo_near::build::run, previously in file /tmp/.tmpO8FnGy/cargo-near/src/build.rs:12

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.23.0/src/lints/struct_missing.ron

Failed in:
  struct cargo_near::util::CompilationArtifact, previously in file /tmp/.tmpO8FnGy/cargo-near/src/util/mod.rs:157
  struct cargo_near::AbiCommand, previously in file /tmp/.tmpO8FnGy/cargo-near/src/lib.rs:37
  struct cargo_near::BuildCommand, previously in file /tmp/.tmpO8FnGy/cargo-near/src/lib.rs:60
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/near/cargo-near/compare/cargo-near-v0.3.1...cargo-near-v0.4.0) - 2023-10-01

### Other
- [**breaking**] Re-implemented cargo-near to use interactive-clap and near-cli-rs features ([#103](https://github.com/near/cargo-near/pull/103))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).