### PR TITLE
fix: use `dunce` crate to remove UNC prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,6 +656,7 @@ dependencies = [
  "color-eyre",
  "colored",
  "derive_more",
+ "dunce",
  "env_logger",
  "inquire",
  "interactive-clap",
@@ -1311,6 +1312,12 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "dyn-clone"

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -42,3 +42,4 @@ interactive-clap-derive = "0.2.5"
 near-cli-rs = { version = "0.5.2" }
 derive_more = "0.99.9"
 shell-words = "1.0.0"
+dunce = "1"

--- a/cargo-near/src/util/mod.rs
+++ b/cargo-near/src/util/mod.rs
@@ -56,7 +56,7 @@ where
 
     if let Some(path) = working_dir {
         let path = path.as_ref();
-        // remove UNC prefix to be able compile on Windows
+        // remove UNC prefix to be able to compile on Windows
         let path = force_canonicalize_dir(path).unwrap();
         log::debug!("Setting cargo working dir to '{}'", path);
         cmd.current_dir(path);
@@ -243,7 +243,7 @@ pub(crate) fn compile_project(
 /// Create the directory if it doesn't exist, and return the absolute path to it.
 pub(crate) fn force_canonicalize_dir(dir: &Utf8Path) -> color_eyre::eyre::Result<Utf8PathBuf> {
     fs::create_dir_all(dir).wrap_err_with(|| format!("failed to create directory `{}`", dir))?;
-    // use `dunce` create instead of default one because it's compatible with Windows UNC paths
+    // use canonicalize from `dunce` create instead of default one from std because it's compatible with Windows UNC paths
     // and don't breake cargo compilation on Windows
     // https://github.com/rust-lang/rust/issues/42869
     let compatible_path = dunce::canonicalize(dir);

--- a/cargo-near/src/util/mod.rs
+++ b/cargo-near/src/util/mod.rs
@@ -243,7 +243,9 @@ pub(crate) fn compile_project(
 /// Create the directory if it doesn't exist, and return the absolute path to it.
 pub(crate) fn force_canonicalize_dir(dir: &Utf8Path) -> color_eyre::eyre::Result<Utf8PathBuf> {
     fs::create_dir_all(dir).wrap_err_with(|| format!("failed to create directory `{}`", dir))?;
-    // use `dunce` create instead of default one because it's compatible with Windows
+    // use `dunce` create instead of default one because it's compatible with Windows UNC paths
+    // and don't breake cargo compilation on Windows
+    // https://github.com/rust-lang/rust/issues/42869
     let compatible_path = dunce::canonicalize(&dir);
     match compatible_path {
         Ok(path) => Ok(Utf8PathBuf::from_path_buf(path).unwrap()),

--- a/cargo-near/src/util/mod.rs
+++ b/cargo-near/src/util/mod.rs
@@ -57,6 +57,13 @@ where
     if let Some(path) = working_dir {
         let path = path.as_ref();
         log::debug!("Setting cargo working dir to '{}'", path);
+        #[cfg(target_os = "windows")]
+        {
+            let mut path = path.as_std_path().to_string_lossy().to_string();
+            // remove first 4 elements from path string
+            path.drain(..4);
+            let path = std::path::PathBuf::from(path);
+        }
         cmd.current_dir(path);
     }
 

--- a/cargo-near/src/util/mod.rs
+++ b/cargo-near/src/util/mod.rs
@@ -246,7 +246,7 @@ pub(crate) fn force_canonicalize_dir(dir: &Utf8Path) -> color_eyre::eyre::Result
     // use `dunce` create instead of default one because it's compatible with Windows UNC paths
     // and don't breake cargo compilation on Windows
     // https://github.com/rust-lang/rust/issues/42869
-    let compatible_path = dunce::canonicalize(&dir);
+    let compatible_path = dunce::canonicalize(dir);
     match compatible_path {
         Ok(path) => Ok(Utf8PathBuf::from_path_buf(path).unwrap()),
         Err(err) => Err(err).wrap_err_with(|| format!("failed to canonicalize path: {} ", dir)),

--- a/cargo-near/src/util/mod.rs
+++ b/cargo-near/src/util/mod.rs
@@ -56,6 +56,7 @@ where
 
     if let Some(path) = working_dir {
         let path = path.as_ref();
+        // remove UNC prefix to be able compile on Windows
         let path = force_canonicalize_dir(path).unwrap();
         log::debug!("Setting cargo working dir to '{}'", path);
         cmd.current_dir(path);
@@ -242,6 +243,7 @@ pub(crate) fn compile_project(
 /// Create the directory if it doesn't exist, and return the absolute path to it.
 pub(crate) fn force_canonicalize_dir(dir: &Utf8Path) -> color_eyre::eyre::Result<Utf8PathBuf> {
     fs::create_dir_all(dir).wrap_err_with(|| format!("failed to create directory `{}`", dir))?;
+    // use `dunce` create instead of default one because it's compatible with Windows
     let compatible_path = dunce::canonicalize(&dir);
     match compatible_path {
         Ok(path) => Ok(Utf8PathBuf::from_path_buf(path).unwrap()),

--- a/cargo-near/src/util/mod.rs
+++ b/cargo-near/src/util/mod.rs
@@ -55,9 +55,7 @@ where
     cmd.envs(env);
 
     if let Some(path) = working_dir {
-        let path = path.as_ref();
-        // remove UNC prefix to be able to compile on Windows
-        let path = force_canonicalize_dir(path)?;
+        let path = force_canonicalize_dir(path.as_ref())?;
         log::debug!("Setting cargo working dir to '{}'", path);
         cmd.current_dir(path);
     }
@@ -244,13 +242,13 @@ pub(crate) fn compile_project(
 pub(crate) fn force_canonicalize_dir(dir: &Utf8Path) -> color_eyre::eyre::Result<Utf8PathBuf> {
     fs::create_dir_all(dir).wrap_err_with(|| format!("failed to create directory `{}`", dir))?;
     // use canonicalize from `dunce` create instead of default one from std because it's compatible with Windows UNC paths
-    // and don't breake cargo compilation on Windows
+    // and don't break cargo compilation on Windows
     // https://github.com/rust-lang/rust/issues/42869
     Utf8PathBuf::from_path_buf(
         dunce::canonicalize(dir)
             .wrap_err_with(|| format!("failed to canonicalize path: {} ", dir))?,
     )
-    .map_err(|err| color_eyre::eyre::eyre!(" failed to convert path {}", err.to_string_lossy()))
+    .map_err(|err| color_eyre::eyre::eyre!("failed to convert path {}", err.to_string_lossy()))
 }
 
 /// Copy a file to a destination.

--- a/cargo-near/src/util/mod.rs
+++ b/cargo-near/src/util/mod.rs
@@ -57,7 +57,7 @@ where
     if let Some(path) = working_dir {
         let path = path.as_ref();
         // remove UNC prefix to be able to compile on Windows
-        let path = force_canonicalize_dir(path).unwrap();
+        let path = force_canonicalize_dir(path)?;
         log::debug!("Setting cargo working dir to '{}'", path);
         cmd.current_dir(path);
     }

--- a/cargo-near/src/util/mod.rs
+++ b/cargo-near/src/util/mod.rs
@@ -248,10 +248,9 @@ pub(crate) fn force_canonicalize_dir(dir: &Utf8Path) -> color_eyre::eyre::Result
     // https://github.com/rust-lang/rust/issues/42869
     Utf8PathBuf::from_path_buf(
         dunce::canonicalize(dir)
-            .wrap_err_with(|| format!("failed to canonicalize path: {} ", dir))?
+            .wrap_err_with(|| format!("failed to canonicalize path: {} ", dir))?,
     )
-    .wrap_err_with(|| format!("failed to convert canonicalized path to UTF-8 path: {} ", dir))
-    .into()
+    .map_err(|err| color_eyre::eyre::eyre!(" failed to convert path {}", err.to_string_lossy()))
 }
 
 /// Copy a file to a destination.

--- a/cargo-near/src/util/mod.rs
+++ b/cargo-near/src/util/mod.rs
@@ -246,11 +246,12 @@ pub(crate) fn force_canonicalize_dir(dir: &Utf8Path) -> color_eyre::eyre::Result
     // use canonicalize from `dunce` create instead of default one from std because it's compatible with Windows UNC paths
     // and don't breake cargo compilation on Windows
     // https://github.com/rust-lang/rust/issues/42869
-    let compatible_path = dunce::canonicalize(dir);
-    match compatible_path {
-        Ok(path) => Ok(Utf8PathBuf::from_path_buf(path).unwrap()),
-        Err(err) => Err(err).wrap_err_with(|| format!("failed to canonicalize path: {} ", dir)),
-    }
+    Utf8PathBuf::from_path_buf(
+        dunce::canonicalize(dir)
+            .wrap_err_with(|| format!("failed to canonicalize path: {} ", dir))?
+    )
+    .wrap_err_with(|| format!("failed to convert canonicalized path to UTF-8 path: {} ", dir))
+    .into()
 }
 
 /// Copy a file to a destination.


### PR DESCRIPTION
Closes #4 

On Windows, `Path::canonicalize()` returns a path with the UNC prefix not supported by `cmd.exe` and breaks the compilation of all crates that have `include!` macros in it. The problem is well known, and no proper solution at the current moment https://github.com/rust-lang/rust/issues/42869 
For now, I just cut this UNC prefix, but if users complain about that, we can come out with a more sophisticated solution like https://lib.rs/crates/dunce  

