### PR TITLE
chore: release v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "atty",
  "bs58 0.4.0",
@@ -842,7 +842,7 @@ version = "0.1.0"
 dependencies = [
  "borsh 0.9.3",
  "camino",
- "cargo-near 0.4.0",
+ "cargo-near 0.5.0",
  "clap 4.4.6",
  "color-eyre",
  "const_format",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.5.0"
+version = "0.4.1"
 dependencies = [
  "atty",
  "bs58 0.4.0",
@@ -842,7 +842,7 @@ version = "0.1.0"
 dependencies = [
  "borsh 0.9.3",
  "camino",
- "cargo-near 0.5.0",
+ "cargo-near 0.4.1",
  "clap 4.4.6",
  "color-eyre",
  "const_format",

--- a/cargo-near/CHANGELOG.md
+++ b/cargo-near/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/near/cargo-near/compare/cargo-near-v0.4.0...cargo-near-v0.5.0) - 2023-10-19
+
+### Added
+- New command - deploy ([#113](https://github.com/near/cargo-near/pull/113))
+- New command - create-dev-account ([#108](https://github.com/near/cargo-near/pull/108))
+
+### Fixed
+- `cargo near build` now works on Windows ([#110](https://github.com/near/cargo-near/pull/110))
+
+### Other
+- remove `#[ignore]` from parts of test suite, using `near-workspaces` ([#111](https://github.com/near/cargo-near/pull/111))
+
 ## [0.4.0](https://github.com/near/cargo-near/compare/cargo-near-v0.3.1...cargo-near-v0.4.0) - 2023-10-01
 
 ### Other

--- a/cargo-near/CHANGELOG.md
+++ b/cargo-near/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.0](https://github.com/near/cargo-near/compare/cargo-near-v0.4.0...cargo-near-v0.5.0) - 2023-10-19
+## [0.4.1](https://github.com/near/cargo-near/compare/cargo-near-v0.4.0...cargo-near-v0.4.1) - 2023-10-19
 
 ### Added
 - New command - deploy ([#113](https://github.com/near/cargo-near/pull/113))

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.70.0"

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.5.0"
+version = "0.4.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.70.0"

--- a/cargo-near/src/commands/mod.rs
+++ b/cargo-near/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod deploy;
 #[interactive_clap(context = near_cli_rs::GlobalContext)]
 #[strum_discriminants(derive(EnumMessage, EnumIter))]
 #[interactive_clap(disable_back)]
+#[non_exhaustive]
 /// What are you up to? (select one of the options with the up-down arrows on your keyboard and press Enter)
 pub enum NearCommand {
     #[strum_discriminants(strum(


### PR DESCRIPTION
## 🤖 New release
* `cargo-near`: 0.4.0 -> 0.5.0 (⚠️ API breaking changes)

### ⚠️ `cargo-near` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.24.0/src/lints/enum_variant_added.ron

Failed in:
  variant NearCommandDiscriminants:CreateDevAccount in /tmp/.tmptlX4be/cargo-near/cargo-near/src/commands/mod.rs:31
  variant NearCommandDiscriminants:Deploy in /tmp/.tmptlX4be/cargo-near/cargo-near/src/commands/mod.rs:34
  variant NearCommandDiscriminants:CreateDevAccount in /tmp/.tmptlX4be/cargo-near/cargo-near/src/commands/mod.rs:31
  variant NearCommandDiscriminants:Deploy in /tmp/.tmptlX4be/cargo-near/cargo-near/src/commands/mod.rs:34
  variant CliNearCommand:CreateDevAccount in /tmp/.tmptlX4be/cargo-near/cargo-near/src/commands/mod.rs:8
  variant CliNearCommand:Deploy in /tmp/.tmptlX4be/cargo-near/cargo-near/src/commands/mod.rs:8
  variant NearCommand:CreateDevAccount in /tmp/.tmptlX4be/cargo-near/cargo-near/src/commands/mod.rs:31
  variant NearCommand:Deploy in /tmp/.tmptlX4be/cargo-near/cargo-near/src/commands/mod.rs:34
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0](https://github.com/near/cargo-near/compare/cargo-near-v0.4.0...cargo-near-v0.5.0) - 2023-10-19

### Added
- New command - deploy ([#113](https://github.com/near/cargo-near/pull/113))
- New command - create-dev-account ([#108](https://github.com/near/cargo-near/pull/108))

### Fixed
- `cargo near build` now works on Windows ([#110](https://github.com/near/cargo-near/pull/110))

### Other
- remove `#[ignore]` from parts of test suite, using `near-workspaces` ([#111](https://github.com/near/cargo-near/pull/111))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).