### PR TITLE
chore: release v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "atty",
  "bs58 0.4.0",
@@ -866,7 +866,7 @@ version = "0.1.0"
 dependencies = [
  "borsh 1.1.0",
  "camino",
- "cargo-near 0.4.1",
+ "cargo-near 0.5.0",
  "clap 4.4.6",
  "color-eyre",
  "const_format",

--- a/cargo-near/CHANGELOG.md
+++ b/cargo-near/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/near/cargo-near/compare/cargo-near-v0.4.1...cargo-near-v0.5.0) - 2023-11-20
+
+### Added
+- New command to initialize a new smart contract project ([#117](https://github.com/near/cargo-near/pull/117))
+
+### Other
+- update `near-sdk`, `near-abi`, `borsh` version ([#109](https://github.com/near/cargo-near/pull/109))
+
 ## [0.4.1](https://github.com/near/cargo-near/compare/cargo-near-v0.4.0...cargo-near-v0.4.1) - 2023-10-19
 
 ### Added

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.70.0"

--- a/cargo-near/src/commands/new/mod.rs
+++ b/cargo-near/src/commands/new/mod.rs
@@ -17,6 +17,14 @@ impl NewContext {
         scope: &<New as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
         let project_dir: &std::path::Path = scope.project_dir.as_ref();
+
+        if project_dir.exists() {
+            return Err(color_eyre::eyre::eyre!(
+                "Destination `{}` already exists. Refusing to overwrite existing project.",
+                project_dir.display()
+            ));
+        }
+
         let project_name = project_dir
             .file_name()
             .wrap_err("Could not extract project name from project path")?
@@ -43,12 +51,17 @@ impl NewContext {
             .output()
             .wrap_err("Failed to execute process: `git init`")?;
 
-        println!("New project is created at '{}'\n", project_dir.display());
-        println!("Now you can build, deploy, and finish CI setup for automatic deployment:");
-        println!("1. `cargo near build`");
-        println!("2. `cargo test`");
-        println!("3. `cargo near deploy`");
-        println!("4. Configure `NEAR_CONTRACT_STAGING_*` and `NEAR_CONTRACT_PRODUCTION_*` variables and secrets on GitHub to enable automatic deployment to staging and production. See more details in `.github/workflow/*` files.");
+        println!("New project is created at '{}'.\n", project_dir.display());
+        println!("Now you can build, test, and deploy your project using cargo-near:");
+        println!(" * `cargo near build`");
+        println!(" * `cargo test`");
+        println!(" * `cargo near deploy`");
+        println!(
+            "Your new project has preconfigured automations for CI and CD, just configure \
+            `NEAR_CONTRACT_STAGING_*` and `NEAR_CONTRACT_PRODUCTION_*` variables and secrets \
+            on GitHub to enable automatic deployment to staging and production. See more \
+            details in `.github/workflow/*` files.\n"
+        );
 
         Ok(Self)
     }

--- a/cargo-near/src/main.rs
+++ b/cargo-near/src/main.rs
@@ -42,7 +42,7 @@ fn main() -> CliResult {
             interactive_clap::ResultFromCli::Ok(cli_cmd)
             | interactive_clap::ResultFromCli::Cancel(Some(cli_cmd)) => {
                 eprintln!(
-                    "Your console command:\n{console_command_path} {}",
+                    "Here is the console command if you ever need to re-run it again:\n{console_command_path} {}",
                     shell_words::join(cli_cmd.to_cli_args())
                 );
                 return Ok(());
@@ -55,7 +55,7 @@ fn main() -> CliResult {
             interactive_clap::ResultFromCli::Err(optional_cli_cmd, err) => {
                 if let Some(cli_cmd) = optional_cli_cmd {
                     eprintln!(
-                        "Your console command:\n{console_command_path} {}",
+                        "Here is the console command if you ever need to re-run it again:\n{console_command_path} {}\n",
                         shell_words::join(cli_cmd.to_cli_args())
                     );
                 }


### PR DESCRIPTION
## 🤖 New release
* `cargo-near`: 0.4.1 -> 0.5.0 (⚠️ API breaking changes)

### ⚠️ `cargo-near` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.24.2/src/lints/enum_variant_added.ron

Failed in:
  variant CliNearCommand:New in /tmp/.tmpgmFX3o/cargo-near/cargo-near/src/commands/mod.rs:9
  variant NearCommandDiscriminants:New in /tmp/.tmpgmFX3o/cargo-near/cargo-near/src/commands/mod.rs:20
  variant NearCommandDiscriminants:New in /tmp/.tmpgmFX3o/cargo-near/cargo-near/src/commands/mod.rs:20
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0](https://github.com/near/cargo-near/compare/cargo-near-v0.4.1...cargo-near-v0.5.0) - 2023-11-20

### Added
- New command to initialize a new smart contract project ([#117](https://github.com/near/cargo-near/pull/117))

### Other
- update `near-sdk`, `near-abi`, `borsh` version ([#109](https://github.com/near/cargo-near/pull/109))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).