### PR TITLE
chore: release v0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "atty",
  "bs58 0.4.0",
@@ -808,7 +808,7 @@ version = "0.1.0"
 dependencies = [
  "borsh 1.3.1",
  "camino",
- "cargo-near 0.5.0",
+ "cargo-near 0.5.1",
  "color-eyre",
  "const_format",
  "function_name",

--- a/cargo-near/CHANGELOG.md
+++ b/cargo-near/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/near/cargo-near/compare/cargo-near-v0.5.0...cargo-near-v0.5.1) - 2024-01-25
+
+### Other
+- Upgraded NEAR crates to 0.20.0 release ([#125](https://github.com/near/cargo-near/pull/125))
+- Updated binary releases pipeline to use cargo-dist v0.7.2 (previously v0.3.0)  ([#122](https://github.com/near/cargo-near/pull/122))
+
 ## [0.5.0](https://github.com/near/cargo-near/compare/cargo-near-v0.4.1...cargo-near-v0.5.0) - 2023-11-20
 
 ### Added

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.72.0"


### PR DESCRIPTION
## 🤖 New release
* `cargo-near`: 0.5.0 -> 0.5.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.1](https://github.com/near/cargo-near/compare/cargo-near-v0.5.0...cargo-near-v0.5.1) - 2024-01-25

### Other
- Upgraded NEAR crates to 0.20.0 release ([#125](https://github.com/near/cargo-near/pull/125))
- Updated binary releases pipeline to use cargo-dist v0.7.2 (previously v0.3.0)  ([#122](https://github.com/near/cargo-near/pull/122))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).