### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/near/cargo-near/compare/cargo-near-v0.6.0...cargo-near-v0.6.1) - 2024-02-23
+
+### Other
+- Updated near-sdk-rs to version 5.0.0 for the new projects ([#132](https://github.com/near/cargo-near/pull/132))
+
 ## [0.6.0](https://github.com/near/cargo-near/compare/cargo-near-v0.5.2...cargo-near-v0.6.0) - 2024-02-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "atty",
  "bs58 0.4.0",
@@ -808,7 +808,7 @@ version = "0.1.0"
 dependencies = [
  "borsh 1.3.1",
  "camino",
- "cargo-near 0.6.0",
+ "cargo-near 0.6.1",
  "color-eyre",
  "const_format",
  "function_name",

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.72.0"


### PR DESCRIPTION
## 🤖 New release
* `cargo-near`: 0.6.0 -> 0.6.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.1](https://github.com/near/cargo-near/compare/cargo-near-v0.6.0...cargo-near-v0.6.1) - 2024-02-23

### Other
- Updated near-sdk-rs to version 5.0.0 for the new projects ([#132](https://github.com/near/cargo-near/pull/132))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).