### PR TITLE
Source scan integration pass uid and gid to container

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,13 +787,13 @@ dependencies = [
  "inquire",
  "interactive-clap",
  "interactive-clap-derive",
- "libc",
  "libloading",
  "linked-hash-map",
  "log",
  "names",
  "near-abi 0.4.2",
  "near-cli-rs",
+ "nix 0.28.0",
  "reqwest",
  "rustc_version",
  "schemars",
@@ -2556,9 +2556,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libgit2-sys"
@@ -3289,6 +3289,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset 0.7.1",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -5975,7 +5987,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2769203cd13a0c6015d515be729c526d041e9cf2c0cc478d57faee85f40c6dcd"
 dependencies = [
- "nix",
+ "nix 0.26.4",
  "winapi",
 ]
 
@@ -6009,7 +6021,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "hex 0.4.3",
- "nix",
+ "nix 0.26.4",
  "once_cell",
  "ordered-stream",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,6 +787,7 @@ dependencies = [
  "inquire",
  "interactive-clap",
  "interactive-clap-derive",
+ "libc",
  "libloading",
  "linked-hash-map",
  "log",

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -34,6 +34,7 @@ near-abi = { version = "0.4.0", features = ["__chunked-entries"] }
 libloading = "0.7.3"
 zstd = "0.11"
 atty = "0.2.14"
+libc = "0.2"
 
 color-eyre = "0.6"
 inquire = "0.6"

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -34,7 +34,7 @@ near-abi = { version = "0.4.0", features = ["__chunked-entries"] }
 libloading = "0.7.3"
 zstd = "0.11"
 atty = "0.2.14"
-libc = "0.2"
+nix = { version = "0.28.0", features = ["user", "process"]}
 
 color-eyre = "0.6"
 inquire = "0.6"

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -34,7 +34,6 @@ near-abi = { version = "0.4.0", features = ["__chunked-entries"] }
 libloading = "0.7.3"
 zstd = "0.11"
 atty = "0.2.14"
-nix = { version = "0.28.0", features = ["user", "process"]}
 
 color-eyre = "0.6"
 inquire = "0.6"
@@ -52,6 +51,9 @@ tempfile = "3.10.1"
 git2 = "0.14"
 cargo_toml = "0.19.1"
 reqwest = "0.11.24"
+
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.28.0", features = ["user", "process"] }
 
 [features]
 default = ["ledger"]

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -118,11 +118,13 @@ pub fn docker_run(args: BuildCommand) -> color_eyre::eyre::Result<camino::Utf8Pa
             .wrap_err("Could not get the working directory for the repository")?
             .to_string_lossy()
     );
-    let docker_image = "docker.io/sourcescan/cargo-near:0.6.0-chown"; //XXX need to fix version!!! image from cargo.toml for contract
+    let docker_image = "docker.io/sourcescan/cargo-near:0.6.0-builder"; //XXX need to fix version!!! image from cargo.toml for contract
     let docker_container_name = format!("cargo-near-{}-{}", timestamp, pid);
     let near_build_env_ref = format!("NEAR_BUILD_ENVIRONMENT_REF={}", docker_image);
+    let uid_gid = format!("{}:{}", uid, gid);
 
     let mut docker_args = vec![
+        "-u", &uid_gid,
         "-it",
         "--name", &docker_container_name,
         "--volume", &volume,
@@ -130,9 +132,7 @@ pub fn docker_run(args: BuildCommand) -> color_eyre::eyre::Result<camino::Utf8Pa
         "--workdir", "/host",
         "--env", &near_build_env_ref,
         docker_image,
-        "--uid", &uid,
-        "--gid", &gid,
-        "--run",
+        "/bin/bash", "-c"
     ];
 
     let mut cargo_cmd_list = vec![

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -119,7 +119,7 @@ pub fn docker_run(args: BuildCommand) -> color_eyre::eyre::Result<camino::Utf8Pa
             .wrap_err("Could not get the working directory for the repository")?
             .to_string_lossy()
     );
-    let docker_image = "cargo-near"; //XXX need to fix version!!! image from cargo.toml for contract
+    let docker_image = "docker.io/sourcescan/cargo-near:0.6.0-builder"; //XXX need to fix version!!! image from cargo.toml for contract
     let docker_container_name = format!("cargo-near-{}-{}", timestamp, pid);
     let near_build_env_ref = format!("NEAR_BUILD_ENVIRONMENT_REF={}", docker_image);
     let uid_gid = format!("{}:{}", uid, gid);

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -1,5 +1,6 @@
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
+use nix::unistd::{getuid, getgid, getpid};
 
 use color_eyre::{
     eyre::{ContextCompat, WrapErr},
@@ -105,9 +106,9 @@ pub fn docker_run(args: BuildCommand) -> color_eyre::eyre::Result<camino::Utf8Pa
     let tmp_repo = git2::Repository::clone(contract_path.as_str(), &tmp_contract_path)?;
 
     // get uid, gid and pid using libc
-    let uid = unsafe { libc::getuid() }.to_string();
-    let gid = unsafe { libc::getgid() }.to_string();
-    let pid = unsafe { libc::getpid() }.to_string();
+    let uid = getuid().to_string();
+    let gid = getgid().to_string();
+    let pid = getpid().to_string();
     
     let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs().to_string();
 
@@ -118,7 +119,7 @@ pub fn docker_run(args: BuildCommand) -> color_eyre::eyre::Result<camino::Utf8Pa
             .wrap_err("Could not get the working directory for the repository")?
             .to_string_lossy()
     );
-    let docker_image = "docker.io/sourcescan/cargo-near:0.6.0-builder"; //XXX need to fix version!!! image from cargo.toml for contract
+    let docker_image = "cargo-near"; //XXX need to fix version!!! image from cargo.toml for contract
     let docker_container_name = format!("cargo-near-{}-{}", timestamp, pid);
     let near_build_env_ref = format!("NEAR_BUILD_ENVIRONMENT_REF={}", docker_image);
     let uid_gid = format!("{}:{}", uid, gid);


### PR DESCRIPTION
Passing uid, gid to container to preserve the privileges the same as for host system, while building to mounted volume from host.

- [append timestamp and pid to container name to make it unique](https://github.com/near/cargo-near/commit/fdc5ee6ebb97bd2fa7c80ebd71ec28b6b00b6524)
- [use image with non-root user builder](https://github.com/near/cargo-near/commit/f3c3b11eba7286bfefd9e956fe81a16611ea0efd)
- [implement cross-platform uid,gid support with platform-specific dependencies](https://github.com/near/cargo-near/pull/140/commits/40f98ba62fe59ad42099441e32a0839655d2ff74) 