### PR TITLE
Source scan locked flag expose

### DIFF
--- a/cargo-near/src/commands/abi_command/abi.rs
+++ b/cargo-near/src/commands/abi_command/abi.rs
@@ -31,6 +31,7 @@ pub(crate) enum AbiCompression {
 pub(crate) fn generate_abi(
     crate_metadata: &CrateMetadata,
     generate_docs: bool,
+    locked: bool,
     hide_warnings: bool,
     color: ColorPreference,
 ) -> color_eyre::eyre::Result<AbiRoot> {
@@ -83,10 +84,16 @@ pub(crate) fn generate_abi(
         color_eyre::eyre::bail!("`near-sdk` dependency must have the `abi` feature enabled")
     }
 
+    let mut cargo_args = vec!["--features", "near-sdk/__abi-generate"];
+
+    if locked {
+        cargo_args.push("--locked");
+    }
+
     util::print_step("Generating ABI");
     let dylib_artifact = util::compile_project(
         &crate_metadata.manifest_path,
-        &["--features", "near-sdk/__abi-generate"],
+        &cargo_args,
         vec![
             ("CARGO_PROFILE_DEV_OPT_LEVEL", "0"),
             ("CARGO_PROFILE_DEV_DEBUG", "0"),
@@ -186,7 +193,7 @@ pub fn run(args: super::AbiCommand) -> near_cli_rs::CliResult {
         } else {
             "Cargo.toml".into()
         };
-        CrateMetadata::collect(CargoManifestPath::try_from(manifest_path)?)
+        CrateMetadata::collect(CargoManifestPath::try_from(manifest_path)?, args.locked)
     })?;
 
     let out_dir = args
@@ -201,7 +208,7 @@ pub fn run(args: super::AbiCommand) -> near_cli_rs::CliResult {
     } else {
         AbiFormat::Json
     };
-    let contract_abi = generate_abi(&crate_metadata, !args.no_doc, false, color)?;
+    let contract_abi = generate_abi(&crate_metadata, !args.no_doc, args.locked, false, color)?;
     let AbiResult { path } =
         write_to_file(&contract_abi, &crate_metadata, format, AbiCompression::NoOp)?;
 

--- a/cargo-near/src/commands/abi_command/mod.rs
+++ b/cargo-near/src/commands/abi_command/mod.rs
@@ -7,6 +7,9 @@ pub struct AbiCommand {
     /// Include rustdocs in the ABI file
     #[interactive_clap(long)]
     pub no_doc: bool,
+    /// add --locked to corresponding `cargo` commands
+    #[interactive_clap(long)]
+    pub locked: bool,
     /// Generate compact (minified) JSON
     #[interactive_clap(long)]
     pub compact_abi: bool,
@@ -35,6 +38,7 @@ impl AbiCommandlContext {
     ) -> color_eyre::eyre::Result<Self> {
         let args = AbiCommand {
             no_doc: scope.no_doc,
+            locked: scope.locked,
             compact_abi: scope.compact_abi,
             out_dir: scope.out_dir.clone(),
             manifest_path: scope.manifest_path.clone(),

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -178,6 +178,8 @@ pub fn docker_run(args: BuildCommand) -> color_eyre::eyre::Result<camino::Utf8Pa
     if args.no_doc {
         cargo_args.push("--no-doc")
     }
+    cargo_args.push("--no-docker");
+
     let color = args
         .color
         .clone()

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -313,13 +313,17 @@ pub fn docker_run(args: BuildCommand) -> color_eyre::eyre::Result<camino::Utf8Pa
 
         for entry in dir.flatten() {
             if entry.path().extension().unwrap().to_str().unwrap() == "wasm" {
-                cloned_repo.contract_path.push("contract.wasm");
+                let wasm_path = {
+                    let mut contract_path = cloned_repo.contract_path.clone();
+                    contract_path.push("contract.wasm");
+                    contract_path
+                };
                 std::fs::copy::<std::path::PathBuf, camino::Utf8PathBuf>(
                     entry.path(),
-                    cloned_repo.contract_path.clone(),
+                    wasm_path.clone(),
                 )?;
 
-                return Ok(cloned_repo.contract_path);
+                return Ok(wasm_path);
             }
         }
 

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -25,6 +25,9 @@ pub struct BuildCommand {
     /// Build contract without SourceScan verification
     #[interactive_clap(long)]
     pub no_docker: bool,
+    /// add --locked to corresponding `cargo` commands
+    #[interactive_clap(long)]
+    pub locked: bool,
     /// Build contract in debug mode, without optimizations and bigger is size
     #[interactive_clap(long)]
     pub no_release: bool,
@@ -62,6 +65,7 @@ impl BuildCommandlContext {
     ) -> color_eyre::eyre::Result<Self> {
         let args = BuildCommand {
             no_docker: scope.no_docker,
+            locked: scope.locked,
             no_release: scope.no_release,
             no_abi: scope.no_abi,
             no_embed_abi: scope.no_embed_abi,
@@ -186,6 +190,7 @@ fn docker_subprocess_step(
         cargo_args.push("--no-doc")
     }
     cargo_args.push("--no-docker");
+    cargo_args.push("--locked");
 
     let color = args
         .color
@@ -286,7 +291,8 @@ pub fn docker_run(args: BuildCommand) -> color_eyre::eyre::Result<camino::Utf8Pa
                 cloned_path.push("Cargo.toml");
                 cloned_path.try_into()?
             };
-            CrateMetadata::collect(CargoManifestPath::try_from(cargo_toml_path)?)
+            let locked = true;
+            CrateMetadata::collect(CargoManifestPath::try_from(cargo_toml_path)?, locked)
         },
     )?;
 

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -96,11 +96,11 @@ fn clone_repo(args: &BuildCommand) -> color_eyre::eyre::Result<ClonedRepo> {
             color_eyre::eyre::eyre!("Failed to convert path {}", err.to_string_lossy())
         })?
     };
-    log::debug!("ClonedRepo.contract_path: {:?}", contract_path,);
+    log::info!("ClonedRepo.contract_path: {:?}", contract_path,);
 
     let tmp_contract_dir = tempfile::tempdir()?;
     let tmp_contract_path = tmp_contract_dir.path().to_path_buf();
-    log::debug!("ClonedRepo.tmp_contract_path: {:?}", tmp_contract_path);
+    log::info!("ClonedRepo.tmp_contract_path: {:?}", tmp_contract_path);
     let tmp_repo = git2::Repository::clone(contract_path.as_str(), &tmp_contract_path)?;
     Ok(ClonedRepo {
         tmp_repo,
@@ -225,10 +225,6 @@ pub fn docker_run(args: BuildCommand) -> color_eyre::eyre::Result<camino::Utf8Pa
     let docker_image = docker_build_meta.concat_image();
     let near_build_env_ref = format!("NEAR_BUILD_ENVIRONMENT_REF={}", docker_image);
 
-    let rust_log = {
-        let value = std::env::var("RUST_LOG").unwrap_or("error".to_string());
-        format!("RUST_LOG={}", value)
-    };
     // Platform-specific UID/GID retrieval
     #[cfg(unix)]
     let uid_gid = format!("{}:{}", getuid(), getgid());
@@ -249,7 +245,7 @@ pub fn docker_run(args: BuildCommand) -> color_eyre::eyre::Result<camino::Utf8Pa
         "--env",
         &near_build_env_ref,
         "--env",
-        &rust_log,
+        "RUST_LOG=cargo_near=info",
         &docker_image,
         "/bin/bash",
         "-c",

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -246,6 +246,8 @@ pub fn docker_run(args: BuildCommand) -> color_eyre::eyre::Result<camino::Utf8Pa
         "/host",
         "--env",
         &near_build_env_ref,
+        "--env",
+        "RUST_LOG=cargo_near=debug",
         &docker_image,
         "/bin/bash",
         "-c",

--- a/cargo-near/src/commands/deploy/mod.rs
+++ b/cargo-near/src/commands/deploy/mod.rs
@@ -38,16 +38,21 @@ impl ContractContext {
                 })?
             };
 
-        eprintln!(
-            "\nThe URL of the remote repository:\n{}\n",
-            remote_repo_url(&contract_path)?
-        );
 
         let file_path = if !scope.build_command_args.no_docker {
             build_command::docker_run(scope.build_command_args.clone())?
         } else {
             build_command::build::run(scope.build_command_args.clone())?.path
         };
+        // TODO: rework flow with checkout after contract built before deploy 
+        // NOTE:  `git clone https://github.com/dj8yfo/sample_no_workspace/tree/73f5eb98c257fd9115675f3894ddfd37a5915e7b `
+        // and `git clone https://github.com/dj8yfo/sample_no_workspace.git/commit/73f5eb98c257fd9115675f3894ddfd37a5915e7`
+        // are both an error
+        // TODO: clone to tmp folder and checkout specific revision must be separate steps
+        // eprintln!(
+        //     "\nThe URL of the remote repository:\n{}\n",
+        //     remote_repo_url(&contract_path)?
+        // );
 
         Ok(Self(
             near_cli_rs::commands::contract::deploy::ContractFileContext {

--- a/cargo-near/src/commands/deploy/mod.rs
+++ b/cargo-near/src/commands/deploy/mod.rs
@@ -39,19 +39,15 @@ impl ContractContext {
             };
 
         let file_path = if !scope.build_command_args.no_docker {
+            // TODO: clone to tmp folder and checkout specific revision must be separate steps
+            eprintln!(
+                "\n The URL of the remote repository:\n {}\n",
+                remote_repo_url(&contract_path)?
+            );
             build_command::docker_run(scope.build_command_args.clone())?
         } else {
             build_command::build::run(scope.build_command_args.clone())?.path
         };
-        // TODO: rework flow with checkout after contract built before deploy
-        // NOTE:  `git clone https://github.com/dj8yfo/sample_no_workspace/tree/73f5eb98c257fd9115675f3894ddfd37a5915e7b `
-        // and `git clone https://github.com/dj8yfo/sample_no_workspace.git/commit/73f5eb98c257fd9115675f3894ddfd37a5915e7`
-        // are both an error
-        // TODO: clone to tmp folder and checkout specific revision must be separate steps
-        // eprintln!(
-        //     "\nThe URL of the remote repository:\n{}\n",
-        //     remote_repo_url(&contract_path)?
-        // );
 
         Ok(Self(
             near_cli_rs::commands::contract::deploy::ContractFileContext {
@@ -249,6 +245,7 @@ fn remote_repo_url(contract_path: &camino::Utf8PathBuf) -> color_eyre::Result<re
     let commit = format!("{path}/commit/{repo_id}");
 
     remote_repo_url.set_path(&commit);
+    log::info!("checking existence of {}", remote_repo_url);
 
     let mut retries_left = (0..5).rev();
     loop {

--- a/cargo-near/src/commands/deploy/mod.rs
+++ b/cargo-near/src/commands/deploy/mod.rs
@@ -85,6 +85,7 @@ impl interactive_clap::FromCli for Contract {
             if let Some(cli_build_command_args) = &clap_variant.build_command_args {
                 build_command::BuildCommand {
                     no_docker: cli_build_command_args.no_docker,
+                    locked: cli_build_command_args.locked,
                     no_release: cli_build_command_args.no_release,
                     no_abi: cli_build_command_args.no_abi,
                     no_embed_abi: cli_build_command_args.no_embed_abi,

--- a/cargo-near/src/commands/deploy/mod.rs
+++ b/cargo-near/src/commands/deploy/mod.rs
@@ -38,13 +38,12 @@ impl ContractContext {
                 })?
             };
 
-
         let file_path = if !scope.build_command_args.no_docker {
             build_command::docker_run(scope.build_command_args.clone())?
         } else {
             build_command::build::run(scope.build_command_args.clone())?.path
         };
-        // TODO: rework flow with checkout after contract built before deploy 
+        // TODO: rework flow with checkout after contract built before deploy
         // NOTE:  `git clone https://github.com/dj8yfo/sample_no_workspace/tree/73f5eb98c257fd9115675f3894ddfd37a5915e7b `
         // and `git clone https://github.com/dj8yfo/sample_no_workspace.git/commit/73f5eb98c257fd9115675f3894ddfd37a5915e7`
         // are both an error

--- a/cargo-near/src/main.rs
+++ b/cargo-near/src/main.rs
@@ -29,7 +29,7 @@ fn main() -> CliResult {
             let ts = buf.timestamp_seconds();
             writeln!(
                 buf,
-                "{}-[{}] {}:{} {} - {}",
+                " {}-[{}] {}:{} {} - {}",
                 level,
                 environment,
                 record.file().unwrap_or("unknown"),

--- a/cargo-near/src/types/metadata.rs
+++ b/cargo-near/src/types/metadata.rs
@@ -40,6 +40,7 @@ impl CrateMetadata {
             manifest_path,
             raw_metadata: metadata,
         };
+        log::trace!("crate metadata : {:#?}", crate_metadata);
         Ok(crate_metadata)
     }
 }

--- a/cargo-near/src/util/mod.rs
+++ b/cargo-near/src/util/mod.rs
@@ -193,10 +193,6 @@ pub(crate) fn compile_project(
             }
         }
     }
-    log::debug!(
-        "compile project args: {:?}",
-        [&["--message-format=json-render-diagnostics"], args].concat()
-    );
 
     let artifacts = invoke_cargo(
         "build",

--- a/cargo-near/src/util/print.rs
+++ b/cargo-near/src/util/print.rs
@@ -7,9 +7,9 @@ where
     eprint!(" {} {}\n", "•".bold().cyan(), msg);
     let result = f();
     if result.is_ok() {
-        eprintln!("{} {}\n", "•".bold().cyan(), "done".bold().green());
+        eprintln!(" {} {}\n", "•".bold().cyan(), "done".bold().green());
     } else {
-        eprintln!("{} {}\n", "•".bold().cyan(), "failed".bold().red());
+        eprintln!(" {} {}\n", "•".bold().cyan(), "failed".bold().red());
     }
     result
 }

--- a/cargo-near/src/util/print.rs
+++ b/cargo-near/src/util/print.rs
@@ -4,12 +4,12 @@ pub(crate) fn handle_step<F, T>(msg: &str, f: F) -> color_eyre::eyre::Result<T>
 where
     F: FnOnce() -> color_eyre::eyre::Result<T>,
 {
-    eprint!(" {} {}", "•".bold().cyan(), msg);
+    eprint!(" {} {}\n", "•".bold().cyan(), msg);
     let result = f();
     if result.is_ok() {
-        eprintln!("{}", "done".bold().green());
+        eprintln!("{} {}\n", "•".bold().cyan(), "done".bold().green());
     } else {
-        eprintln!("{}", "failed".bold().red());
+        eprintln!("{} {}\n", "•".bold().cyan(), "failed".bold().red());
     }
     result
 }

--- a/cargo-near/src/util/print.rs
+++ b/cargo-near/src/util/print.rs
@@ -4,7 +4,7 @@ pub(crate) fn handle_step<F, T>(msg: &str, f: F) -> color_eyre::eyre::Result<T>
 where
     F: FnOnce() -> color_eyre::eyre::Result<T>,
 {
-    eprint!(" {} {}\n", "•".bold().cyan(), msg);
+    eprintln!(" {} {}", "•".bold().cyan(), msg);
     let result = f();
     if result.is_ok() {
         eprintln!(" {} {}\n", "•".bold().cyan(), "done".bold().green());
@@ -20,4 +20,15 @@ pub(crate) fn print_step(msg: &str) {
 
 pub(crate) fn print_success(msg: &str) {
     eprintln!(" {} {}", "✓".bold().green(), msg);
+}
+
+pub(crate) fn indent_string(msg: &str) -> String {
+    let indent = " ";
+    let newline_indent = format!("\n{}", indent);
+    let lines = msg.split('\n').collect::<Vec<_>>();
+    let mut res = String::new();
+    res.push_str(indent);
+
+    res.push_str(&lines.join(&newline_indent));
+    res
 }

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -64,6 +64,7 @@ macro_rules! invoke_cargo_near {
             Some(cargo_near::commands::CliNearCommand::Abi(cmd)) => {
                 let args = cargo_near::commands::abi_command::AbiCommand {
                     no_doc: cmd.no_doc,
+                    locked: false,
                     compact_abi: cmd.compact_abi,
                     out_dir: cmd.out_dir,
                     manifest_path: Some(cargo_path.into()),
@@ -75,6 +76,7 @@ macro_rules! invoke_cargo_near {
                 let args = cargo_near::commands::build_command::BuildCommand {
                     // this is implied by 10 lines below
                     no_docker: true,
+                    locked: false,
                     no_release: cmd.no_release,
                     no_abi: cmd.no_abi,
                     no_embed_abi: cmd.no_embed_abi,

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -73,7 +73,8 @@ macro_rules! invoke_cargo_near {
             },
             Some(cargo_near::commands::CliNearCommand::Build(cmd)) => {
                 let args = cargo_near::commands::build_command::BuildCommand {
-                    no_docker: cmd.no_docker,
+                    // this is implied by 10 lines below
+                    no_docker: true,
                     no_release: cmd.no_release,
                     no_abi: cmd.no_abi,
                     no_embed_abi: cmd.no_embed_abi,


### PR DESCRIPTION
fast forward extension of https://github.com/near/cargo-near/pull/144

first screenshot is from [set_metadata_locked branch](https://github.com/dj8yfo/sample_no_workspace/tree/set_metadata_locked) contract build with `cargo-near` from this branch pr embedded into docker image
![Screenshot_20240410_234613](https://github.com/near/cargo-near/assets/26653921/962f77dd-f5d5-4a31-a0ee-02d63f5b9db0)

second screenshot is from [set_metadata_locked_remove_lock branch](https://github.com/dj8yfo/sample_no_workspace/tree/set_metadata_locked_remove_lock) with the same docker image
![Screenshot_20240410_235057](https://github.com/near/cargo-near/assets/26653921/a238bfc6-5fd7-4063-b455-b68176e80347)

