### PR TITLE
feat(source-scan): implicitly enable `--locked` everywhere

### DIFF
--- a/cargo-near/src/commands/abi_command/abi.rs
+++ b/cargo-near/src/commands/abi_command/abi.rs
@@ -6,6 +6,7 @@ use color_eyre::eyre::ContextCompat;
 use colored::Colorize;
 use near_abi::AbiRoot;
 
+use crate::commands::cargo_locked;
 use crate::common::ColorPreference;
 use crate::types::{manifest::CargoManifestPath, metadata::CrateMetadata};
 use crate::util;
@@ -83,10 +84,16 @@ pub(crate) fn generate_abi(
         color_eyre::eyre::bail!("`near-sdk` dependency must have the `abi` feature enabled")
     }
 
+    let mut cargo_args = vec!["--features", "near-sdk/__abi-generate"];
+
+    if cargo_locked() {
+        cargo_args.push("--locked");
+    }
     util::print_step("Generating ABI");
+
     let dylib_artifact = util::compile_project(
         &crate_metadata.manifest_path,
-        &["--features", "near-sdk/__abi-generate"],
+        &cargo_args,
         vec![
             ("CARGO_PROFILE_DEV_OPT_LEVEL", "0"),
             ("CARGO_PROFILE_DEV_DEBUG", "0"),

--- a/cargo-near/src/commands/build_command/build.rs
+++ b/cargo-near/src/commands/build_command/build.rs
@@ -6,6 +6,7 @@ use std::io::BufRead;
 
 use crate::commands::abi_command::abi;
 use crate::commands::abi_command::abi::{AbiCompression, AbiFormat, AbiResult};
+use crate::commands::cargo_locked;
 use crate::common::ColorPreference;
 use crate::types::{manifest::CargoManifestPath, metadata::CrateMetadata};
 use crate::util;
@@ -45,9 +46,12 @@ pub(super) fn run(
         })?;
 
     let mut build_env = vec![("RUSTFLAGS", "-C link-arg=-s")];
-    let mut cargo_args = vec!["--target", COMPILATION_TARGET, "--locked"];
+    let mut cargo_args = vec!["--target", COMPILATION_TARGET];
     if !args.no_release {
         cargo_args.push("--release");
+    }
+    if cargo_locked() {
+        cargo_args.push("--locked");
     }
 
     let mut abi = None;

--- a/cargo-near/src/commands/build_command/docker.rs
+++ b/cargo-near/src/commands/build_command/docker.rs
@@ -3,7 +3,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use crate::types::manifest::CargoManifestPath;
+use crate::{commands::build_command::INSIDE_DOCKER_ENV_KEY, types::manifest::CargoManifestPath};
 use crate::{types::metadata::CrateMetadata, util};
 
 use color_eyre::{
@@ -165,7 +165,7 @@ impl super::BuildCommand {
         );
         let docker_container_name = format!("cargo-near-{}-{}", timestamp, pid);
         let docker_image = docker_build_meta.concat_image();
-        let near_build_env_ref = format!("NEAR_BUILD_ENVIRONMENT_REF={}", docker_image);
+        let near_build_env_ref = format!("{}={}", INSIDE_DOCKER_ENV_KEY, docker_image);
 
         // Platform-specific UID/GID retrieval
         #[cfg(unix)]

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -4,7 +4,7 @@ use crate::{types::manifest::CargoManifestPath, util};
 
 mod build;
 mod docker;
-pub const INSIDE_DOCKER_ENV_KEY: &str = "NEAR_BUILD_ENVIRONMENT_REF";
+pub const INSIDE_DOCKER_ENV_KEY: &str = "CARGO_NEAR_BUILD_ENVIRONMENT";
 
 #[derive(Debug, Default, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(input_context = near_cli_rs::GlobalContext)]

--- a/cargo-near/src/commands/mod.rs
+++ b/cargo-near/src/commands/mod.rs
@@ -6,6 +6,8 @@ pub mod create_dev_account;
 pub mod deploy;
 pub mod new;
 
+pub const CARGO_NEAR_UNLOCKED: &str = "CARGO_NEAR_UNLOCKED";
+
 #[derive(Debug, EnumDiscriminants, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(context = near_cli_rs::GlobalContext)]
 #[strum_discriminants(derive(EnumMessage, EnumIter))]
@@ -38,4 +40,11 @@ pub enum NearCommand {
     #[strum_discriminants(strum(message = "deploy              -  Add a new contract code"))]
     /// Add a new contract code
     Deploy(self::deploy::Contract),
+}
+
+/// By default, all cargo commands, besides ones, run by `cargo near check`,
+/// should be run with `--locked` enabled, unless `CARGO_NEAR_UNLOCKED`
+/// ENV variable is set
+pub fn cargo_locked() -> bool {
+    std::env::var(CARGO_NEAR_UNLOCKED).is_err()
 }

--- a/cargo-near/src/types/metadata.rs
+++ b/cargo-near/src/types/metadata.rs
@@ -1,5 +1,5 @@
-use crate::types::manifest::CargoManifestPath;
 use crate::util;
+use crate::{commands::cargo_locked, types::manifest::CargoManifestPath};
 use camino::Utf8PathBuf;
 use cargo_metadata::{MetadataCommand, Package};
 use color_eyre::eyre::{ContextCompat, WrapErr};
@@ -51,6 +51,9 @@ fn get_cargo_metadata(
 ) -> color_eyre::eyre::Result<(cargo_metadata::Metadata, Package)> {
     log::info!("Fetching cargo metadata for {}", manifest_path.path);
     let mut cmd = MetadataCommand::new();
+    if cargo_locked() {
+        cmd.other_options(["--locked".to_string()]);
+    }
     let metadata = cmd
         .manifest_path(&manifest_path.path)
         .exec()

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -60,6 +60,7 @@ macro_rules! invoke_cargo_near {
 
         let cargo_near::CliOpts::Near(cli_args) = cargo_near::Opts::try_parse_from($cli_opts)?;
 
+        std::env::set_var(cargo_near::commands::CARGO_NEAR_UNLOCKED, "yes");
         match cli_args.cmd {
             Some(cargo_near::commands::CliNearCommand::Abi(cmd)) => {
                 let args = cargo_near::commands::abi_command::AbiCommand {


### PR DESCRIPTION
tested on https://github.com/dj8yfo/sample_no_workspace/tree/set_metadata