### PR TITLE
chore: release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2](https://github.com/near/cargo-near/compare/cargo-near-v0.6.1...cargo-near-v0.6.2) - 2024-04-14
+
+### Added
+- Updated new project template with near-sdk-rs 5.1.0 ([#143](https://github.com/near/cargo-near/pull/143))
+
+### Fixed
+- Support nixOS - decouple cargo-near from rustup ([#146](https://github.com/near/cargo-near/pull/146))
+
 ## [0.6.1](https://github.com/near/cargo-near/compare/cargo-near-v0.6.0...cargo-near-v0.6.1) - 2024-02-23
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "atty",
  "bs58 0.4.0",
@@ -808,7 +808,7 @@ version = "0.1.0"
 dependencies = [
  "borsh 1.3.1",
  "camino",
- "cargo-near 0.6.1",
+ "cargo-near 0.6.2",
  "color-eyre",
  "const_format",
  "function_name",

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.74.0"


### PR DESCRIPTION
## 🤖 New release
* `cargo-near`: 0.6.1 -> 0.6.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.2](https://github.com/near/cargo-near/compare/cargo-near-v0.6.1...cargo-near-v0.6.2) - 2024-04-14

### Added
- Updated new project template with near-sdk-rs 5.1.0 ([#143](https://github.com/near/cargo-near/pull/143))

### Fixed
- Support nixOS - decouple cargo-near from rustup ([#146](https://github.com/near/cargo-near/pull/146))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).