### PR TITLE
feat(source-scan): implicit `--locked` by default, add `--no-locked` flag

### DIFF
--- a/cargo-near/src/commands/abi_command/abi.rs
+++ b/cargo-near/src/commands/abi_command/abi.rs
@@ -6,6 +6,7 @@ use color_eyre::eyre::ContextCompat;
 use colored::Colorize;
 use near_abi::AbiRoot;
 
+use crate::commands::cargo_locked;
 use crate::common::ColorPreference;
 use crate::types::{manifest::CargoManifestPath, metadata::CrateMetadata};
 use crate::util;
@@ -83,10 +84,16 @@ pub(crate) fn generate_abi(
         color_eyre::eyre::bail!("`near-sdk` dependency must have the `abi` feature enabled")
     }
 
+    let mut cargo_args = vec!["--features", "near-sdk/__abi-generate"];
+
+    if cargo_locked() {
+        cargo_args.push("--locked");
+    }
     util::print_step("Generating ABI");
+
     let dylib_artifact = util::compile_project(
         &crate_metadata.manifest_path,
-        &["--features", "near-sdk/__abi-generate"],
+        &cargo_args,
         vec![
             ("CARGO_PROFILE_DEV_OPT_LEVEL", "0"),
             ("CARGO_PROFILE_DEV_DEBUG", "0"),

--- a/cargo-near/src/commands/abi_command/mod.rs
+++ b/cargo-near/src/commands/abi_command/mod.rs
@@ -4,6 +4,9 @@ pub mod abi;
 #[interactive_clap(input_context = near_cli_rs::GlobalContext)]
 #[interactive_clap(output_context = AbiCommandlContext)]
 pub struct AbiCommand {
+    /// disable implicit `--locked` flag for all `cargo` commands, enabled by default
+    #[interactive_clap(long)]
+    pub no_locked: bool,
     /// Include rustdocs in the ABI file
     #[interactive_clap(long)]
     pub no_doc: bool,
@@ -34,6 +37,7 @@ impl AbiCommandlContext {
         scope: &<AbiCommand as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
         let args = AbiCommand {
+            no_locked: scope.no_locked,
             no_doc: scope.no_doc,
             compact_abi: scope.compact_abi,
             out_dir: scope.out_dir.clone(),

--- a/cargo-near/src/commands/build_command/build.rs
+++ b/cargo-near/src/commands/build_command/build.rs
@@ -4,6 +4,7 @@ use near_abi::BuildInfo;
 use sha2::{Digest, Sha256};
 
 use crate::commands::abi_command::abi::{AbiCompression, AbiFormat, AbiResult};
+use crate::commands::cargo_locked;
 use crate::common::ColorPreference;
 use crate::types::{manifest::CargoManifestPath, metadata::CrateMetadata};
 use crate::util;
@@ -41,9 +42,12 @@ pub(super) fn run(
         })?;
 
     let mut build_env = vec![("RUSTFLAGS", "-C link-arg=-s")];
-    let mut cargo_args = vec!["--target", COMPILATION_TARGET, "--locked"];
+    let mut cargo_args = vec!["--target", COMPILATION_TARGET];
     if !args.no_release {
         cargo_args.push("--release");
+    }
+    if cargo_locked() {
+        cargo_args.push("--locked");
     }
 
     let mut abi = None;

--- a/cargo-near/src/commands/build_command/docker.rs
+++ b/cargo-near/src/commands/build_command/docker.rs
@@ -52,7 +52,7 @@ impl super::BuildCommand {
                     cloned_path.push("Cargo.toml");
                     cloned_path.try_into()?
                 };
-                CrateMetadata::collect(CargoManifestPath::try_from(cargo_toml_path)?)
+                CrateMetadata::collect(CargoManifestPath::try_from(cargo_toml_path)?, false)
             },
         )?;
 
@@ -130,13 +130,19 @@ impl super::BuildCommand {
         let mut cargo_args = vec![];
 
         if self.no_abi {
-            cargo_args.push("--no-abi")
+            cargo_args.push("--no-abi");
         }
         if self.no_embed_abi {
-            cargo_args.push("--no-embed-abi")
+            cargo_args.push("--no-embed-abi");
         }
         if self.no_doc {
-            cargo_args.push("--no-doc")
+            cargo_args.push("--no-doc");
+        }
+        if self.no_locked {
+            return Err(color_eyre::eyre::eyre!("`--no-locked` flag is forbidden for reproducible builds in containers, because a specific Cargo.lock is required"));
+        }
+        if self.no_release {
+            cargo_args.push("--no-release");
         }
 
         let color = self
@@ -195,6 +201,10 @@ impl super::BuildCommand {
 
         let mut cargo_cmd_list = vec!["cargo", "near", "build"];
         cargo_cmd_list.extend(&cargo_args);
+        println!(
+            " {}",
+            format!("build command in container: {}", cargo_cmd_list.join(" ")).green()
+        );
 
         let cargo_cmd = cargo_cmd_list.join(" ");
 

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -10,6 +10,9 @@ pub const INSIDE_DOCKER_ENV_KEY: &str = "CARGO_NEAR_BUILD_ENVIRONMENT";
 #[interactive_clap(input_context = near_cli_rs::GlobalContext)]
 #[interactive_clap(output_context = BuildCommandlContext)]
 pub struct BuildCommand {
+    /// disable implicit `--locked` flag for all `cargo` commands, enabled by default
+    #[interactive_clap(long)]
+    pub no_locked: bool,
     /// Build contract on host system and without embedding SourceScan NEP-330 metadata
     #[interactive_clap(long)]
     no_docker: bool,
@@ -72,6 +75,7 @@ impl BuildCommand {
 impl From<CliBuildCommand> for BuildCommand {
     fn from(value: CliBuildCommand) -> Self {
         Self {
+            no_locked: value.no_locked,
             no_docker: value.no_docker,
             no_release: value.no_release,
             no_abi: value.no_abi,
@@ -93,6 +97,7 @@ impl BuildCommandlContext {
         scope: &<BuildCommand as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
         let args = BuildCommand {
+            no_locked: scope.no_locked,
             no_docker: scope.no_docker,
             no_release: scope.no_release,
             no_abi: scope.no_abi,

--- a/cargo-near/src/commands/mod.rs
+++ b/cargo-near/src/commands/mod.rs
@@ -6,6 +6,8 @@ pub mod create_dev_account;
 pub mod deploy;
 pub mod new;
 
+pub const CARGO_NEAR_UNLOCKED: &str = "CARGO_NEAR_UNLOCKED";
+
 #[derive(Debug, EnumDiscriminants, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(context = near_cli_rs::GlobalContext)]
 #[strum_discriminants(derive(EnumMessage, EnumIter))]
@@ -38,4 +40,11 @@ pub enum NearCommand {
     #[strum_discriminants(strum(message = "deploy              -  Add a new contract code"))]
     /// Add a new contract code
     Deploy(self::deploy::Contract),
+}
+
+/// By default, all cargo commands, besides ones, run by `cargo near check`,
+/// should be run with `--locked` enabled, unless `CARGO_NEAR_UNLOCKED`
+/// ENV variable is set
+pub fn cargo_locked() -> bool {
+    std::env::var(CARGO_NEAR_UNLOCKED).is_err()
 }

--- a/cargo-near/src/commands/mod.rs
+++ b/cargo-near/src/commands/mod.rs
@@ -6,8 +6,6 @@ pub mod create_dev_account;
 pub mod deploy;
 pub mod new;
 
-pub const CARGO_NEAR_UNLOCKED: &str = "CARGO_NEAR_UNLOCKED";
-
 #[derive(Debug, EnumDiscriminants, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(context = near_cli_rs::GlobalContext)]
 #[strum_discriminants(derive(EnumMessage, EnumIter))]
@@ -40,11 +38,4 @@ pub enum NearCommand {
     #[strum_discriminants(strum(message = "deploy              -  Add a new contract code"))]
     /// Add a new contract code
     Deploy(self::deploy::Contract),
-}
-
-/// By default, all cargo commands, besides ones, run by `cargo near check`,
-/// should be run with `--locked` enabled, unless `CARGO_NEAR_UNLOCKED`
-/// ENV variable is set
-pub fn cargo_locked() -> bool {
-    std::env::var(CARGO_NEAR_UNLOCKED).is_err()
 }

--- a/cargo-near/src/types/metadata.rs
+++ b/cargo-near/src/types/metadata.rs
@@ -59,16 +59,13 @@ fn get_cargo_metadata(
         cmd.other_options(["--locked".to_string()]);
     }
     let metadata = cmd.manifest_path(&manifest_path.path).exec();
-    match metadata.as_ref() {
-        Err(cargo_metadata::Error::CargoMetadata { stderr }) => {
-            if stderr.contains("remove the --locked flag") {
-                return Err(cargo_metadata::Error::CargoMetadata {
-                    stderr: stderr.clone(),
-                })
-                .wrap_err("Cargo.lock is absent");
-            }
+    if let Err(cargo_metadata::Error::CargoMetadata { stderr }) = metadata.as_ref() {
+        if stderr.contains("remove the --locked flag") {
+            return Err(cargo_metadata::Error::CargoMetadata {
+                stderr: stderr.clone(),
+            })
+            .wrap_err("Cargo.lock is absent");
         }
-        _ => {}
     }
     let metadata = metadata
         .wrap_err("Error invoking `cargo metadata`. Your `Cargo.toml` file is likely malformed")?;

--- a/cargo-near/src/types/metadata.rs
+++ b/cargo-near/src/types/metadata.rs
@@ -1,5 +1,5 @@
-use crate::types::manifest::CargoManifestPath;
 use crate::util;
+use crate::{commands::cargo_locked, types::manifest::CargoManifestPath};
 use camino::Utf8PathBuf;
 use cargo_metadata::{MetadataCommand, Package};
 use color_eyre::eyre::{ContextCompat, WrapErr};
@@ -51,6 +51,9 @@ fn get_cargo_metadata(
 ) -> color_eyre::eyre::Result<(cargo_metadata::Metadata, Package)> {
     log::info!("Fetching cargo metadata for {}", manifest_path.path);
     let mut cmd = MetadataCommand::new();
+    if cargo_locked() {
+        cmd.other_options(["--locked".to_string()]);
+    }
     let metadata = cmd
         .manifest_path(&manifest_path.path)
         .exec()

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -60,10 +60,10 @@ macro_rules! invoke_cargo_near {
 
         let cargo_near::CliOpts::Near(cli_args) = cargo_near::Opts::try_parse_from($cli_opts)?;
 
-        std::env::set_var(cargo_near::commands::CARGO_NEAR_UNLOCKED, "yes");
         match cli_args.cmd {
             Some(cargo_near::commands::CliNearCommand::Abi(cmd)) => {
                 let args = cargo_near::commands::abi_command::AbiCommand {
+                    no_locked: cmd.no_locked,
                     no_doc: cmd.no_doc,
                     compact_abi: cmd.compact_abi,
                     out_dir: cmd.out_dir,
@@ -91,8 +91,8 @@ macro_rules! invoke_cargo_near {
 #[macro_export]
 macro_rules! generate_abi_with {
     ($(Cargo: $cargo_path:expr;)? $(Vars: $cargo_vars:expr;)? $(Opts: $cli_opts:expr;)? Code: $($code:tt)*) => {{
-        let opts = "cargo near abi";
-        $(let opts = format!("cargo near abi {}", $cli_opts);)?;
+        let opts = "cargo near abi --no-locked";
+        $(let opts = format!("cargo near abi --no-locked {}", $cli_opts);)?;
         let result_dir = $crate::invoke_cargo_near! {
             $(Cargo: $cargo_path;)? $(Vars: $cargo_vars;)?
             Opts: &opts;
@@ -160,8 +160,8 @@ pub struct BuildResult {
 #[macro_export]
 macro_rules! build_with {
     ($(Cargo: $cargo_path:expr;)? $(Vars: $cargo_vars:expr;)? $(Opts: $cli_opts:expr;)? Code: $($code:tt)*) => {{
-        let opts = "cargo near build --no-docker";
-        $(let opts = format!("cargo near build --no-docker {}", $cli_opts);)?;
+        let opts = "cargo near build --no-docker --no-locked";
+        $(let opts = format!("cargo near build --no-docker --no-locked {}", $cli_opts);)?;
         let result_dir = $crate::invoke_cargo_near! {
             $(Cargo: $cargo_path;)? $(Vars: $cargo_vars;)?
             Opts: &opts;

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -60,6 +60,7 @@ macro_rules! invoke_cargo_near {
 
         let cargo_near::CliOpts::Near(cli_args) = cargo_near::Opts::try_parse_from($cli_opts)?;
 
+        std::env::set_var(cargo_near::commands::CARGO_NEAR_UNLOCKED, "yes");
         match cli_args.cmd {
             Some(cargo_near::commands::CliNearCommand::Abi(cmd)) => {
                 let args = cargo_near::commands::abi_command::AbiCommand {


### PR DESCRIPTION
tested on https://github.com/dj8yfo/sample_no_workspace/tree/set_metadata and https://github.com/dj8yfo/sample_no_workspace/tree/set_metadata_locked_remove_lock