### PR TITLE
chore: release v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3](https://github.com/near/cargo-near/compare/cargo-near-v0.6.2...cargo-near-v0.6.3) - 2024-07-03
+
+### Added
+- Support passing feature flags to `cargo` invocation ([#160](https://github.com/near/cargo-near/pull/160))
+
+### Fixed
+- Also pass feature flags to ABI build step ([#161](https://github.com/near/cargo-near/pull/161))
+
+### Other
+- Updates near-cli-rs and cargo-near in the new project template to latest versions ([#168](https://github.com/near/cargo-near/pull/168))
+- Updated dependencies to the latest versions ([#167](https://github.com/near/cargo-near/pull/167))
+- Updated "interactive_clap" to 0.2.10 (updated "flatten" parameter) ([#154](https://github.com/near/cargo-near/pull/154))
+
 ## [0.6.2](https://github.com/near/cargo-near/compare/cargo-near-v0.6.1...cargo-near-v0.6.2) - 2024-04-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "atty",
  "bs58 0.5.1",
@@ -855,7 +855,7 @@ version = "0.1.0"
 dependencies = [
  "borsh",
  "camino",
- "cargo-near 0.6.2",
+ "cargo-near 0.6.3",
  "color-eyre",
  "const_format",
  "function_name",

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.76.0"


### PR DESCRIPTION
## 🤖 New release
* `cargo-near`: 0.6.2 -> 0.6.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.3](https://github.com/near/cargo-near/compare/cargo-near-v0.6.2...cargo-near-v0.6.3) - 2024-07-03

### Added
- Support passing feature flags to `cargo` invocation ([#160](https://github.com/near/cargo-near/pull/160))

### Fixed
- Also pass feature flags to ABI build step ([#161](https://github.com/near/cargo-near/pull/161))

### Other
- Updates near-cli-rs and cargo-near in the new project template to latest versions ([#168](https://github.com/near/cargo-near/pull/168))
- Updated dependencies to the latest versions ([#167](https://github.com/near/cargo-near/pull/167))
- Updated "interactive_clap" to 0.2.10 (updated "flatten" parameter) ([#154](https://github.com/near/cargo-near/pull/154))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).