### PR TITLE
feat(source-scan): precise docker build wasm input/destination

### DIFF
--- a/cargo-near/src/commands/abi_command/abi.rs
+++ b/cargo-near/src/commands/abi_command/abi.rs
@@ -137,7 +137,7 @@ pub(crate) fn write_to_file(
 
     let out_path_abi = crate_metadata.target_directory.join(format!(
         "{}_abi.{}",
-        crate_metadata.root_package.name.replace('-', "_"),
+        crate_metadata.formatted_package_name(),
         abi_file_extension(format, compression)
     ));
     fs::write(&out_path_abi, near_abi_compressed)?;

--- a/cargo-near/src/commands/build_command/build.rs
+++ b/cargo-near/src/commands/build_command/build.rs
@@ -11,7 +11,7 @@ use crate::types::{manifest::CargoManifestPath, metadata::CrateMetadata};
 use crate::util;
 use crate::{commands::abi_command::abi, util::wasm32_target_libdir_exists};
 
-use super::ArtifactMessages;
+use super::{ArtifactMessages, INSIDE_DOCKER_ENV_KEY};
 
 const COMPILATION_TARGET: &str = "wasm32-unknown-unknown";
 
@@ -105,7 +105,11 @@ pub(super) fn run(
     wasm_artifact.path = util::copy(&wasm_artifact.path, &out_dir)?;
 
     // todo! if we embedded, check that the binary exports the __contract_abi symbol
-    util::print_success("Contract successfully built!");
+
+    util::print_success(&format!(
+        "Contract successfully built! (in CARGO_NEAR_BUILD_ENVIRONMENT={})",
+        std::env::var(INSIDE_DOCKER_ENV_KEY).unwrap_or("host".into())
+    ));
     let mut messages = ArtifactMessages::default();
     messages.push_binary(&wasm_artifact);
     if let Some(mut abi) = abi {

--- a/cargo-near/src/commands/build_command/docker/cloned_repo.rs
+++ b/cargo-near/src/commands/build_command/docker/cloned_repo.rs
@@ -65,11 +65,11 @@ impl ClonedRepo {
 
         let destination_dir = destination_crate_metadata.resolve_output_dir(cli_override)?;
 
-        search_and_copy(tmp_out_dir, self.tmp_crate_metadata, destination_dir)
+        copy(tmp_out_dir, self.tmp_crate_metadata, destination_dir)
     }
 }
 
-fn search_and_copy(
+fn copy(
     tmp_out_dir: Utf8PathBuf,
     tmp_crate_metadata: CrateMetadata,
     mut destination_dir: Utf8PathBuf,

--- a/cargo-near/src/commands/build_command/docker/cloned_repo.rs
+++ b/cargo-near/src/commands/build_command/docker/cloned_repo.rs
@@ -1,5 +1,3 @@
-use std::ffi::OsStr;
-
 use crate::{
     commands::build_command::{ArtifactMessages, BuildCommand},
     types::{
@@ -9,7 +7,7 @@ use crate::{
     util::{self, CompilationArtifact},
 };
 use camino::Utf8PathBuf;
-use color_eyre::{eyre::WrapErr, owo_colors::OwoColorize};
+use color_eyre::owo_colors::OwoColorize;
 
 pub(super) struct ClonedRepo {
     pub tmp_repo: git2::Repository,
@@ -67,12 +65,13 @@ impl ClonedRepo {
 
         let destination_dir = destination_crate_metadata.resolve_output_dir(cli_override)?;
 
-        search_and_copy(tmp_out_dir, destination_dir)
+        search_and_copy(tmp_out_dir, self.tmp_crate_metadata, destination_dir)
     }
 }
 
 fn search_and_copy(
     tmp_out_dir: Utf8PathBuf,
+    tmp_crate_metadata: CrateMetadata,
     mut destination_dir: Utf8PathBuf,
 ) -> color_eyre::eyre::Result<CompilationArtifact> {
     println!(
@@ -81,52 +80,34 @@ fn search_and_copy(
         tmp_out_dir
     );
 
-    let dir = tmp_out_dir
-        .read_dir()
-        .wrap_err_with(|| format!("No artifacts directory found: `{:?}`.", tmp_out_dir))?;
+    let filename = format!("{}.wasm", tmp_crate_metadata.formatted_package_name());
 
-    for entry in dir.flatten() {
-        if entry
-            .path()
-            .extension()
-            .unwrap_or(OsStr::new("not_wasm"))
-            .to_str()
-            .unwrap_or("not_wasm")
-            == "wasm"
-        {
-            let out_wasm_path = {
-                let filename = entry
-                    .path()
-                    .file_name()
-                    .unwrap()
-                    .to_string_lossy()
-                    .into_owned();
-                destination_dir.push(filename);
-                destination_dir
-            };
-            if out_wasm_path.exists() {
-                println!(" {}", "removing previous artifact".cyan());
-                std::fs::remove_file(&out_wasm_path)?;
-            }
-            std::fs::copy::<std::path::PathBuf, camino::Utf8PathBuf>(
-                entry.path(),
-                out_wasm_path.clone(),
-            )?;
-            let result = CompilationArtifact {
-                path: out_wasm_path,
-                fresh: true,
-                from_docker: true,
-            };
-            let mut messages = ArtifactMessages::default();
-            messages.push_binary(&result);
-            messages.pretty_print();
+    let in_wasm_path = tmp_out_dir.join(filename.clone());
 
-            return Ok(result);
-        }
+    if !in_wasm_path.exists() {
+        return Err(color_eyre::eyre::eyre!(
+            "Temporary build site result wasm file not found: `{:?}`.",
+            in_wasm_path
+        ));
     }
 
-    Err(color_eyre::eyre::eyre!(
-        "Wasm file not found in directory: `{:?}`.",
-        tmp_out_dir
-    ))
+    let out_wasm_path = {
+        destination_dir.push(filename);
+        destination_dir
+    };
+    if out_wasm_path.exists() {
+        println!(" {}", "removing previous artifact".cyan());
+        std::fs::remove_file(&out_wasm_path)?;
+    }
+    std::fs::copy::<camino::Utf8PathBuf, camino::Utf8PathBuf>(in_wasm_path, out_wasm_path.clone())?;
+    let result = CompilationArtifact {
+        path: out_wasm_path,
+        fresh: true,
+        from_docker: true,
+    };
+    let mut messages = ArtifactMessages::default();
+    messages.push_binary(&result);
+    messages.pretty_print();
+
+    return Ok(result);
 }

--- a/cargo-near/src/commands/build_command/docker/cloned_repo.rs
+++ b/cargo-near/src/commands/build_command/docker/cloned_repo.rs
@@ -109,5 +109,5 @@ fn copy(
     messages.push_binary(&result);
     messages.pretty_print();
 
-    return Ok(result);
+    Ok(result)
 }

--- a/cargo-near/src/commands/build_command/docker/cloned_repo.rs
+++ b/cargo-near/src/commands/build_command/docker/cloned_repo.rs
@@ -7,7 +7,7 @@ use crate::{
     util::{self, CompilationArtifact},
 };
 use camino::Utf8PathBuf;
-use color_eyre::owo_colors::OwoColorize;
+use colored::Colorize;
 
 pub(super) struct ClonedRepo {
     pub tmp_repo: git2::Repository,

--- a/cargo-near/src/types/metadata.rs
+++ b/cargo-near/src/types/metadata.rs
@@ -51,12 +51,14 @@ impl CrateMetadata {
         &self,
         cli_override: Option<crate::types::utf8_path_buf::Utf8PathBuf>,
     ) -> color_eyre::eyre::Result<Utf8PathBuf> {
-        if let Some(cli_override) = cli_override {
+        let result = if let Some(cli_override) = cli_override {
             let out_dir = Utf8PathBuf::from(cli_override);
-            return util::force_canonicalize_dir(&out_dir);
-        }
-
-        Ok(self.target_directory.clone())
+            util::force_canonicalize_dir(&out_dir)?
+        } else {
+            self.target_directory.clone()
+        };
+        log::debug!("resolved output directory: {}", result);
+        Ok(result)
     }
 
     pub fn formatted_package_name(&self) -> String {

--- a/cargo-near/src/types/metadata.rs
+++ b/cargo-near/src/types/metadata.rs
@@ -58,6 +58,10 @@ impl CrateMetadata {
 
         Ok(self.target_directory.clone())
     }
+
+    pub fn formatted_package_name(&self) -> String {
+        self.root_package.name.replace('-', "_")
+    }
 }
 
 /// Get the result of `cargo metadata`, together with the root package id.


### PR DESCRIPTION
this addresses https://github.com/near/cargo-near/pull/153#discussion_r1575955226

screenshot from https://github.com/dj8yfo/sample_no_workspace/tree/metadata_image_repo_build_cmd
![Screenshot_20240424_154301](https://github.com/near/cargo-near/assets/26653921/afe9a29c-6c78-494d-bb42-b71b1ff260f2)
