### PR TITLE
Support passing feature flags to `cargo` invocation

### DIFF
--- a/cargo-near/src/commands/build_command/build.rs
+++ b/cargo-near/src/commands/build_command/build.rs
@@ -86,7 +86,7 @@ pub fn run(args: super::BuildCommand) -> color_eyre::eyre::Result<util::Compilat
         cargo_args.push(&cargo_feature_flags);
     }
 
-    if args.no_default_features.unwrap_or(false) {
+    if args.no_default_features {
         cargo_args.push("--no-default-features");
     }
 

--- a/cargo-near/src/commands/build_command/build.rs
+++ b/cargo-near/src/commands/build_command/build.rs
@@ -40,6 +40,8 @@ pub fn run(args: super::BuildCommand) -> color_eyre::eyre::Result<util::Compilat
 
     let mut build_env = vec![("RUSTFLAGS", "-C link-arg=-s")];
     let mut cargo_args = vec!["--target", COMPILATION_TARGET];
+    let mut cargo_feature_flags = Vec::<&str>::new();
+
     if !args.no_release {
         cargo_args.push("--release");
     }
@@ -70,9 +72,24 @@ pub fn run(args: super::BuildCommand) -> color_eyre::eyre::Result<util::Compilat
     }
 
     if let (false, Some(abi_path)) = (args.no_embed_abi, &min_abi_path) {
-        cargo_args.extend(&["--features", "near-sdk/__abi-embed"]);
+        cargo_feature_flags.push("near-sdk/__abi-embed");
         build_env.push(("CARGO_NEAR_ABI_PATH", abi_path.as_str()));
     }
+
+    if let Some(features) = args.features.as_ref() {
+        cargo_feature_flags.push(features);
+    }
+
+    let cargo_feature_flags = cargo_feature_flags.join(",");
+    if !cargo_feature_flags.is_empty() {
+        cargo_args.push("--features");
+        cargo_args.push(&cargo_feature_flags);
+    }
+
+    if args.no_default_features.unwrap_or(false) {
+        cargo_args.push("--no-default-features");
+    }
+
     util::print_step("Building contract");
     let mut wasm_artifact = util::compile_project(
         &crate_metadata.manifest_path,

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -24,6 +24,14 @@ pub struct BuildCommand {
     #[interactive_clap(long)]
     #[interactive_clap(skip_interactive_input)]
     pub manifest_path: Option<crate::types::utf8_path_buf::Utf8PathBuf>,
+    /// Set compile-time feature flags.
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_interactive_input)]
+    pub features: Option<String>,
+    /// Disables default feature flags.
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_interactive_input)]
+    pub no_default_features: Option<bool>,
     /// Coloring: auto, always, never
     #[interactive_clap(long)]
     #[interactive_clap(value_enum)]
@@ -46,6 +54,8 @@ impl BuildCommandlContext {
             no_doc: scope.no_doc,
             out_dir: scope.out_dir.clone(),
             manifest_path: scope.manifest_path.clone(),
+            features: scope.features.clone(),
+            no_default_features: scope.no_default_features,
             color: scope.color.clone(),
         };
         self::build::run(args)?;

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -31,7 +31,7 @@ pub struct BuildCommand {
     /// Disables default feature flags.
     #[interactive_clap(long)]
     #[interactive_clap(skip_interactive_input)]
-    pub no_default_features: Option<bool>,
+    pub no_default_features: bool,
     /// Coloring: auto, always, never
     #[interactive_clap(long)]
     #[interactive_clap(value_enum)]

--- a/cargo-near/src/commands/deploy/mod.rs
+++ b/cargo-near/src/commands/deploy/mod.rs
@@ -67,6 +67,8 @@ impl interactive_clap::FromCli for Contract {
                     no_doc: cli_build_command_args.no_doc,
                     out_dir: cli_build_command_args.out_dir.clone(),
                     manifest_path: cli_build_command_args.manifest_path.clone(),
+                    features: cli_build_command_args.features.clone(),
+                    no_default_features: cli_build_command_args.no_default_features,
                     color: cli_build_command_args.color.clone(),
                 }
             } else {

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -79,6 +79,8 @@ macro_rules! invoke_cargo_near {
                     no_doc: cmd.no_doc,
                     out_dir: cmd.out_dir,
                     manifest_path: Some(cargo_path.into()),
+                    features: cmd.features,
+                    no_default_features: cmd.no_default_features,
                     color: cmd.color,
                 };
                 cargo_near::commands::build_command::build::run(args)?;


### PR DESCRIPTION
Adds support for passing feature flags to `cargo`.

## Motivation

Smart contract developers will sometimes use [feature flags](https://doc.rust-lang.org/cargo/reference/features.html#the-features-section) to enable/disable certain portions of code during compilation (e.g. enable certain debugging features for the testnet version which are not available in the production version).

## Usage

```txt
cargo near build --features feat1,feat2
```

```txt
cargo near build --no-default-features
```

## Implementation Notes

It does no validation of the input received to the flag, transparently forwarding it as an opaque string directly to `cargo`, after appending `near-sdk/__abi-embed` if necessary.