### PR TITLE
chore(source-scan): exports, needed for factory `build.rs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,6 +805,7 @@ dependencies = [
  "strum_macros",
  "symbolic-debuginfo",
  "tempfile",
+ "tmp_env",
  "unix_path",
  "url",
  "zstd",
@@ -5184,6 +5185,15 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tmp_env"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56eb9e5a28c3c4f0a6aa8ea70a8ad2d6c53e4bf364571ce78f57945b6766843"
+dependencies = [
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "tokio"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,6 +782,7 @@ dependencies = [
  "dunce",
  "env_logger",
  "git2",
+ "hex 0.4.3",
  "home",
  "inquire",
  "interactive-clap",

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -55,6 +55,7 @@ home = "0.5.9"
 pathdiff = { version = "0.2.1", features = ["camino"]}
 unix_path = "1.0.1"
 url = { version = "2.5.0", features = ["serde"]}
+tmp_env = "0.1.1"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.28.0", features = ["user", "process"] }

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -19,6 +19,7 @@ eula = false
 
 [dependencies]
 bs58 = "0.4"
+hex = "0.4.3"
 camino = "1.1.1"
 cargo_metadata = "0.18.1"
 clap = { version = "4.0.18", features = ["derive", "env"] }

--- a/cargo-near/src/build_extended.rs
+++ b/cargo-near/src/build_extended.rs
@@ -6,7 +6,7 @@ pub use build_script::BuildScriptOpts;
 #[derive(Debug, Clone)]
 pub struct OptsExtended<'a> {
     pub workdir: &'a str,
-    /// vector of key-value pairs of for temporary env overrides during build process
+    /// vector of key-value pairs of temporary env overrides during build process
     pub env: Vec<(&'a str, &'a str)>,
     pub build_opts: BuildOpts,
     pub build_script_opts: BuildScriptOpts<'a>,

--- a/cargo-near/src/build_extended.rs
+++ b/cargo-near/src/build_extended.rs
@@ -1,0 +1,141 @@
+use crate::{
+    commands::build_command::{BUILD_RS_ABI_STEP_HINT_ENV_KEY, NEP330_CONTRACT_PATH_ENV_KEY},
+    util::CompilationArtifact,
+    BuildOpts,
+};
+
+macro_rules! print_warn {
+    ($($tokens: tt)*) => {
+        println!("cargo:warning={}", format!($($tokens)*))
+    }
+}
+
+pub struct OptsExtended<'a> {
+    pub workdir: &'a str,
+    /// the desired value of `contract_path` from `BuildInfo`
+    /// <https://github.com/near/NEPs/blob/master/neps/nep-0330.md?plain=1#L155>
+    pub metadata_contract_path: &'a str,
+    pub build_opts: BuildOpts,
+    /// substitution export of `CARGO_TARGET_DIR`,
+    /// which is required to avoid deadlock <https://github.com/rust-lang/cargo/issues/8938>
+    /// should be a subfolder of `CARGO_TARGET_DIR` of package being built to work normally in
+    /// docker builds
+    ///
+    /// if this path is relative, then the base is `workdir` field
+    pub distinct_target_dir: &'a str,
+    /// skipping emitting output sub-build `*.wasm` may be helpful in `debug` profile, when
+    /// interacting with `rust-analyzer/flycheck`,
+    /// `cargo check`, `bacon` and other dev-tools, running `cargo test --workspace`, etc.
+    pub skipped_profiles: Vec<&'a str>,
+    /// path of stub file, where a placeholder empty `wasm` output is emitted to, when
+    /// build is skipped
+    pub stub_path: &'a str,
+    /// list of paths for [`cargo:rerun-if-changed=`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)
+    /// instruction
+    pub rerun_if_changed_list: Vec<&'a str>,
+}
+
+pub fn build(args: OptsExtended, result_env_key: String) -> Result<(), Box<dyn std::error::Error>> {
+    skip_or_compile(&args, &result_env_key)?;
+    print_warn!(
+        "Path to result artifact of build in `{}` is exported to `{}`",
+        &args.workdir,
+        result_env_key,
+    );
+    Ok(())
+}
+
+// TODO: replace `cargo:` -> `cargo::`, as the former is being deprecated since rust 1.77
+// or handle both with `rustc_version`
+fn skip_or_compile(
+    args: &OptsExtended,
+    result_env_key: &String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if skip(args) {
+        let stub_path = std::path::Path::new(&args.stub_path);
+        create_stub_file(stub_path)?;
+        let stub_path = stub_path
+            .canonicalize()
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        print_warn!("Sub-build empty artifact stub written to: `{}`", stub_path);
+        println!("cargo:rustc-env={}={}", result_env_key, stub_path);
+    } else {
+        let artifact = compile_near_artifact(args)?;
+        pretty_print(&artifact)?;
+        println!(
+            "cargo:rustc-env={}={}",
+            result_env_key,
+            artifact.path.into_string()
+        );
+        for path in args.rerun_if_changed_list.iter() {
+            println!("cargo:rerun-if-changed={}", path);
+        }
+    }
+    Ok(())
+}
+
+fn skip(args: &OptsExtended) -> bool {
+    let profile = std::env::var("PROFILE").unwrap_or("unknown".to_string());
+    print_warn!("`PROFILE` env set to `{}`", profile);
+
+    if args.skipped_profiles.contains(&profile.as_str()) {
+        print_warn!(
+            "No need to build factory's product contract during `{}` profile build",
+            profile
+        );
+        return true;
+    }
+    if std::env::var(BUILD_RS_ABI_STEP_HINT_ENV_KEY).is_ok() {
+        print_warn!("No need to build factory's product contract during ABI generation step");
+        return true;
+    }
+    false
+}
+
+/// `CARGO_NEAR_BUILD_COMMAND` and `CARGO_NEAR_CONTRACT_PATH`
+/// exports ensure, that contract, deployed from factory, produces the same metadata
+/// as one, deployed by `cargo near deploy` from `product-donation` subfolder,
+/// (in the context of docker builds)
+///
+/// `CARGO_TARGET_DIR` export is needed to avoid attempt to acquire same `target/<profile-path>/.cargo-lock`
+/// as the `cargo` process, which is running the build-script
+fn compile_near_artifact(
+    args: &OptsExtended,
+) -> Result<CompilationArtifact, Box<dyn std::error::Error>> {
+    let _tmp_workdir = tmp_env::set_current_dir(args.workdir)?;
+
+    let _tmp_contract_path_env =
+        tmp_env::set_var(NEP330_CONTRACT_PATH_ENV_KEY, args.metadata_contract_path);
+
+    let _tmp_cargo_target_env = tmp_env::set_var("CARGO_TARGET_DIR", args.distinct_target_dir);
+    let artifact = crate::build(args.build_opts.clone())?;
+
+    Ok(artifact)
+}
+
+fn create_stub_file(out_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
+    std::fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .create(true)
+        .open(out_path)?;
+    Ok(())
+}
+
+fn pretty_print(artifact: &CompilationArtifact) -> Result<(), Box<dyn std::error::Error>> {
+    let hash = artifact.compute_hash()?;
+
+    print_warn!("");
+    print_warn!("");
+    print_warn!(
+        "Sub-build artifact path: {}",
+        artifact.path.clone().into_string()
+    );
+    print_warn!("Sub-build artifact SHA-256 checksum hex: {}", hash.hex);
+    print_warn!("Sub-build artifact SHA-256 checksum bs58: {}", hash.base58);
+    print_warn!("");
+    print_warn!("");
+    Ok(())
+}

--- a/cargo-near/src/build_extended.rs
+++ b/cargo-near/src/build_extended.rs
@@ -1,153 +1,56 @@
-use crate::{
-    commands::build_command::{BUILD_RS_ABI_STEP_HINT_ENV_KEY, NEP330_CONTRACT_PATH_ENV_KEY},
-    BuildArtifact, BuildOpts,
-};
+use crate::{BuildArtifact, BuildOpts};
 
-macro_rules! print_warn {
-    ($($tokens: tt)*) => {
-        println!("cargo:warning={}", format!($($tokens)*))
-    }
-}
+mod build_script;
+pub use build_script::BuildScriptOpts;
 
+#[derive(Debug, Clone)]
 pub struct OptsExtended<'a> {
     pub workdir: &'a str,
-    /// the desired value of `contract_path` from `BuildInfo`
-    /// <https://github.com/near/NEPs/blob/master/neps/nep-0330.md?plain=1#L155>
-    pub metadata_contract_path: &'a str,
+    /// vector of key-value pairs of for temporary env overrides during build process
+    pub env: Vec<(&'a str, &'a str)>,
     pub build_opts: BuildOpts,
-    /// substitution export of `CARGO_TARGET_DIR`,
-    /// which is required to avoid deadlock <https://github.com/rust-lang/cargo/issues/8938>
-    /// should be a subfolder of `CARGO_TARGET_DIR` of package being built to work normally in
-    /// docker builds
-    ///
-    /// if this path is relative, then the base is `workdir` field
-    pub distinct_target_dir: &'a str,
-    /// skipping emitting output sub-build `*.wasm` may be helpful in `debug` profile, when
-    /// interacting with `rust-analyzer/flycheck`,
-    /// `cargo check`, `bacon` and other dev-tools, running `cargo test --workspace`, etc.
-    pub skipped_profiles: Vec<&'a str>,
-    /// path of stub file, where a placeholder empty `wasm` output is emitted to, when
-    /// build is skipped
-    pub stub_path: &'a str,
-    /// list of paths for [`cargo:rerun-if-changed=`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)
-    /// instruction
-    pub rerun_if_changed_list: Vec<&'a str>,
+    pub build_script_opts: BuildScriptOpts<'a>,
 }
 
-pub fn build(
-    args: OptsExtended,
-    result_env_key: String,
-) -> Result<BuildArtifact, Box<dyn std::error::Error>> {
-    let (artifact, skipped) = skip_or_compile(&args, &result_env_key)?;
-    print_warn!(
-        "Path to result artifact of build in `{}` is exported to `{}`",
-        &args.workdir,
-        result_env_key,
-    );
+pub fn build(args: OptsExtended) -> Result<BuildArtifact, Box<dyn std::error::Error>> {
+    let (artifact, skipped) = args.skip_or_compile()?;
+
+    args.build_script_opts
+        .post_build(skipped, &artifact, args.workdir)?;
     Ok(artifact)
 }
 
-// TODO: replace `cargo:` -> `cargo::`, as the former is being deprecated since rust 1.77
-// or handle both with `rustc_version`
-fn skip_or_compile(
-    args: &OptsExtended,
-    result_env_key: &String,
-) -> Result<(BuildArtifact, bool), Box<dyn std::error::Error>> {
-    let result = if skip(args) {
-        let stub_path = std::path::Path::new(&args.stub_path);
-        create_stub_file(stub_path)?;
-
-        let artifact = {
-            let stub_path = camino::Utf8PathBuf::from_path_buf(stub_path.to_path_buf())
-                .map_err(|err| format!("`{}` isn't a valid UTF-8 path", err.to_string_lossy()))?;
-            BuildArtifact {
-                path: stub_path,
-                fresh: true,
-                from_docker: false,
-            }
+impl<'a> OptsExtended<'a> {
+    pub fn skip_or_compile(&self) -> Result<(BuildArtifact, bool), Box<dyn std::error::Error>> {
+        let _tmp_workdir = tmp_env::set_current_dir(self.workdir)?;
+        let result = if self.build_script_opts.should_skip() {
+            let artifact = self.build_script_opts.create_empty_stub()?;
+            (artifact, true)
+        } else {
+            let artifact = self.compile_near_artifact()?;
+            (artifact, false)
         };
-        let stub_path = stub_path
-            .canonicalize()
-            .unwrap()
-            .to_string_lossy()
-            .to_string();
-        print_warn!("Sub-build empty artifact stub written to: `{}`", stub_path);
-        println!("cargo:rustc-env={}={}", result_env_key, stub_path);
-        (artifact, true)
-    } else {
-        let artifact = compile_near_artifact(args)?;
-        pretty_print(&artifact)?;
-        println!(
-            "cargo:rustc-env={}={}",
-            result_env_key,
-            artifact.path.clone().into_string()
-        );
-        for path in args.rerun_if_changed_list.iter() {
-            println!("cargo:rerun-if-changed={}", path);
+        Ok(result)
+    }
+
+    /// `CARGO_TARGET_DIR` export is needed to avoid attempt to acquire same `target/<profile-path>/.cargo-lock`
+    /// as the `cargo` process, which is running the build-script
+    pub fn compile_near_artifact(&self) -> Result<BuildArtifact, Box<dyn std::error::Error>> {
+        let mut tmp_envs = vec![];
+        for (env_key, value) in self.env.iter() {
+            let tmp_env = tmp_env::set_var(env_key, value);
+            tmp_envs.push(tmp_env);
         }
-        (artifact, false)
-    };
-    Ok(result)
-}
 
-fn skip(args: &OptsExtended) -> bool {
-    let profile = std::env::var("PROFILE").unwrap_or("unknown".to_string());
-    print_warn!("`PROFILE` env set to `{}`", profile);
+        let artifact = if let Some(distinct_target_dir) = self.build_script_opts.distinct_target_dir
+        {
+            let _tmp_cargo_target_env = tmp_env::set_var("CARGO_TARGET_DIR", distinct_target_dir);
 
-    if args.skipped_profiles.contains(&profile.as_str()) {
-        print_warn!(
-            "No need to build factory's product contract during `{}` profile build",
-            profile
-        );
-        return true;
+            crate::build(self.build_opts.clone())?
+        } else {
+            crate::build(self.build_opts.clone())?
+        };
+
+        Ok(artifact)
     }
-    if std::env::var(BUILD_RS_ABI_STEP_HINT_ENV_KEY).is_ok() {
-        print_warn!("No need to build factory's product contract during ABI generation step");
-        return true;
-    }
-    false
-}
-
-/// `CARGO_NEAR_BUILD_COMMAND` and `CARGO_NEAR_CONTRACT_PATH`
-/// exports ensure, that contract, deployed from factory, produces the same metadata
-/// as one, deployed by `cargo near deploy` from `product-donation` subfolder,
-/// (in the context of docker builds)
-///
-/// `CARGO_TARGET_DIR` export is needed to avoid attempt to acquire same `target/<profile-path>/.cargo-lock`
-/// as the `cargo` process, which is running the build-script
-fn compile_near_artifact(args: &OptsExtended) -> Result<BuildArtifact, Box<dyn std::error::Error>> {
-    let _tmp_workdir = tmp_env::set_current_dir(args.workdir)?;
-
-    let _tmp_contract_path_env =
-        tmp_env::set_var(NEP330_CONTRACT_PATH_ENV_KEY, args.metadata_contract_path);
-
-    let _tmp_cargo_target_env = tmp_env::set_var("CARGO_TARGET_DIR", args.distinct_target_dir);
-    let artifact = crate::build(args.build_opts.clone())?;
-
-    Ok(artifact)
-}
-
-fn create_stub_file(out_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
-    std::fs::OpenOptions::new()
-        .write(true)
-        .truncate(true)
-        .create(true)
-        .open(out_path)?;
-    Ok(())
-}
-
-fn pretty_print(artifact: &BuildArtifact) -> Result<(), Box<dyn std::error::Error>> {
-    let hash = artifact.compute_hash()?;
-
-    print_warn!("");
-    print_warn!("");
-    print_warn!(
-        "Sub-build artifact path: {}",
-        artifact.path.clone().into_string()
-    );
-    print_warn!("Sub-build artifact SHA-256 checksum hex: {}", hash.hex);
-    print_warn!("Sub-build artifact SHA-256 checksum bs58: {}", hash.base58);
-    print_warn!("");
-    print_warn!("");
-    Ok(())
 }

--- a/cargo-near/src/build_extended/build_script.rs
+++ b/cargo-near/src/build_extended/build_script.rs
@@ -10,7 +10,7 @@ macro_rules! print_warn {
 
 #[derive(Debug, Clone)]
 pub struct BuildScriptOpts<'a> {
-    /// key to export result path to with [`cargo:rustc-env=`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-env)
+    /// environment variable name to export result `*.wasm` path to with [`cargo:rustc-env=`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-env)
     /// instruction
     pub result_env_key: Option<&'a str>,
     /// list of paths for [`cargo:rerun-if-changed=`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)
@@ -18,23 +18,23 @@ pub struct BuildScriptOpts<'a> {
     ///
     /// if relative, it's relative to path of crate, where build.rs is compiled
     pub rerun_if_changed_list: Vec<&'a str>,
-    /// vector of key-value pairs of env variable name and its value,
-    /// when compiling should be skipped on env variable's value match;
+    /// vector of key-value pairs of environment variable name and its value,
+    /// when compilation should be skipped on a variable's value match;
     /// e.g.
-    /// skipping emitting output sub-build `*.wasm` may be helpful when `PROFILE` is equal to `debug`
+    /// skipping emitting output `*.wasm` may be helpful when `PROFILE` is equal to `debug`
     /// for using  `rust-analyzer/flycheck`, `cargo check`, `bacon` and other dev-tools
     pub build_skipped_when_env_is: Vec<(&'a str, &'a str)>,
     /// path of stub file, where a placeholder empty `wasm` output is emitted to, when
-    /// build is skipped due to match in `skipped_env_values`
+    /// build is skipped due to match in [`Self::build_skipped_when_env_is`]
     ///
-    /// if this path is relative, then the base is `workdir` field of `OptsExtended`
+    /// if this path is relative, then the base is [`crate::BuildOptsExtended::workdir`]
     pub stub_path: Option<&'a str>,
-    /// substitution export of `CARGO_TARGET_DIR`,
-    /// which is required to avoid deadlock <https://github.com/rust-lang/cargo/issues/8938>
-    /// should be a subfolder of `CARGO_TARGET_DIR` of package being built to work normally in
-    /// docker builds
+    /// substitution export of [`CARGO_TARGET_DIR`](https://doc.rust-lang.org/cargo/reference/environment-variables.html),
+    /// which is required to avoid deadlock <https://github.com/rust-lang/cargo/issues/8938>;
+    /// should best be a subfolder of [`CARGO_TARGET_DIR`](https://doc.rust-lang.org/cargo/reference/environment-variables.html)
+    /// of crate being built to work normally in docker builds
     ///
-    /// if this path is relative, then the base is `workdir` field of `OptsExtended`
+    /// if this path is relative, then the base is [`crate::BuildOptsExtended::workdir`]
     pub distinct_target_dir: Option<&'a str>,
 }
 

--- a/cargo-near/src/build_extended/build_script.rs
+++ b/cargo-near/src/build_extended/build_script.rs
@@ -1,0 +1,138 @@
+//! TODO: replace `cargo:` -> `cargo::`, as the former is being deprecated since rust 1.77
+//! or handle both with `rustc_version`
+use crate::BuildArtifact;
+
+macro_rules! print_warn {
+    ($($tokens: tt)*) => {
+        println!("cargo:warning={}", format!($($tokens)*))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct BuildScriptOpts<'a> {
+    /// key to export result path to with [`cargo:rustc-env=`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-env)
+    /// instruction
+    pub result_env_key: Option<&'a str>,
+    /// list of paths for [`cargo:rerun-if-changed=`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)
+    /// instruction
+    ///
+    /// if relative, it's relative to path of crate, where build.rs is compiled
+    pub rerun_if_changed_list: Vec<&'a str>,
+    /// vector of key-value pairs of env variable name and its value,
+    /// when compiling should be skipped on env variable's value match;
+    /// e.g.
+    /// skipping emitting output sub-build `*.wasm` may be helpful when `PROFILE` is equal to `debug`
+    /// for using  `rust-analyzer/flycheck`, `cargo check`, `bacon` and other dev-tools
+    pub build_skipped_when_env_is: Vec<(&'a str, &'a str)>,
+    /// path of stub file, where a placeholder empty `wasm` output is emitted to, when
+    /// build is skipped due to match in `skipped_env_values`
+    ///
+    /// if this path is relative, then the base is `workdir` field of `OptsExtended`
+    pub stub_path: Option<&'a str>,
+    /// substitution export of `CARGO_TARGET_DIR`,
+    /// which is required to avoid deadlock <https://github.com/rust-lang/cargo/issues/8938>
+    /// should be a subfolder of `CARGO_TARGET_DIR` of package being built to work normally in
+    /// docker builds
+    ///
+    /// if this path is relative, then the base is `workdir` field of `OptsExtended`
+    pub distinct_target_dir: Option<&'a str>,
+}
+
+impl<'a> BuildScriptOpts<'a> {
+    pub fn should_skip(&self) -> bool {
+        let mut return_bool = false;
+        for (env_key, value_to_skip) in self.build_skipped_when_env_is.iter() {
+            if let Ok(actual_value) = std::env::var(env_key) {
+                if actual_value == *value_to_skip {
+                    return_bool = true;
+                    print_warn!(
+                        "`{}` env set to `{}`, build was configured to skip on this value",
+                        env_key,
+                        actual_value
+                    );
+                }
+            }
+        }
+
+        return_bool
+    }
+    pub fn create_empty_stub(&self) -> Result<BuildArtifact, Box<dyn std::error::Error>> {
+        if self.stub_path.is_none() {
+            return Err(
+                "build must be skipped, but `BuildScriptOpts.stub_path` wasn't configured"
+                    .to_string(),
+            )?;
+        }
+        let stub_path = std::path::Path::new(self.stub_path.as_ref().unwrap());
+        create_stub_file(stub_path)?;
+        let stub_path = stub_path.canonicalize()?;
+
+        let artifact = {
+            let stub_path = camino::Utf8PathBuf::from_path_buf(stub_path)
+                .map_err(|err| format!("`{}` isn't a valid UTF-8 path", err.to_string_lossy()))?;
+            BuildArtifact {
+                path: stub_path,
+                fresh: true,
+                from_docker: false,
+            }
+        };
+        Ok(artifact)
+    }
+
+    pub fn post_build(
+        &self,
+        skipped: bool,
+        artifact: &BuildArtifact,
+        workdir: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        if let Some(ref result_env_key) = self.result_env_key {
+            pretty_print(skipped, artifact)?;
+            println!(
+                "cargo:rustc-env={}={}",
+                result_env_key,
+                artifact.path.clone().into_string()
+            );
+            print_warn!(
+                "Path to result artifact of build in `{}` is exported to `{}`",
+                workdir,
+                result_env_key,
+            );
+        }
+        for path in self.rerun_if_changed_list.iter() {
+            println!("cargo:rerun-if-changed={}", path);
+        }
+        Ok(())
+    }
+}
+
+fn create_stub_file(out_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
+    std::fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .create(true)
+        .open(out_path)?;
+    Ok(())
+}
+
+fn pretty_print(skipped: bool, artifact: &BuildArtifact) -> Result<(), Box<dyn std::error::Error>> {
+    if skipped {
+        print_warn!(
+            "Build empty artifact stub-file written to: `{}`",
+            artifact.path.clone().into_string()
+        );
+        return Ok(());
+    }
+    let hash = artifact.compute_hash()?;
+
+    print_warn!("");
+    print_warn!("");
+    print_warn!(
+        "Build artifact path: {}",
+        artifact.path.clone().into_string()
+    );
+    print_warn!("Sub-build artifact SHA-256 checksum hex: {}", hash.hex);
+    print_warn!("Sub-build artifact SHA-256 checksum bs58: {}", hash.base58);
+    print_warn!("");
+    print_warn!("");
+    Ok(())
+}

--- a/cargo-near/src/commands/abi_command/abi.rs
+++ b/cargo-near/src/commands/abi_command/abi.rs
@@ -6,7 +6,7 @@ use color_eyre::eyre::ContextCompat;
 use colored::Colorize;
 use near_abi::AbiRoot;
 
-use crate::commands::build_command::ABI_GENERATION_STEP_ENV_KEY;
+use crate::commands::build_command::BUILD_RS_ABI_STEP_HINT_ENV_KEY;
 use crate::common::ColorPreference;
 use crate::types::{manifest::CargoManifestPath, metadata::CrateMetadata};
 use crate::util;
@@ -94,7 +94,7 @@ pub(crate) fn generate_abi(
             ("CARGO_PROFILE_DEV_OPT_LEVEL", "0"),
             ("CARGO_PROFILE_DEV_DEBUG", "0"),
             ("CARGO_PROFILE_DEV_LTO", "off"),
-            (ABI_GENERATION_STEP_ENV_KEY, "true"),
+            (BUILD_RS_ABI_STEP_HINT_ENV_KEY, "true"),
         ],
         util::dylib_extension(),
         hide_warnings,

--- a/cargo-near/src/commands/abi_command/abi.rs
+++ b/cargo-near/src/commands/abi_command/abi.rs
@@ -6,6 +6,7 @@ use color_eyre::eyre::ContextCompat;
 use colored::Colorize;
 use near_abi::AbiRoot;
 
+use crate::commands::build_command::ABI_GENERATION_STEP_ENV_KEY;
 use crate::common::ColorPreference;
 use crate::types::{manifest::CargoManifestPath, metadata::CrateMetadata};
 use crate::util;
@@ -93,6 +94,7 @@ pub(crate) fn generate_abi(
             ("CARGO_PROFILE_DEV_OPT_LEVEL", "0"),
             ("CARGO_PROFILE_DEV_DEBUG", "0"),
             ("CARGO_PROFILE_DEV_LTO", "off"),
+            (ABI_GENERATION_STEP_ENV_KEY, "true"),
         ],
         util::dylib_extension(),
         hide_warnings,

--- a/cargo-near/src/commands/build_command/build.rs
+++ b/cargo-near/src/commands/build_command/build.rs
@@ -152,12 +152,15 @@ pub(super) fn run(
 }
 
 fn export_nep_330_build_command() {
-    let mut cmd: Vec<String> = vec!["cargo".into(), "near".into()];
-    cmd.extend(std::env::args().skip(2));
+    // only attempt to set by self, if not set extenally
+    if std::env::var(BUILD_CMD_ENV_KEY).is_err() {
+        let mut cmd: Vec<String> = vec!["cargo".into(), "near".into()];
+        cmd.extend(std::env::args().skip(2));
 
-    let cmd = cmd.join(" ");
+        let cmd = cmd.join(" ");
 
-    std::env::set_var(BUILD_CMD_ENV_KEY, cmd.clone());
+        std::env::set_var(BUILD_CMD_ENV_KEY, cmd.clone());
+    }
 }
 
 fn print_nep_330_env() {

--- a/cargo-near/src/commands/build_command/build.rs
+++ b/cargo-near/src/commands/build_command/build.rs
@@ -239,7 +239,9 @@ fn export_nep_330_build_command(args: &Opts) {
     );
     let env_value = match std::env::args().next() {
         // this is for cli context, being called from `cargo-near` bin
-        Some(cli_arg_0) if cli_arg_0.contains("cargo-near") => {
+        Some(cli_arg_0)
+            if cli_arg_0.ends_with("cargo-near") || cli_arg_0.ends_with("cargo-near.exe") =>
+        {
             let mut cmd: Vec<String> = vec!["cargo".into()];
             // skipping `cargo-near`
             cmd.extend(std::env::args().skip(1));

--- a/cargo-near/src/commands/build_command/build.rs
+++ b/cargo-near/src/commands/build_command/build.rs
@@ -129,7 +129,7 @@ pub fn run(args: super::BuildCommand) -> color_eyre::eyre::Result<util::Compilat
     let mut messages = ArtifactMessages::default();
     messages.push_binary(&wasm_artifact)?;
     if let Some(mut abi) = abi {
-        abi.metadata.wasm_hash = Some(wasm_artifact.compute_hash()?);
+        abi.metadata.wasm_hash = Some(wasm_artifact.compute_hash()?.base58);
 
         let AbiResult { path } =
             abi::write_to_file(&abi, &crate_metadata, AbiFormat::Json, AbiCompression::NoOp)?;

--- a/cargo-near/src/commands/build_command/build.rs
+++ b/cargo-near/src/commands/build_command/build.rs
@@ -16,12 +16,100 @@ use super::{ArtifactMessages, NEP330_INSIDE_DOCKER_ENV_KEY};
 
 const COMPILATION_TARGET: &str = "wasm32-unknown-unknown";
 
-pub fn run(args: super::BuildCommand) -> color_eyre::eyre::Result<util::CompilationArtifact> {
+// These `Opts` have no `no_docker` flag, i.e., they are only indented for build
+// inside of a specific environment
+#[derive(Debug, Default, Clone)]
+pub struct Opts {
+    /// disable implicit `--locked` flag for all `cargo` commands, enabled by default
+    pub no_locked: bool,
+    /// Build contract in debug mode, without optimizations and bigger is size
+    pub no_release: bool,
+    /// Do not generate ABI for the contract
+    pub no_abi: bool,
+    /// Do not embed the ABI in the contract binary
+    pub no_embed_abi: bool,
+    /// Do not include rustdocs in the embedded ABI
+    pub no_doc: bool,
+    /// Copy final artifacts to this directory
+    pub out_dir: Option<crate::types::utf8_path_buf::Utf8PathBuf>,
+    /// Path to the `Cargo.toml` of the contract to build
+    pub manifest_path: Option<crate::types::utf8_path_buf::Utf8PathBuf>,
+    /// Set compile-time feature flags.
+    pub features: Option<String>,
+    /// Disables default feature flags.
+    pub no_default_features: bool,
+    /// Coloring: auto, always, never
+    pub color: Option<crate::common::ColorPreference>,
+}
+
+impl Opts {
+    /// this is just 1-to-1 mapping of each struct's field to a cli flag
+    /// in order of fields, as specified in struct's definition.
+    /// `Default` implementation corresponds to plain `cargo near build` command without any args
+    fn get_cli_build_command(&self) -> String {
+        let mut cargo_args = vec![];
+        if self.no_locked {
+            cargo_args.push("--no-locked");
+        }
+        // `no_docker` field isn't present
+        if self.no_release {
+            cargo_args.push("--no-release");
+        }
+        if self.no_abi {
+            cargo_args.push("--no-abi");
+        }
+        if self.no_embed_abi {
+            cargo_args.push("--no-embed-abi");
+        }
+        if self.no_doc {
+            cargo_args.push("--no-doc");
+        }
+        if let Some(ref out_dir) = self.out_dir {
+            cargo_args.extend_from_slice(&["--out-dir", out_dir.as_str()]);
+        }
+        if let Some(ref manifest_path) = self.manifest_path {
+            cargo_args.extend_from_slice(&["--manifest-path", manifest_path.as_str()]);
+        }
+        if let Some(ref features) = self.features {
+            cargo_args.extend(&["--features", features]);
+        }
+        if self.no_default_features {
+            cargo_args.push("--no-default-features");
+        }
+        let color;
+        if let Some(ref color_arg) = self.color {
+            color = color_arg.to_string();
+            cargo_args.extend(&["--color", &color]);
+        }
+        let mut cargo_cmd_list = vec!["cargo", "near", "build"];
+        cargo_cmd_list.extend(&cargo_args);
+        cargo_cmd_list.join(" ")
+    }
+}
+
+impl From<super::BuildCommand> for Opts {
+    fn from(value: super::BuildCommand) -> Self {
+        Self {
+            no_locked: value.no_locked,
+            no_release: value.no_release,
+            no_abi: value.no_abi,
+            no_embed_abi: value.no_embed_abi,
+            no_doc: value.no_doc,
+            features: value.features,
+            no_default_features: value.no_default_features,
+            out_dir: value.out_dir,
+            manifest_path: value.manifest_path,
+            color: value.color,
+        }
+    }
+}
+
+pub fn run(args: Opts) -> color_eyre::eyre::Result<util::CompilationArtifact> {
+    export_nep_330_build_command(&args);
+    print_nep_330_env();
+
     let color = args.color.unwrap_or(ColorPreference::Auto);
     color.apply();
-
-    export_nep_330_build_command();
-    print_nep_330_env();
 
     util::handle_step("Checking the host environment...", || {
         if !wasm32_target_libdir_exists() {
@@ -144,16 +232,28 @@ pub fn run(args: super::BuildCommand) -> color_eyre::eyre::Result<util::Compilat
     Ok(wasm_artifact)
 }
 
-fn export_nep_330_build_command() {
-    // only attempt to set by self, if not set extenally
-    if std::env::var(NEP330_BUILD_CMD_ENV_KEY).is_err() {
-        let mut cmd: Vec<String> = vec!["cargo".into(), "near".into()];
-        cmd.extend(std::env::args().skip(2));
-
-        let cmd = cmd.join(" ");
-
-        std::env::set_var(NEP330_BUILD_CMD_ENV_KEY, cmd.clone());
-    }
+fn export_nep_330_build_command(args: &Opts) {
+    log::debug!(
+        "compute `CARGO_NEAR_BUILD_COMMAND`,  current executable: {:?}",
+        std::env::args().collect::<Vec<_>>()
+    );
+    let env_value = match std::env::args().next() {
+        // this is for cli context, being called from `cargo-near` bin
+        Some(cli_arg_0) if cli_arg_0.contains("cargo-near") => {
+            let mut cmd: Vec<String> = vec!["cargo".into()];
+            // skipping `cargo-near`
+            cmd.extend(std::env::args().skip(1));
+            cmd.join(" ")
+        }
+        // this is for lib context, when build method is called from code
+        // where `cargo-near` is an unlikely name to be chosen for executable
+        _ => {
+            // NOTE: order of output of cli flags shouldn't be too important, as the version of
+            // `cargo-near` used as lib will be fixed in `Cargo.lock`
+            args.get_cli_build_command()
+        }
+    };
+    std::env::set_var(NEP330_BUILD_CMD_ENV_KEY, env_value);
 }
 
 fn print_nep_330_env() {

--- a/cargo-near/src/commands/build_command/build.rs
+++ b/cargo-near/src/commands/build_command/build.rs
@@ -4,7 +4,7 @@ use near_abi::BuildInfo;
 
 use crate::commands::abi_command::abi::{AbiCompression, AbiFormat, AbiResult};
 use crate::commands::build_command::{
-    BUILD_CMD_ENV_KEY, CONTRACT_PATH_ENV_KEY, SOURCE_CODE_SNAPSHOT_ENV_KEY,
+    NEP330_BUILD_CMD_ENV_KEY, NEP330_CONTRACT_PATH_ENV_KEY, NEP330_SOURCE_CODE_SNAPSHOT_ENV_KEY,
 };
 use crate::common::ColorPreference;
 use crate::types::manifest::MANIFEST_FILE_NAME;
@@ -12,13 +12,11 @@ use crate::types::{manifest::CargoManifestPath, metadata::CrateMetadata};
 use crate::util;
 use crate::{commands::abi_command::abi, util::wasm32_target_libdir_exists};
 
-use super::{ArtifactMessages, INSIDE_DOCKER_ENV_KEY};
+use super::{ArtifactMessages, NEP330_INSIDE_DOCKER_ENV_KEY};
 
 const COMPILATION_TARGET: &str = "wasm32-unknown-unknown";
 
-pub(super) fn run(
-    args: super::BuildCommand,
-) -> color_eyre::eyre::Result<util::CompilationArtifact> {
+pub fn run(args: super::BuildCommand) -> color_eyre::eyre::Result<util::CompilationArtifact> {
     let color = args.color.unwrap_or(ColorPreference::Auto);
     color.apply();
 
@@ -126,7 +124,7 @@ pub(super) fn run(
 
     util::print_success(&format!(
         "Contract successfully built! (in CARGO_NEAR_BUILD_ENVIRONMENT={})",
-        std::env::var(INSIDE_DOCKER_ENV_KEY).unwrap_or("host".into())
+        std::env::var(NEP330_INSIDE_DOCKER_ENV_KEY).unwrap_or("host".into())
     ));
     let mut messages = ArtifactMessages::default();
     messages.push_binary(&wasm_artifact)?;
@@ -148,23 +146,23 @@ pub(super) fn run(
 
 fn export_nep_330_build_command() {
     // only attempt to set by self, if not set extenally
-    if std::env::var(BUILD_CMD_ENV_KEY).is_err() {
+    if std::env::var(NEP330_BUILD_CMD_ENV_KEY).is_err() {
         let mut cmd: Vec<String> = vec!["cargo".into(), "near".into()];
         cmd.extend(std::env::args().skip(2));
 
         let cmd = cmd.join(" ");
 
-        std::env::set_var(BUILD_CMD_ENV_KEY, cmd.clone());
+        std::env::set_var(NEP330_BUILD_CMD_ENV_KEY, cmd.clone());
     }
 }
 
 fn print_nep_330_env() {
     log::info!("Variables, relevant for reproducible builds:");
     for key in [
-        INSIDE_DOCKER_ENV_KEY,
-        BUILD_CMD_ENV_KEY,
-        CONTRACT_PATH_ENV_KEY,
-        SOURCE_CODE_SNAPSHOT_ENV_KEY,
+        NEP330_INSIDE_DOCKER_ENV_KEY,
+        NEP330_BUILD_CMD_ENV_KEY,
+        NEP330_CONTRACT_PATH_ENV_KEY,
+        NEP330_SOURCE_CODE_SNAPSHOT_ENV_KEY,
     ] {
         let value = std::env::var(key)
             .map(|val| format!("'{}'", val))

--- a/cargo-near/src/commands/build_command/docker.rs
+++ b/cargo-near/src/commands/build_command/docker.rs
@@ -3,8 +3,12 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use crate::{commands::build_command::NEP330_CONTRACT_PATH_ENV_KEY, types::source_id, util};
 use crate::{commands::build_command::NEP330_INSIDE_DOCKER_ENV_KEY, common::ColorPreference};
+use crate::{
+    commands::build_command::{NEP330_CONTRACT_PATH_ENV_KEY, SERVER_DISABLE_INTERACTIVE},
+    types::source_id,
+    util,
+};
 
 use color_eyre::eyre::ContextCompat;
 
@@ -126,7 +130,6 @@ impl super::BuildCommand {
                 let mut docker_args = vec![
                     "-u",
                     &uid_gid,
-                    "-it",
                     "--name",
                     &docker_container_name,
                     "--volume",
@@ -135,6 +138,10 @@ impl super::BuildCommand {
                     "--workdir",
                     &container_paths.crate_path,
                 ];
+
+                if std::env::var(SERVER_DISABLE_INTERACTIVE).is_err() {
+                    docker_args.push("-it");
+                }
 
                 docker_args.extend(env_args.iter().map(|string| string.as_str()));
 

--- a/cargo-near/src/commands/build_command/docker.rs
+++ b/cargo-near/src/commands/build_command/docker.rs
@@ -3,8 +3,8 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use crate::{commands::build_command::CONTRACT_PATH_ENV_KEY, types::source_id, util};
-use crate::{commands::build_command::INSIDE_DOCKER_ENV_KEY, common::ColorPreference};
+use crate::{commands::build_command::NEP330_CONTRACT_PATH_ENV_KEY, types::source_id, util};
+use crate::{commands::build_command::NEP330_INSIDE_DOCKER_ENV_KEY, common::ColorPreference};
 
 use color_eyre::eyre::ContextCompat;
 
@@ -12,7 +12,7 @@ use colored::Colorize;
 #[cfg(unix)]
 use nix::unistd::{getgid, getuid};
 
-use super::{BuildContext, REPO_LINK_HINT_ENV_KEY, SOURCE_CODE_SNAPSHOT_ENV_KEY};
+use super::{BuildContext, NEP330_SOURCE_CODE_SNAPSHOT_ENV_KEY, REPO_LINK_HINT_ENV_KEY};
 
 mod cloned_repo;
 mod crate_in_repo;
@@ -366,18 +366,21 @@ impl Nep330BuildInfo {
     fn docker_args(&self) -> Vec<String> {
         let mut result = vec![
             "--env".to_string(),
-            format!("{}={}", INSIDE_DOCKER_ENV_KEY, self.build_environment),
+            format!(
+                "{}={}",
+                NEP330_INSIDE_DOCKER_ENV_KEY, self.build_environment
+            ),
             "--env".to_string(),
             format!(
                 "{}={}",
-                SOURCE_CODE_SNAPSHOT_ENV_KEY,
+                NEP330_SOURCE_CODE_SNAPSHOT_ENV_KEY,
                 self.source_code_snapshot.as_url()
             ),
         ];
 
         result.extend(vec![
             "--env".to_string(),
-            format!("{}={}", CONTRACT_PATH_ENV_KEY, self.contract_path),
+            format!("{}={}", NEP330_CONTRACT_PATH_ENV_KEY, self.contract_path),
         ]);
 
         result

--- a/cargo-near/src/commands/build_command/docker/cloned_repo.rs
+++ b/cargo-near/src/commands/build_command/docker/cloned_repo.rs
@@ -109,7 +109,7 @@ fn copy(
         from_docker: true,
     };
     let mut messages = ArtifactMessages::default();
-    messages.push_binary(&result);
+    messages.push_binary(&result)?;
     messages.pretty_print();
 
     Ok(result)

--- a/cargo-near/src/commands/build_command/docker/git_checks/pushed_to_remote.rs
+++ b/cargo-near/src/commands/build_command/docker/git_checks/pushed_to_remote.rs
@@ -1,3 +1,4 @@
+use color_eyre::eyre::WrapErr;
 use colored::Colorize;
 
 const BETWEEN_ATTEMPTS_SLEEP: std::time::Duration = std::time::Duration::from_millis(100);
@@ -16,7 +17,8 @@ pub fn check(git_url: &url::Url, commit_id: git2::Oid) -> color_eyre::Result<()>
         match repo {
             Ok(repo) => {
                 println!(" {}", "Checking if HEAD is present...".green());
-                repo.find_commit(commit_id)?;
+                repo.find_commit(commit_id)
+                    .wrap_err("commit wasn't found in remote repo")?;
                 println!(
                     " {} {} in `{}` -> `{}`",
                     "commit was found in repo:".green(),

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -70,6 +70,7 @@ pub enum BuildContext {
     Deploy,
 }
 impl BuildCommand {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         no_locked: bool,
         no_release: bool,

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -17,6 +17,7 @@ pub const CONTRACT_PATH_ENV_KEY: &str = "CARGO_NEAR_CONTRACT_PATH";
 pub const SOURCE_CODE_SNAPSHOT_ENV_KEY: &str = "CARGO_NEAR_SOURCE_CODE_SNAPSHOT";
 // ====================== End section =======================================
 pub const REPO_LINK_HINT_ENV_KEY: &str = "CARGO_NEAR_REPO_LINK_HINT";
+pub const ABI_GENERATION_STEP_ENV_KEY: &str = "CARGO_NEAR_ABI_GENERATION";
 
 #[derive(Debug, Default, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(input_context = near_cli_rs::GlobalContext)]

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -18,6 +18,7 @@ pub const NEP330_SOURCE_CODE_SNAPSHOT_ENV_KEY: &str = "CARGO_NEAR_SOURCE_CODE_SN
 // ====================== End section =======================================
 pub const REPO_LINK_HINT_ENV_KEY: &str = "CARGO_NEAR_REPO_LINK_HINT";
 pub const BUILD_RS_ABI_STEP_HINT_ENV_KEY: &str = "CARGO_NEAR_ABI_GENERATION";
+pub const SERVER_DISABLE_INTERACTIVE: &str = "CARGO_NEAR_SERVER_BUILD_DISABLE_INTERACTIVE";
 
 #[derive(Debug, Default, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(input_context = near_cli_rs::GlobalContext)]

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -7,17 +7,17 @@ use crate::{
     util::{self, CompilationArtifact},
 };
 
-mod build;
+pub(crate) mod build;
 mod docker;
 
 // ====================== NEP-330 Build Details Extension section ===========
-pub const INSIDE_DOCKER_ENV_KEY: &str = "CARGO_NEAR_BUILD_ENVIRONMENT";
-pub const BUILD_CMD_ENV_KEY: &str = "CARGO_NEAR_BUILD_COMMAND";
-pub const CONTRACT_PATH_ENV_KEY: &str = "CARGO_NEAR_CONTRACT_PATH";
-pub const SOURCE_CODE_SNAPSHOT_ENV_KEY: &str = "CARGO_NEAR_SOURCE_CODE_SNAPSHOT";
+pub const NEP330_INSIDE_DOCKER_ENV_KEY: &str = "CARGO_NEAR_BUILD_ENVIRONMENT";
+pub const NEP330_BUILD_CMD_ENV_KEY: &str = "CARGO_NEAR_BUILD_COMMAND";
+pub const NEP330_CONTRACT_PATH_ENV_KEY: &str = "CARGO_NEAR_CONTRACT_PATH";
+pub const NEP330_SOURCE_CODE_SNAPSHOT_ENV_KEY: &str = "CARGO_NEAR_SOURCE_CODE_SNAPSHOT";
 // ====================== End section =======================================
 pub const REPO_LINK_HINT_ENV_KEY: &str = "CARGO_NEAR_REPO_LINK_HINT";
-pub const ABI_GENERATION_STEP_ENV_KEY: &str = "CARGO_NEAR_ABI_GENERATION";
+pub const BUILD_RS_ABI_STEP_HINT_ENV_KEY: &str = "CARGO_NEAR_ABI_GENERATION";
 
 #[derive(Debug, Default, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(input_context = near_cli_rs::GlobalContext)]
@@ -70,6 +70,32 @@ pub enum BuildContext {
     Deploy,
 }
 impl BuildCommand {
+    pub fn new(
+        no_locked: bool,
+        no_release: bool,
+        no_abi: bool,
+        no_embed_abi: bool,
+        no_doc: bool,
+        out_dir: Option<crate::types::utf8_path_buf::Utf8PathBuf>,
+        manifest_path: Option<crate::types::utf8_path_buf::Utf8PathBuf>,
+        features: Option<String>,
+        no_default_features: bool,
+        color: Option<crate::common::ColorPreference>,
+    ) -> Self {
+        Self {
+            no_locked,
+            no_docker: true,
+            no_release,
+            no_abi,
+            no_embed_abi,
+            no_doc,
+            features,
+            no_default_features,
+            out_dir,
+            manifest_path,
+            color,
+        }
+    }
     pub fn contract_path(&self) -> color_eyre::eyre::Result<camino::Utf8PathBuf> {
         let contract_path: camino::Utf8PathBuf = if let Some(manifest_path) = &self.manifest_path {
             let manifest_path = CargoManifestPath::try_from(manifest_path.deref().clone())?;
@@ -89,7 +115,7 @@ impl BuildCommand {
         }
     }
     pub fn no_docker(&self) -> bool {
-        std::env::var(INSIDE_DOCKER_ENV_KEY).is_ok() || self.no_docker
+        std::env::var(NEP330_INSIDE_DOCKER_ENV_KEY).is_ok() || self.no_docker
     }
 }
 

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -134,8 +134,11 @@ impl<'a> ArtifactMessages<'a> {
             "Binary",
             wasm_artifact.path.to_string().bright_yellow().bold(),
         ));
+        let checksum = wasm_artifact.compute_hash()?;
         self.messages
-            .push(("Hashsum", wasm_artifact.compute_hash()?.green().dimmed()));
+            .push(("SHA-256 checksum hex ", checksum.hex.green().dimmed()));
+        self.messages
+            .push(("SHA-256 checksum bs58", checksum.base58.green().dimmed()));
         Ok(())
     }
     pub fn push_free(&mut self, msg: (&'a str, ColoredString)) {

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -98,11 +98,17 @@ pub struct ArtifactMessages<'a> {
 }
 
 impl<'a> ArtifactMessages<'a> {
-    pub fn push_binary(&mut self, wasm_artifact: &CompilationArtifact) {
+    pub fn push_binary(
+        &mut self,
+        wasm_artifact: &CompilationArtifact,
+    ) -> color_eyre::eyre::Result<()> {
         self.messages.push((
             "Binary",
             wasm_artifact.path.to_string().bright_yellow().bold(),
         ));
+        self.messages
+            .push(("Hashsum", wasm_artifact.compute_hash()?.green().dimmed()));
+        Ok(())
     }
     pub fn push_free(&mut self, msg: (&'a str, ColoredString)) {
         self.messages.push(msg);

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -70,33 +70,6 @@ pub enum BuildContext {
     Deploy,
 }
 impl BuildCommand {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        no_locked: bool,
-        no_release: bool,
-        no_abi: bool,
-        no_embed_abi: bool,
-        no_doc: bool,
-        out_dir: Option<crate::types::utf8_path_buf::Utf8PathBuf>,
-        manifest_path: Option<crate::types::utf8_path_buf::Utf8PathBuf>,
-        features: Option<String>,
-        no_default_features: bool,
-        color: Option<crate::common::ColorPreference>,
-    ) -> Self {
-        Self {
-            no_locked,
-            no_docker: true,
-            no_release,
-            no_abi,
-            no_embed_abi,
-            no_doc,
-            features,
-            no_default_features,
-            out_dir,
-            manifest_path,
-            color,
-        }
-    }
     pub fn contract_path(&self) -> color_eyre::eyre::Result<camino::Utf8PathBuf> {
         let contract_path: camino::Utf8PathBuf = if let Some(manifest_path) = &self.manifest_path {
             let manifest_path = CargoManifestPath::try_from(manifest_path.deref().clone())?;
@@ -110,7 +83,7 @@ impl BuildCommand {
     }
     pub fn run(self, context: BuildContext) -> color_eyre::eyre::Result<util::CompilationArtifact> {
         if self.no_docker() {
-            self::build::run(self)
+            self::build::run(self.into())
         } else {
             self.docker_run(context)
         }

--- a/cargo-near/src/lib.rs
+++ b/cargo-near/src/lib.rs
@@ -12,6 +12,7 @@ pub mod util;
 pub use build_extended::{build as build_extended, OptsExtended as BuildOptsExtended};
 pub use commands::build_command::build::run as build;
 pub use commands::build_command::build::Opts as BuildOpts;
+pub use util::CompilationArtifact as BuildArtifact;
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(context = near_cli_rs::GlobalContext)]

--- a/cargo-near/src/lib.rs
+++ b/cargo-near/src/lib.rs
@@ -3,13 +3,15 @@
 pub use near_cli_rs::CliResult;
 use strum::{EnumDiscriminants, EnumIter, EnumMessage};
 
+pub mod build_extended;
 pub mod commands;
 pub mod common;
 pub mod types;
 pub mod util;
 
-pub use commands::build_command::build::run as run_build;
-pub use commands::build_command::BuildCommand as BuildArgs;
+pub use build_extended::{build as build_extended, OptsExtended as BuildOptsExtended};
+pub use commands::build_command::build::run as build;
+pub use commands::build_command::build::Opts as BuildOpts;
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(context = near_cli_rs::GlobalContext)]

--- a/cargo-near/src/lib.rs
+++ b/cargo-near/src/lib.rs
@@ -4,9 +4,12 @@ pub use near_cli_rs::CliResult;
 use strum::{EnumDiscriminants, EnumIter, EnumMessage};
 
 pub mod commands;
-mod common;
+pub mod common;
 pub mod types;
 pub mod util;
+
+pub use commands::build_command::build::run as run_build;
+pub use commands::build_command::BuildCommand as BuildArgs;
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(context = near_cli_rs::GlobalContext)]

--- a/cargo-near/src/lib.rs
+++ b/cargo-near/src/lib.rs
@@ -9,7 +9,9 @@ pub mod common;
 pub mod types;
 pub mod util;
 
-pub use build_extended::{build as build_extended, OptsExtended as BuildOptsExtended};
+pub use build_extended::{
+    build as build_extended, BuildScriptOpts, OptsExtended as BuildOptsExtended,
+};
 pub use commands::build_command::build::run as build;
 pub use commands::build_command::build::Opts as BuildOpts;
 pub use util::CompilationArtifact as BuildArtifact;

--- a/cargo-near/src/lib.rs
+++ b/cargo-near/src/lib.rs
@@ -6,7 +6,7 @@ use strum::{EnumDiscriminants, EnumIter, EnumMessage};
 pub mod commands;
 mod common;
 pub mod types;
-mod util;
+pub mod util;
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(context = near_cli_rs::GlobalContext)]

--- a/cargo-near/src/main.rs
+++ b/cargo-near/src/main.rs
@@ -1,4 +1,4 @@
-use cargo_near::commands::build_command::INSIDE_DOCKER_ENV_KEY;
+use cargo_near::commands::build_command::NEP330_INSIDE_DOCKER_ENV_KEY;
 use colored::Colorize;
 use interactive_clap::ToCliArgs;
 use log::Level;
@@ -11,7 +11,7 @@ use cargo_near::Cmd;
 fn main() -> CliResult {
     let mut builder = env_logger::Builder::from_env(env_logger::Env::default());
 
-    let environment = if std::env::var(INSIDE_DOCKER_ENV_KEY).is_ok() {
+    let environment = if std::env::var(NEP330_INSIDE_DOCKER_ENV_KEY).is_ok() {
         "container".cyan()
     } else {
         "host".purple()

--- a/cargo-near/src/util/mod.rs
+++ b/cargo-near/src/util/mod.rs
@@ -167,13 +167,20 @@ pub struct CompilationArtifact {
     pub fresh: bool,
     pub from_docker: bool,
 }
+pub struct SHA256Checksum {
+    pub hex: String,
+    pub base58: String,
+}
 
 impl CompilationArtifact {
-    pub fn compute_hash(&self) -> color_eyre::eyre::Result<String> {
+    pub fn compute_hash(&self) -> color_eyre::eyre::Result<SHA256Checksum> {
         let mut hasher = Sha256::new();
         hasher.update(std::fs::read(&self.path)?);
         let hash = hasher.finalize();
-        Ok(bs58::encode(hash).into_string())
+        Ok(SHA256Checksum {
+            hex: hex::encode(hash),
+            base58: bs58::encode(hash).into_string(),
+        })
     }
 }
 

--- a/cargo-near/src/util/mod.rs
+++ b/cargo-near/src/util/mod.rs
@@ -15,6 +15,7 @@ use log::{error, info};
 
 use crate::common::ColorPreference;
 use crate::types::manifest::CargoManifestPath;
+use sha2::{Digest, Sha256};
 
 mod print;
 pub(crate) use print::*;
@@ -165,6 +166,15 @@ pub struct CompilationArtifact {
     pub path: Utf8PathBuf,
     pub fresh: bool,
     pub from_docker: bool,
+}
+
+impl CompilationArtifact {
+    pub fn compute_hash(&self) -> color_eyre::eyre::Result<String> {
+        let mut hasher = Sha256::new();
+        hasher.update(std::fs::read(&self.path)?);
+        let hash = hasher.finalize();
+        Ok(bs58::encode(hash).into_string())
+    }
 }
 
 /// Builds the cargo project with manifest located at `manifest_path` and returns the path to the generated artifact.


### PR DESCRIPTION
tested this against modified near-examples [repo/tree/main](https://github.com/dj8yfo/factory-rust/tree/main): 
Obtained 3 contracts by deploying :
1st & 2nd:
```bash
cd factory
cargo near deploy repro-fct-11.testnet
near contract call-function as-transaction repro-fct-11.testnet create_factory_subaccount_and_deploy json-args '{ "name": "donation-product", "beneficiary": "donatello2.testnet"}' prepaid-gas '300.0 Tgas' attached-deposit '1.7 NEAR' sign-as donatello2.testnet network-config testnet sign-with-keychain send
```
=> 
`repro-fct-11.testnet` and `donation-product.repro-fct-11.testnet` 
3rd:
```bash
cd product-donation
cargo near deploy repro-fct-product-11.testnet
```
=> 
`repro-fct-product-11.testnet`

2nd and 3rd have identical code hashes and contract source metadata:

```bash
 repro-fct-11.testnet - 7eFN2zuvy1DLSQoYV5ksMjzaoXpJw6ppS7f3rtRiF4uz  
 donation-product.repro-fct-11.testnet - CvRsj8e7xSyumyLeKsQjn8r19TAd6WV5ohUw3DzKoM3A 
 repro-fct-product-11.testnet - CvRsj8e7xSyumyLeKsQjn8r19TAd6WV5ohUw3DzKoM3A  
```
section https://github.com/dj8yfo/factory-rust/blob/main/product-donation/Cargo.toml#L10-L14 was needed to deploy
`product-donation` subfolder as a standalone contract (to check that metadata is same while `cargo near verify` is not implemented) 

---
![Screenshot_20240522_175228](https://github.com/near/cargo-near/assets/26653921/26a5b5a8-4ae4-44f9-98a0-bdac2318712b)
![Screenshot_20240522_175329](https://github.com/near/cargo-near/assets/26653921/40ffb4ce-5216-4a9a-add4-cb3e94706db9)

