### PR TITLE
chore(source-scan): factory `build.rs` exports + cli mini-parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,6 +805,7 @@ dependencies = [
  "strum_macros",
  "symbolic-debuginfo",
  "tempfile",
+ "tmp_env",
  "unix_path",
  "url",
  "zstd",
@@ -5184,6 +5185,15 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tmp_env"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56eb9e5a28c3c4f0a6aa8ea70a8ad2d6c53e4bf364571ce78f57945b6766843"
+dependencies = [
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "tokio"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,6 +782,7 @@ dependencies = [
  "dunce",
  "env_logger",
  "git2",
+ "hex 0.4.3",
  "home",
  "inquire",
  "interactive-clap",

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -55,6 +55,7 @@ home = "0.5.9"
 pathdiff = { version = "0.2.1", features = ["camino"]}
 unix_path = "1.0.1"
 url = { version = "2.5.0", features = ["serde"]}
+tmp_env = "0.1.1"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.28.0", features = ["user", "process"] }

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -19,6 +19,7 @@ eula = false
 
 [dependencies]
 bs58 = "0.4"
+hex = "0.4.3"
 camino = "1.1.1"
 cargo_metadata = "0.18.1"
 clap = { version = "4.0.18", features = ["derive", "env"] }

--- a/cargo-near/src/build_rs.rs
+++ b/cargo-near/src/build_rs.rs
@@ -1,0 +1,150 @@
+use crate::{
+    commands::build_command::{
+        BUILD_RS_ABI_STEP_HINT_ENV_KEY, NEP330_BUILD_CMD_ENV_KEY, NEP330_CONTRACT_PATH_ENV_KEY,
+    },
+    util::CompilationArtifact,
+    BuildOpts,
+};
+
+macro_rules! print_warn {
+    ($($tokens: tt)*) => {
+        println!("cargo:warning={}", format!($($tokens)*))
+    }
+}
+
+pub struct SubBuildOpts<'a> {
+    pub workdir: &'a str,
+    /// the desired value of `contract_path` from `BuildInfo`
+    /// <https://github.com/near/NEPs/blob/master/neps/nep-0330.md?plain=1#L155>
+    pub metadata_contract_path: &'a str,
+    /// the first of element in tuple `cargo near build...` command must correspond to 2nd element,
+    /// the first element is used as an override for contract metadata field
+    /// <https://github.com/near/NEPs/blob/master/neps/nep-0330.md?plain=1#L156>
+    pub build_command: (String, BuildOpts),
+    /// substitution export of `CARGO_TARGET_DIR`,
+    /// which is required to avoid deadlock <https://github.com/rust-lang/cargo/issues/8938>
+    /// should be a subfolder of `CARGO_TARGET_DIR` of package being built to work normally in
+    /// docker builds
+    ///
+    /// if this path is relative, then the base is `workdir` field
+    pub distinct_target_dir: &'a str,
+    /// skipping emitting output sub-build `*.wasm` may be helpful in `debug` profile, when
+    /// interacting with `rust-analyzer/flycheck`,
+    /// `cargo check`, `bacon` and other dev-tools, running `cargo test --workspace`, etc.
+    pub skipped_profiles: Vec<&'a str>,
+    /// path of stub file, where a placeholder empty `wasm` output is emitted to, when
+    /// build is skipped
+    pub stub_path: &'a str,
+    /// list of paths for [`cargo:rerun-if-changed=`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)
+    /// instruction
+    pub rerun_if_changed_list: Vec<&'a str>,
+}
+
+pub fn process_sub_build(
+    args: SubBuildOpts,
+    result_env_key: String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    skip_or_compile(&args, &result_env_key)?;
+    print_warn!(
+        "Path to result artifact of build in `{}` is exported to `{}`",
+        &args.workdir,
+        result_env_key,
+    );
+    Ok(())
+}
+
+// TODO: replace `cargo:` -> `cargo::`, as the former is being deprecated since rust 1.77
+// or handle both with `rustc_version`
+fn skip_or_compile(
+    args: &SubBuildOpts,
+    result_env_key: &String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if skip(args) {
+        let stub_path = std::path::Path::new(&args.stub_path);
+        create_stub_file(stub_path)?;
+        let stub_path = stub_path
+            .canonicalize()
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        print_warn!("Sub-build empty artifact stub written to: `{}`", stub_path);
+        println!("cargo:rustc-env={}={}", result_env_key, stub_path);
+    } else {
+        let artifact = compile_near_artifact(args)?;
+        pretty_print(&artifact)?;
+        println!(
+            "cargo:rustc-env={}={}",
+            result_env_key,
+            artifact.path.into_string()
+        );
+        for path in args.rerun_if_changed_list.iter() {
+            println!("cargo:rerun-if-changed={}", path);
+        }
+    }
+    Ok(())
+}
+
+fn skip(args: &SubBuildOpts) -> bool {
+    let profile = std::env::var("PROFILE").unwrap_or("unknown".to_string());
+    print_warn!("`PROFILE` env set to `{}`", profile);
+
+    if args.skipped_profiles.contains(&profile.as_str()) {
+        print_warn!(
+            "No need to build factory's product contract during `{}` profile build",
+            profile
+        );
+        return true;
+    }
+    if std::env::var(BUILD_RS_ABI_STEP_HINT_ENV_KEY).is_ok() {
+        print_warn!("No need to build factory's product contract during ABI generation step");
+        return true;
+    }
+    false
+}
+
+/// `CARGO_NEAR_BUILD_COMMAND` and `CARGO_NEAR_CONTRACT_PATH`
+/// exports ensure, that contract, deployed from factory, produces the same metadata
+/// as one, deployed by `cargo near deploy` from `product-donation` subfolder,
+/// (in the context of docker builds)
+///
+/// `CARGO_TARGET_DIR` export is needed to avoid attempt to acquire same `target/<profile-path>/.cargo-lock`
+/// as the `cargo` process, which is running the build-script
+fn compile_near_artifact(
+    args: &SubBuildOpts,
+) -> Result<CompilationArtifact, Box<dyn std::error::Error>> {
+    let _tmp_workdir = tmp_env::set_current_dir(args.workdir)?;
+
+    let _tmp_contract_path_env =
+        tmp_env::set_var(NEP330_CONTRACT_PATH_ENV_KEY, args.metadata_contract_path);
+    let _tmp_build_cmd_env = tmp_env::set_var(NEP330_BUILD_CMD_ENV_KEY, &args.build_command.0);
+
+    let _tmp_cargo_target_env = tmp_env::set_var("CARGO_TARGET_DIR", args.distinct_target_dir);
+    let artifact = crate::run_build(args.build_command.1.clone())?;
+
+    Ok(artifact)
+}
+
+fn create_stub_file(out_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
+    std::fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .create(true)
+        .open(out_path)?;
+    Ok(())
+}
+
+fn pretty_print(artifact: &CompilationArtifact) -> Result<(), Box<dyn std::error::Error>> {
+    let hash = artifact.compute_hash()?;
+
+    print_warn!("");
+    print_warn!("");
+    print_warn!(
+        "Sub-build artifact path: {}",
+        artifact.path.clone().into_string()
+    );
+    print_warn!("Sub-build artifact SHA-256 checksum hex: {}", hash.hex);
+    print_warn!("Sub-build artifact SHA-256 checksum bs58: {}", hash.base58);
+    print_warn!("");
+    print_warn!("");
+    Ok(())
+}

--- a/cargo-near/src/build_rs.rs
+++ b/cargo-near/src/build_rs.rs
@@ -17,10 +17,9 @@ pub struct SubBuildOpts<'a> {
     /// the desired value of `contract_path` from `BuildInfo`
     /// <https://github.com/near/NEPs/blob/master/neps/nep-0330.md?plain=1#L155>
     pub metadata_contract_path: &'a str,
-    /// the first of element in tuple `cargo near build...` command must correspond to 2nd element,
-    /// the first element is used as an override for contract metadata field
+    /// command used as an override for contract metadata field
     /// <https://github.com/near/NEPs/blob/master/neps/nep-0330.md?plain=1#L156>
-    pub build_command: (String, BuildOpts),
+    pub build_command: String,
     /// substitution export of `CARGO_TARGET_DIR`,
     /// which is required to avoid deadlock <https://github.com/rust-lang/cargo/issues/8938>
     /// should be a subfolder of `CARGO_TARGET_DIR` of package being built to work normally in
@@ -116,10 +115,12 @@ fn compile_near_artifact(
 
     let _tmp_contract_path_env =
         tmp_env::set_var(NEP330_CONTRACT_PATH_ENV_KEY, args.metadata_contract_path);
-    let _tmp_build_cmd_env = tmp_env::set_var(NEP330_BUILD_CMD_ENV_KEY, &args.build_command.0);
+    let _tmp_build_cmd_env = tmp_env::set_var(NEP330_BUILD_CMD_ENV_KEY, &args.build_command);
 
     let _tmp_cargo_target_env = tmp_env::set_var("CARGO_TARGET_DIR", args.distinct_target_dir);
-    let artifact = crate::run_build(args.build_command.1.clone())?;
+
+    let build_opts = BuildOpts::from_cli_command(&args.build_command)?;
+    let artifact = crate::run_build(build_opts)?;
 
     Ok(artifact)
 }

--- a/cargo-near/src/commands/abi_command/abi.rs
+++ b/cargo-near/src/commands/abi_command/abi.rs
@@ -6,7 +6,7 @@ use color_eyre::eyre::ContextCompat;
 use colored::Colorize;
 use near_abi::AbiRoot;
 
-use crate::commands::build_command::ABI_GENERATION_STEP_ENV_KEY;
+use crate::commands::build_command::BUILD_RS_ABI_STEP_HINT_ENV_KEY;
 use crate::common::ColorPreference;
 use crate::types::{manifest::CargoManifestPath, metadata::CrateMetadata};
 use crate::util;
@@ -94,7 +94,7 @@ pub(crate) fn generate_abi(
             ("CARGO_PROFILE_DEV_OPT_LEVEL", "0"),
             ("CARGO_PROFILE_DEV_DEBUG", "0"),
             ("CARGO_PROFILE_DEV_LTO", "off"),
-            (ABI_GENERATION_STEP_ENV_KEY, "true"),
+            (BUILD_RS_ABI_STEP_HINT_ENV_KEY, "true"),
         ],
         util::dylib_extension(),
         hide_warnings,

--- a/cargo-near/src/commands/abi_command/abi.rs
+++ b/cargo-near/src/commands/abi_command/abi.rs
@@ -6,6 +6,7 @@ use color_eyre::eyre::ContextCompat;
 use colored::Colorize;
 use near_abi::AbiRoot;
 
+use crate::commands::build_command::ABI_GENERATION_STEP_ENV_KEY;
 use crate::common::ColorPreference;
 use crate::types::{manifest::CargoManifestPath, metadata::CrateMetadata};
 use crate::util;
@@ -93,6 +94,7 @@ pub(crate) fn generate_abi(
             ("CARGO_PROFILE_DEV_OPT_LEVEL", "0"),
             ("CARGO_PROFILE_DEV_DEBUG", "0"),
             ("CARGO_PROFILE_DEV_LTO", "off"),
+            (ABI_GENERATION_STEP_ENV_KEY, "true"),
         ],
         util::dylib_extension(),
         hide_warnings,

--- a/cargo-near/src/commands/build_command/build.rs
+++ b/cargo-near/src/commands/build_command/build.rs
@@ -152,12 +152,15 @@ pub(super) fn run(
 }
 
 fn export_nep_330_build_command() {
-    let mut cmd: Vec<String> = vec!["cargo".into(), "near".into()];
-    cmd.extend(std::env::args().skip(2));
+    // only attempt to set by self, if not set extenally
+    if std::env::var(BUILD_CMD_ENV_KEY).is_err() {
+        let mut cmd: Vec<String> = vec!["cargo".into(), "near".into()];
+        cmd.extend(std::env::args().skip(2));
 
-    let cmd = cmd.join(" ");
+        let cmd = cmd.join(" ");
 
-    std::env::set_var(BUILD_CMD_ENV_KEY, cmd.clone());
+        std::env::set_var(BUILD_CMD_ENV_KEY, cmd.clone());
+    }
 }
 
 fn print_nep_330_env() {

--- a/cargo-near/src/commands/build_command/build.rs
+++ b/cargo-near/src/commands/build_command/build.rs
@@ -129,7 +129,7 @@ pub fn run(args: super::BuildCommand) -> color_eyre::eyre::Result<util::Compilat
     let mut messages = ArtifactMessages::default();
     messages.push_binary(&wasm_artifact)?;
     if let Some(mut abi) = abi {
-        abi.metadata.wasm_hash = Some(wasm_artifact.compute_hash()?);
+        abi.metadata.wasm_hash = Some(wasm_artifact.compute_hash()?.base58);
 
         let AbiResult { path } =
             abi::write_to_file(&abi, &crate_metadata, AbiFormat::Json, AbiCompression::NoOp)?;

--- a/cargo-near/src/commands/build_command/build.rs
+++ b/cargo-near/src/commands/build_command/build.rs
@@ -4,7 +4,7 @@ use near_abi::BuildInfo;
 
 use crate::commands::abi_command::abi::{AbiCompression, AbiFormat, AbiResult};
 use crate::commands::build_command::{
-    BUILD_CMD_ENV_KEY, CONTRACT_PATH_ENV_KEY, SOURCE_CODE_SNAPSHOT_ENV_KEY,
+    NEP330_BUILD_CMD_ENV_KEY, NEP330_CONTRACT_PATH_ENV_KEY, NEP330_SOURCE_CODE_SNAPSHOT_ENV_KEY,
 };
 use crate::common::ColorPreference;
 use crate::types::manifest::MANIFEST_FILE_NAME;
@@ -12,13 +12,11 @@ use crate::types::{manifest::CargoManifestPath, metadata::CrateMetadata};
 use crate::util;
 use crate::{commands::abi_command::abi, util::wasm32_target_libdir_exists};
 
-use super::{ArtifactMessages, INSIDE_DOCKER_ENV_KEY};
+use super::{ArtifactMessages, NEP330_INSIDE_DOCKER_ENV_KEY};
 
 const COMPILATION_TARGET: &str = "wasm32-unknown-unknown";
 
-pub(super) fn run(
-    args: super::BuildCommand,
-) -> color_eyre::eyre::Result<util::CompilationArtifact> {
+pub fn run(args: super::BuildCommand) -> color_eyre::eyre::Result<util::CompilationArtifact> {
     let color = args.color.unwrap_or(ColorPreference::Auto);
     color.apply();
 
@@ -126,7 +124,7 @@ pub(super) fn run(
 
     util::print_success(&format!(
         "Contract successfully built! (in CARGO_NEAR_BUILD_ENVIRONMENT={})",
-        std::env::var(INSIDE_DOCKER_ENV_KEY).unwrap_or("host".into())
+        std::env::var(NEP330_INSIDE_DOCKER_ENV_KEY).unwrap_or("host".into())
     ));
     let mut messages = ArtifactMessages::default();
     messages.push_binary(&wasm_artifact)?;
@@ -148,23 +146,23 @@ pub(super) fn run(
 
 fn export_nep_330_build_command() {
     // only attempt to set by self, if not set extenally
-    if std::env::var(BUILD_CMD_ENV_KEY).is_err() {
+    if std::env::var(NEP330_BUILD_CMD_ENV_KEY).is_err() {
         let mut cmd: Vec<String> = vec!["cargo".into(), "near".into()];
         cmd.extend(std::env::args().skip(2));
 
         let cmd = cmd.join(" ");
 
-        std::env::set_var(BUILD_CMD_ENV_KEY, cmd.clone());
+        std::env::set_var(NEP330_BUILD_CMD_ENV_KEY, cmd.clone());
     }
 }
 
 fn print_nep_330_env() {
     log::info!("Variables, relevant for reproducible builds:");
     for key in [
-        INSIDE_DOCKER_ENV_KEY,
-        BUILD_CMD_ENV_KEY,
-        CONTRACT_PATH_ENV_KEY,
-        SOURCE_CODE_SNAPSHOT_ENV_KEY,
+        NEP330_INSIDE_DOCKER_ENV_KEY,
+        NEP330_BUILD_CMD_ENV_KEY,
+        NEP330_CONTRACT_PATH_ENV_KEY,
+        NEP330_SOURCE_CODE_SNAPSHOT_ENV_KEY,
     ] {
         let value = std::env::var(key)
             .map(|val| format!("'{}'", val))

--- a/cargo-near/src/commands/build_command/docker.rs
+++ b/cargo-near/src/commands/build_command/docker.rs
@@ -3,8 +3,8 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use crate::{commands::build_command::CONTRACT_PATH_ENV_KEY, types::source_id, util};
-use crate::{commands::build_command::INSIDE_DOCKER_ENV_KEY, common::ColorPreference};
+use crate::{commands::build_command::NEP330_CONTRACT_PATH_ENV_KEY, types::source_id, util};
+use crate::{commands::build_command::NEP330_INSIDE_DOCKER_ENV_KEY, common::ColorPreference};
 
 use color_eyre::eyre::ContextCompat;
 
@@ -12,7 +12,7 @@ use colored::Colorize;
 #[cfg(unix)]
 use nix::unistd::{getgid, getuid};
 
-use super::{BuildContext, REPO_LINK_HINT_ENV_KEY, SOURCE_CODE_SNAPSHOT_ENV_KEY};
+use super::{BuildContext, NEP330_SOURCE_CODE_SNAPSHOT_ENV_KEY, REPO_LINK_HINT_ENV_KEY};
 
 mod cloned_repo;
 mod crate_in_repo;
@@ -366,18 +366,21 @@ impl Nep330BuildInfo {
     fn docker_args(&self) -> Vec<String> {
         let mut result = vec![
             "--env".to_string(),
-            format!("{}={}", INSIDE_DOCKER_ENV_KEY, self.build_environment),
+            format!(
+                "{}={}",
+                NEP330_INSIDE_DOCKER_ENV_KEY, self.build_environment
+            ),
             "--env".to_string(),
             format!(
                 "{}={}",
-                SOURCE_CODE_SNAPSHOT_ENV_KEY,
+                NEP330_SOURCE_CODE_SNAPSHOT_ENV_KEY,
                 self.source_code_snapshot.as_url()
             ),
         ];
 
         result.extend(vec![
             "--env".to_string(),
-            format!("{}={}", CONTRACT_PATH_ENV_KEY, self.contract_path),
+            format!("{}={}", NEP330_CONTRACT_PATH_ENV_KEY, self.contract_path),
         ]);
 
         result

--- a/cargo-near/src/commands/build_command/docker/cloned_repo.rs
+++ b/cargo-near/src/commands/build_command/docker/cloned_repo.rs
@@ -109,7 +109,7 @@ fn copy(
         from_docker: true,
     };
     let mut messages = ArtifactMessages::default();
-    messages.push_binary(&result);
+    messages.push_binary(&result)?;
     messages.pretty_print();
 
     Ok(result)

--- a/cargo-near/src/commands/build_command/docker/git_checks/pushed_to_remote.rs
+++ b/cargo-near/src/commands/build_command/docker/git_checks/pushed_to_remote.rs
@@ -1,3 +1,4 @@
+use color_eyre::eyre::WrapErr;
 use colored::Colorize;
 
 const BETWEEN_ATTEMPTS_SLEEP: std::time::Duration = std::time::Duration::from_millis(100);
@@ -16,7 +17,8 @@ pub fn check(git_url: &url::Url, commit_id: git2::Oid) -> color_eyre::Result<()>
         match repo {
             Ok(repo) => {
                 println!(" {}", "Checking if HEAD is present...".green());
-                repo.find_commit(commit_id)?;
+                repo.find_commit(commit_id)
+                    .wrap_err("commit wasn't found in remote repo")?;
                 println!(
                     " {} {} in `{}` -> `{}`",
                     "commit was found in repo:".green(),

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -70,6 +70,7 @@ pub enum BuildContext {
     Deploy,
 }
 impl BuildCommand {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         no_locked: bool,
         no_release: bool,

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -17,6 +17,7 @@ pub const CONTRACT_PATH_ENV_KEY: &str = "CARGO_NEAR_CONTRACT_PATH";
 pub const SOURCE_CODE_SNAPSHOT_ENV_KEY: &str = "CARGO_NEAR_SOURCE_CODE_SNAPSHOT";
 // ====================== End section =======================================
 pub const REPO_LINK_HINT_ENV_KEY: &str = "CARGO_NEAR_REPO_LINK_HINT";
+pub const ABI_GENERATION_STEP_ENV_KEY: &str = "CARGO_NEAR_ABI_GENERATION";
 
 #[derive(Debug, Default, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(input_context = near_cli_rs::GlobalContext)]

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -7,17 +7,17 @@ use crate::{
     util::{self, CompilationArtifact},
 };
 
-mod build;
+pub(crate) mod build;
 mod docker;
 
 // ====================== NEP-330 Build Details Extension section ===========
-pub const INSIDE_DOCKER_ENV_KEY: &str = "CARGO_NEAR_BUILD_ENVIRONMENT";
-pub const BUILD_CMD_ENV_KEY: &str = "CARGO_NEAR_BUILD_COMMAND";
-pub const CONTRACT_PATH_ENV_KEY: &str = "CARGO_NEAR_CONTRACT_PATH";
-pub const SOURCE_CODE_SNAPSHOT_ENV_KEY: &str = "CARGO_NEAR_SOURCE_CODE_SNAPSHOT";
+pub const NEP330_INSIDE_DOCKER_ENV_KEY: &str = "CARGO_NEAR_BUILD_ENVIRONMENT";
+pub const NEP330_BUILD_CMD_ENV_KEY: &str = "CARGO_NEAR_BUILD_COMMAND";
+pub const NEP330_CONTRACT_PATH_ENV_KEY: &str = "CARGO_NEAR_CONTRACT_PATH";
+pub const NEP330_SOURCE_CODE_SNAPSHOT_ENV_KEY: &str = "CARGO_NEAR_SOURCE_CODE_SNAPSHOT";
 // ====================== End section =======================================
 pub const REPO_LINK_HINT_ENV_KEY: &str = "CARGO_NEAR_REPO_LINK_HINT";
-pub const ABI_GENERATION_STEP_ENV_KEY: &str = "CARGO_NEAR_ABI_GENERATION";
+pub const BUILD_RS_ABI_STEP_HINT_ENV_KEY: &str = "CARGO_NEAR_ABI_GENERATION";
 
 #[derive(Debug, Default, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(input_context = near_cli_rs::GlobalContext)]
@@ -70,6 +70,32 @@ pub enum BuildContext {
     Deploy,
 }
 impl BuildCommand {
+    pub fn new(
+        no_locked: bool,
+        no_release: bool,
+        no_abi: bool,
+        no_embed_abi: bool,
+        no_doc: bool,
+        out_dir: Option<crate::types::utf8_path_buf::Utf8PathBuf>,
+        manifest_path: Option<crate::types::utf8_path_buf::Utf8PathBuf>,
+        features: Option<String>,
+        no_default_features: bool,
+        color: Option<crate::common::ColorPreference>,
+    ) -> Self {
+        Self {
+            no_locked,
+            no_docker: true,
+            no_release,
+            no_abi,
+            no_embed_abi,
+            no_doc,
+            features,
+            no_default_features,
+            out_dir,
+            manifest_path,
+            color,
+        }
+    }
     pub fn contract_path(&self) -> color_eyre::eyre::Result<camino::Utf8PathBuf> {
         let contract_path: camino::Utf8PathBuf = if let Some(manifest_path) = &self.manifest_path {
             let manifest_path = CargoManifestPath::try_from(manifest_path.deref().clone())?;
@@ -89,7 +115,7 @@ impl BuildCommand {
         }
     }
     pub fn no_docker(&self) -> bool {
-        std::env::var(INSIDE_DOCKER_ENV_KEY).is_ok() || self.no_docker
+        std::env::var(NEP330_INSIDE_DOCKER_ENV_KEY).is_ok() || self.no_docker
     }
 }
 

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -134,8 +134,11 @@ impl<'a> ArtifactMessages<'a> {
             "Binary",
             wasm_artifact.path.to_string().bright_yellow().bold(),
         ));
+        let checksum = wasm_artifact.compute_hash()?;
         self.messages
-            .push(("Hashsum", wasm_artifact.compute_hash()?.green().dimmed()));
+            .push(("SHA-256 checksum hex ", checksum.hex.green().dimmed()));
+        self.messages
+            .push(("SHA-256 checksum bs58", checksum.base58.green().dimmed()));
         Ok(())
     }
     pub fn push_free(&mut self, msg: (&'a str, ColoredString)) {

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -98,11 +98,17 @@ pub struct ArtifactMessages<'a> {
 }
 
 impl<'a> ArtifactMessages<'a> {
-    pub fn push_binary(&mut self, wasm_artifact: &CompilationArtifact) {
+    pub fn push_binary(
+        &mut self,
+        wasm_artifact: &CompilationArtifact,
+    ) -> color_eyre::eyre::Result<()> {
         self.messages.push((
             "Binary",
             wasm_artifact.path.to_string().bright_yellow().bold(),
         ));
+        self.messages
+            .push(("Hashsum", wasm_artifact.compute_hash()?.green().dimmed()));
+        Ok(())
     }
     pub fn push_free(&mut self, msg: (&'a str, ColoredString)) {
         self.messages.push(msg);

--- a/cargo-near/src/lib.rs
+++ b/cargo-near/src/lib.rs
@@ -3,13 +3,16 @@
 pub use near_cli_rs::CliResult;
 use strum::{EnumDiscriminants, EnumIter, EnumMessage};
 
+/// module with common code to write
+/// build-scripts, utilizing [commands::build_command::build::run]
+pub mod build_rs;
 pub mod commands;
 pub mod common;
 pub mod types;
 pub mod util;
 
 pub use commands::build_command::build::run as run_build;
-pub use commands::build_command::BuildCommand as BuildArgs;
+pub use commands::build_command::BuildCommand as BuildOpts;
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(context = near_cli_rs::GlobalContext)]

--- a/cargo-near/src/lib.rs
+++ b/cargo-near/src/lib.rs
@@ -4,9 +4,12 @@ pub use near_cli_rs::CliResult;
 use strum::{EnumDiscriminants, EnumIter, EnumMessage};
 
 pub mod commands;
-mod common;
+pub mod common;
 pub mod types;
 pub mod util;
+
+pub use commands::build_command::build::run as run_build;
+pub use commands::build_command::BuildCommand as BuildArgs;
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(context = near_cli_rs::GlobalContext)]

--- a/cargo-near/src/lib.rs
+++ b/cargo-near/src/lib.rs
@@ -6,7 +6,7 @@ use strum::{EnumDiscriminants, EnumIter, EnumMessage};
 pub mod commands;
 mod common;
 pub mod types;
-mod util;
+pub mod util;
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(context = near_cli_rs::GlobalContext)]

--- a/cargo-near/src/main.rs
+++ b/cargo-near/src/main.rs
@@ -1,4 +1,4 @@
-use cargo_near::commands::build_command::INSIDE_DOCKER_ENV_KEY;
+use cargo_near::commands::build_command::NEP330_INSIDE_DOCKER_ENV_KEY;
 use colored::Colorize;
 use interactive_clap::ToCliArgs;
 use log::Level;
@@ -11,7 +11,7 @@ use cargo_near::Cmd;
 fn main() -> CliResult {
     let mut builder = env_logger::Builder::from_env(env_logger::Env::default());
 
-    let environment = if std::env::var(INSIDE_DOCKER_ENV_KEY).is_ok() {
+    let environment = if std::env::var(NEP330_INSIDE_DOCKER_ENV_KEY).is_ok() {
         "container".cyan()
     } else {
         "host".purple()

--- a/cargo-near/src/util/mod.rs
+++ b/cargo-near/src/util/mod.rs
@@ -167,13 +167,20 @@ pub struct CompilationArtifact {
     pub fresh: bool,
     pub from_docker: bool,
 }
+pub struct SHA256Checksum {
+    pub hex: String,
+    pub base58: String,
+}
 
 impl CompilationArtifact {
-    pub fn compute_hash(&self) -> color_eyre::eyre::Result<String> {
+    pub fn compute_hash(&self) -> color_eyre::eyre::Result<SHA256Checksum> {
         let mut hasher = Sha256::new();
         hasher.update(std::fs::read(&self.path)?);
         let hash = hasher.finalize();
-        Ok(bs58::encode(hash).into_string())
+        Ok(SHA256Checksum {
+            hex: hex::encode(hash),
+            base58: bs58::encode(hash).into_string(),
+        })
     }
 }
 

--- a/cargo-near/src/util/mod.rs
+++ b/cargo-near/src/util/mod.rs
@@ -15,6 +15,7 @@ use log::{error, info};
 
 use crate::common::ColorPreference;
 use crate::types::manifest::CargoManifestPath;
+use sha2::{Digest, Sha256};
 
 mod print;
 pub(crate) use print::*;
@@ -165,6 +166,15 @@ pub struct CompilationArtifact {
     pub path: Utf8PathBuf,
     pub fresh: bool,
     pub from_docker: bool,
+}
+
+impl CompilationArtifact {
+    pub fn compute_hash(&self) -> color_eyre::eyre::Result<String> {
+        let mut hasher = Sha256::new();
+        hasher.update(std::fs::read(&self.path)?);
+        let hash = hasher.finalize();
+        Ok(bs58::encode(hash).into_string())
+    }
 }
 
 /// Builds the cargo project with manifest located at `manifest_path` and returns the path to the generated artifact.


### PR DESCRIPTION
this is only ahead of #164 by https://github.com/near/cargo-near/commit/91ffe0dfbda5b69b62896503bae0461f02c45b6f
tested against [repo/tree/main2](https://github.com/dj8yfo/factory-rust/tree/main2)

doing a [cli mini-parser](https://github.com/dj8yfo/cargo-near/blob/source-scan-fct-scratch-mini-clap/cargo-near/src/commands/build_command/mod.rs#L74-L154) allows simplifying a bit 
https://github.com/dj8yfo/factory-rust/blob/main2/factory/build.rs#L5
instead of
https://github.com/dj8yfo/factory-rust/blob/main/factory/build.rs#L9
