### PR TITLE
Updates near-cli-rs and cargo-near to latest versions

### DIFF
--- a/cargo-near/src/commands/new/new-project-template/.github/workflows/deploy-production.yml
+++ b/cargo-near/src/commands/new/new-project-template/.github/workflows/deploy-production.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install cargo-near CLI
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.4.1/cargo-near-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.6.2/cargo-near-installer.sh | sh
       - name: Deploy to production
         run: |
           cargo near deploy "${{ vars.NEAR_CONTRACT_PRODUCTION_ACCOUNT_ID }}" \

--- a/cargo-near/src/commands/new/new-project-template/.github/workflows/deploy-staging.yml
+++ b/cargo-near/src/commands/new/new-project-template/.github/workflows/deploy-staging.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install near CLI
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/near-cli-rs/releases/download/v0.7.0/near-cli-rs-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/near-cli-rs/releases/download/v0.11.1/near-cli-rs-installer.sh | sh
       - name: Create staging account
         if: github.event.action == 'opened' || github.event.action == 'reopened'
         run: |
@@ -34,7 +34,7 @@ jobs:
             send
 
       - name: Install cargo-near CLI
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.4.1/cargo-near-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.6.2/cargo-near-installer.sh | sh
       - name: Deploy to staging
         run: |
           cargo near deploy "${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }}" \

--- a/cargo-near/src/commands/new/new-project-template/.github/workflows/undeploy-staging.yml
+++ b/cargo-near/src/commands/new/new-project-template/.github/workflows/undeploy-staging.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install near CLI
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/near-cli-rs/releases/download/v0.7.0/near-cli-rs-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/near-cli-rs/releases/download/v0.11.1/near-cli-rs-installer.sh | sh
       - name: Remove staging account
         run: |
           near account delete-account "${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }}" \


### PR DESCRIPTION
`cargo near new` creates a new contract from template with pre-populated git workflows.

It seems the versions of near-cli-rs and cargo-near are no longer compatible, getting error:

```
Error: 
   0: expected `schema_version` to be ~0.3, but got 0.4.0: consider upgrading near-abi to a newer version
```

This pull request updates these two packages to latest versions. I've validated a successful deploy after modified workflows here: https://github.com/NEARBuilders/gateway/pull/457#issuecomment-2204429774