### PR TITLE
feat(source-scan): coerce `cargo-near` version in nested builds (for abi)

### DIFF
--- a/cargo-near/src/build_extended/build_script.rs
+++ b/cargo-near/src/build_extended/build_script.rs
@@ -83,6 +83,7 @@ impl<'a> BuildScriptOpts<'a> {
                 path: stub_path,
                 fresh: true,
                 from_docker: false,
+                cargo_near_version_mismatch: None,
             }
         };
         Ok(artifact)
@@ -100,6 +101,13 @@ impl<'a> BuildScriptOpts<'a> {
         } else {
             ":"
         };
+        if let Some(ref version_mismatch) = artifact.cargo_near_version_mismatch {
+            print_warn!(
+                version,
+                "WARNING: `cargo-near` version was coerced during build: {}",
+                version_mismatch
+            );
+        }
         if let Some(ref result_env_key) = self.result_env_key {
             pretty_print(skipped, artifact, version)?;
             println!(

--- a/cargo-near/src/build_extended/build_script.rs
+++ b/cargo-near/src/build_extended/build_script.rs
@@ -104,8 +104,17 @@ impl<'a> BuildScriptOpts<'a> {
         if let Some(ref version_mismatch) = artifact.cargo_near_version_mismatch {
             print_warn!(
                 version,
-                "WARNING: `cargo-near` version was coerced during build: {}",
+                "WARNING: `cargo-near` version was coerced during build: {}.",
                 version_mismatch
+            );
+            print_warn!(version, "`cargo-near` crate version (potentially used in `build.rs`) did not match `cargo-near` build environment.");
+            print_warn!(
+                version,
+                "1. Use the matching `cargo-near` CLI version in docker container or on host."
+            );
+            print_warn!(
+                version,
+                "2. Alternatively, update `cargo-near` in `[build-dependencies]` in Cargo.toml."
             );
         }
         if let Some(ref result_env_key) = self.result_env_key {

--- a/cargo-near/src/build_extended/build_script.rs
+++ b/cargo-near/src/build_extended/build_script.rs
@@ -106,17 +106,18 @@ impl<'a> BuildScriptOpts<'a> {
         {
             print_warn!(
                 version,
-                "WARNING: `cargo-near` version was coerced during build: {}.",
+                "INFO: `cargo-near` version was coerced during build: {}.",
                 version_mismatch
             );
-            print_warn!(version, "`cargo-near` crate version (potentially used in `build.rs`) did not match `cargo-near` build environment.");
+            print_warn!(version, "`cargo-near` crate version (used in `build.rs`) did not match `cargo-near` build environment.");
+            print_warn!(version, "You may consider to optionally make 2 following versions match exactly, if they're too far away:");
             print_warn!(
                 version,
-                "1. Use the matching `cargo-near` CLI version in docker container or on host."
+                "1. `cargo-near` CLI version being run in docker container, OR version of `cargo-near` CLI on host for a NO-Docker build."
             );
             print_warn!(
                 version,
-                "2. Alternatively, update `cargo-near` in `[build-dependencies]` in Cargo.toml."
+                "2. `cargo-near` version in `[build-dependencies]` in Cargo.toml."
             );
         }
         if let Some(ref result_env_key) = self.result_env_key {

--- a/cargo-near/src/build_extended/build_script.rs
+++ b/cargo-near/src/build_extended/build_script.rs
@@ -1,4 +1,4 @@
-use crate::BuildArtifact;
+use crate::{util::VersionMismatch, BuildArtifact};
 use rustc_version::Version;
 
 /// `cargo::` prefix for build script outputs, that `cargo` recognizes
@@ -83,7 +83,7 @@ impl<'a> BuildScriptOpts<'a> {
                 path: stub_path,
                 fresh: true,
                 from_docker: false,
-                cargo_near_version_mismatch: None,
+                cargo_near_version_mismatch: VersionMismatch::None,
             }
         };
         Ok(artifact)
@@ -101,7 +101,9 @@ impl<'a> BuildScriptOpts<'a> {
         } else {
             ":"
         };
-        if let Some(ref version_mismatch) = artifact.cargo_near_version_mismatch {
+        if let ref version_mismatch @ VersionMismatch::Some { .. } =
+            artifact.cargo_near_version_mismatch
+        {
             print_warn!(
                 version,
                 "WARNING: `cargo-near` version was coerced during build: {}.",

--- a/cargo-near/src/commands/build_command/build.rs
+++ b/cargo-near/src/commands/build_command/build.rs
@@ -299,7 +299,7 @@ fn print_nep_330_env() {
     }
 }
 
-fn coerce_cargo_near_version() -> color_eyre::eyre::Result<(String, Option<VersionMismatch>)> {
+fn coerce_cargo_near_version() -> color_eyre::eyre::Result<(String, VersionMismatch)> {
     match std::env::var(CARGO_NEAR_ABI_SCHEMA_VERSION_ENV_KEY) {
         Ok(env_near_abi_schema_version) => {
             if env_near_abi_schema_version != near_abi::SCHEMA_VERSION {
@@ -315,16 +315,16 @@ fn coerce_cargo_near_version() -> color_eyre::eyre::Result<(String, Option<Versi
     let current_version = env!("CARGO_PKG_VERSION");
 
     let result = match std::env::var(CARGO_NEAR_VERSION_ENV_KEY) {
-        Err(_err) => (current_version.to_string(), None),
+        Err(_err) => (current_version.to_string(), VersionMismatch::None),
         Ok(env_version) => match env_version == current_version {
-            true => (current_version.to_string(), None),
+            true => (current_version.to_string(), VersionMismatch::None),
             // coercing to env_version on mismatch
             false => (
                 env_version.clone(),
-                Some(VersionMismatch {
+                VersionMismatch::Some {
                     environment: env_version,
                     current_process: current_version.to_string(),
-                }),
+                },
             ),
         },
     };

--- a/cargo-near/src/commands/build_command/docker/cloned_repo.rs
+++ b/cargo-near/src/commands/build_command/docker/cloned_repo.rs
@@ -127,6 +127,7 @@ fn copy(
         path: out_wasm_path,
         fresh: true,
         from_docker: true,
+        cargo_near_version_mismatch: None,
     };
     let mut messages = ArtifactMessages::default();
     messages.push_binary(&result)?;

--- a/cargo-near/src/commands/build_command/docker/cloned_repo.rs
+++ b/cargo-near/src/commands/build_command/docker/cloned_repo.rs
@@ -4,7 +4,7 @@ use crate::{
         manifest::{CargoManifestPath, MANIFEST_FILE_NAME},
         metadata::CrateMetadata,
     },
-    util::{self, CompilationArtifact},
+    util::{self, CompilationArtifact, VersionMismatch},
 };
 use camino::Utf8PathBuf;
 use colored::Colorize;
@@ -127,7 +127,7 @@ fn copy(
         path: out_wasm_path,
         fresh: true,
         from_docker: true,
-        cargo_near_version_mismatch: None,
+        cargo_near_version_mismatch: VersionMismatch::UnknownFromDocker,
     };
     let mut messages = ArtifactMessages::default();
     messages.push_binary(&result)?;

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -22,6 +22,9 @@ pub const NEP330_LINK_ENV_KEY: &str = "NEP330_LINK";
 pub const NEP330_VERSION_ENV_KEY: &str = "NEP330_VERSION";
 // ====================== End section =======================================
 
+pub const CARGO_NEAR_VERSION_ENV_KEY: &str = "CARGO_NEAR_VERSION";
+pub const CARGO_NEAR_ABI_SCHEMA_VERSION_ENV_KEY: &str = "CARGO_NEAR_ABI_SCHEMA_VERSION";
+
 pub const BUILD_RS_ABI_STEP_HINT_ENV_KEY: &str = "CARGO_NEAR_ABI_GENERATION";
 
 pub const SERVER_DISABLE_INTERACTIVE: &str = "CARGO_NEAR_SERVER_BUILD_DISABLE_INTERACTIVE";

--- a/cargo-near/src/util/mod.rs
+++ b/cargo-near/src/util/mod.rs
@@ -162,10 +162,27 @@ where
     }
 }
 
+#[derive(Debug)]
+pub struct VersionMismatch {
+    pub environment: String,
+    pub current_process: String,
+}
+
+impl std::fmt::Display for VersionMismatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "`cargo-near` version {} -> `cargo-near` environment version {}",
+            self.current_process, self.environment
+        )
+    }
+}
+
 pub struct CompilationArtifact {
     pub path: Utf8PathBuf,
     pub fresh: bool,
     pub from_docker: bool,
+    pub cargo_near_version_mismatch: Option<VersionMismatch>,
 }
 pub struct SHA256Checksum {
     hash: Vec<u8>,
@@ -261,6 +278,7 @@ pub(crate) fn compile_project(
             path,
             fresh: !compile_artifact.fresh,
             from_docker: false,
+            cargo_near_version_mismatch: None,
         }),
         _ => color_eyre::eyre::bail!(
             "Compilation resulted in more than one '.{}' target file: {:?}",

--- a/cargo-near/src/util/mod.rs
+++ b/cargo-near/src/util/mod.rs
@@ -163,18 +163,31 @@ where
 }
 
 #[derive(Debug)]
-pub struct VersionMismatch {
-    pub environment: String,
-    pub current_process: String,
+pub enum VersionMismatch {
+    Some {
+        environment: String,
+        current_process: String,
+    },
+    None,
+    UnknownFromDocker,
 }
 
 impl std::fmt::Display for VersionMismatch {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "`cargo-near` version {} -> `cargo-near` environment version {}",
-            self.current_process, self.environment
-        )
+        match self {
+            Self::Some {
+                environment,
+                current_process,
+            } => {
+                write!(
+                    f,
+                    "`cargo-near` version {} -> `cargo-near` environment version {}",
+                    current_process, environment
+                )
+            }
+            Self::None => write!(f, "no `cargo-near` version mismatch in nested builds detected",),
+            Self::UnknownFromDocker => write!(f, "it's unknown if `cargo-near` version mismatch has occured in docker build environment",),
+        }
     }
 }
 
@@ -182,7 +195,7 @@ pub struct CompilationArtifact {
     pub path: Utf8PathBuf,
     pub fresh: bool,
     pub from_docker: bool,
-    pub cargo_near_version_mismatch: Option<VersionMismatch>,
+    pub cargo_near_version_mismatch: VersionMismatch,
 }
 pub struct SHA256Checksum {
     hash: Vec<u8>,
@@ -278,7 +291,7 @@ pub(crate) fn compile_project(
             path,
             fresh: !compile_artifact.fresh,
             from_docker: false,
-            cargo_near_version_mismatch: None,
+            cargo_near_version_mismatch: VersionMismatch::None,
         }),
         _ => color_eyre::eyre::bail!(
             "Compilation resulted in more than one '.{}' target file: {:?}",


### PR DESCRIPTION
addresses [bug](https://github.com/near/cargo-near/pull/179#issuecomment-2226846711)
Host with CLI built from [cargo-near branch](https://github.com/dj8yfo/cargo-near/tree/artificially_bumped_version):
![image](https://github.com/user-attachments/assets/bd3956d2-f8b3-43e9-b4c0-dd74f5bd241f)




From [docker](https://github.com/dj8yfo/cargo-near-image/blob/0.13.0-fake-dev-cargo-near-git/Dockerfile#L36) from [cargo-near branch](https://github.com/dj8yfo/cargo-near/tree/artificially_bumped_version):
![image](https://github.com/user-attachments/assets/b0fcec72-9e7f-43d8-8f58-49fc7e8ff51c)

--- 

```bash
near contract call-function as-read-only donation-product.repro-fct-37.testnet contract_source_metadata json-args {} network-config testnet now
```

=> 

<details>
  <summary>donation-product.repro-fct-37.testnet</summary><p>
  
```json
{
  "build_info": {
    "build_command": [
      "cargo",
      "near",
      "build"
    ],
    "build_environment": "dj8yfo/sourcescan:0.x.x-dev-git-artif-0.13.0@sha256:bf0945f898cb141786df5e8ebfbaeefdd9f9c7afedabf3a1109b9d06743ca4bc",
    "contract_path": "product-donation",
    "source_code_snapshot": "git+https://github.com/dj8yfo/factory-rust?rev=0bc030fb4e3340f998b48e34f97823c3958c8cf7"
  },
  "link": "https://github.com/dj8yfo/factory-rust/tree/0bc030fb4e3340f998b48e34f97823c3958c8cf7",
  "standards": [
    {
      "standard": "nep330",
      "version": "1.2.0"
    }
  ],
  "version": "0.2.9"
}
```

</p></details>

--- 

```bash
near contract download-abi donation-product.repro-fct-37.testnet save-to-file donation-product.repro-fct-37.testnet.json network-config testnet now
```
=> 

```json
{
  "schema_version": "0.4.0",
  "metadata": {
    "name": "donation",
    "version": "0.2.9",
    "build": {
      "compiler": "rustc 1.79.0",
      "builder": "cargo-near 0.13.0"
    }
  },
  "body": {
  ...
```

--- 

```bash
sha256sum *.wasm
8d3b755c02f8b8341581af03b84c9608e59c557153d9fc64a3ba3c1b4c19a34e  donation-product.repro-fct-37.testnet.wasm
3a1c58f6d9fc0e3b0c987cd5e01fbf5c63627ade4babfd74fdf4ac7a566ab253  repro-fct-37.testnet.wasm
8d3b755c02f8b8341581af03b84c9608e59c557153d9fc64a3ba3c1b4c19a34e  repro-fct-product-37.testnet.wasm
```
