### PR TITLE
chore: release v0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.4](https://github.com/near/cargo-near/compare/cargo-near-v0.6.3...cargo-near-v0.6.4) - 2024-07-22
+
+### Other
+- Updated near-sdk and near-workspaces versions in the new project Cargo.toml.template ([#183](https://github.com/near/cargo-near/pull/183))
+
 ## [0.6.3](https://github.com/near/cargo-near/compare/cargo-near-v0.6.2...cargo-near-v0.6.3) - 2024-07-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,6 +749,8 @@ dependencies = [
 [[package]]
 name = "cargo-near"
 version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8776b38372bc29e069d2797a9a6ebd7d55da456c5b3b3acf35b2a93ba8894b6"
 dependencies = [
  "atty",
  "bs58 0.5.1",
@@ -782,9 +784,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8776b38372bc29e069d2797a9a6ebd7d55da456c5b3b3acf35b2a93ba8894b6"
+version = "0.6.4"
 dependencies = [
  "atty",
  "bs58 0.5.1",
@@ -822,7 +822,7 @@ version = "0.1.0"
 dependencies = [
  "borsh",
  "camino",
- "cargo-near 0.6.3",
+ "cargo-near 0.6.4",
  "color-eyre",
  "const_format",
  "function_name",
@@ -3408,7 +3408,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bs58 0.5.1",
- "cargo-near 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo-near 0.6.3",
  "chrono",
  "fs2",
  "json-patch",

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.6.3"
+version = "0.6.4"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.76.0"


### PR DESCRIPTION
## 🤖 New release
* `cargo-near`: 0.6.3 -> 0.6.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.4](https://github.com/near/cargo-near/compare/cargo-near-v0.6.3...cargo-near-v0.6.4) - 2024-07-22

### Other
- Updated near-sdk and near-workspaces versions in the new project Cargo.toml.template ([#183](https://github.com/near/cargo-near/pull/183))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).