### PR TITLE
chore: add linux in wsl docker site link; correct Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,42 +748,6 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8776b38372bc29e069d2797a9a6ebd7d55da456c5b3b3acf35b2a93ba8894b6"
-dependencies = [
- "atty",
- "bs58 0.5.1",
- "camino",
- "cargo_metadata",
- "clap",
- "color-eyre",
- "colored",
- "derive_more",
- "dunce",
- "env_logger",
- "inquire",
- "interactive-clap",
- "interactive-clap-derive",
- "libloading",
- "linked-hash-map",
- "log",
- "names",
- "near-abi",
- "near-cli-rs",
- "rustc_version",
- "schemars",
- "serde_json",
- "sha2 0.10.8",
- "shell-words",
- "strum",
- "strum_macros",
- "symbolic-debuginfo",
- "zstd 0.13.2",
-]
-
-[[package]]
-name = "cargo-near"
 version = "0.6.4"
 dependencies = [
  "atty",
@@ -823,6 +787,42 @@ dependencies = [
  "tmp_env",
  "unix_path",
  "url",
+ "zstd 0.13.2",
+]
+
+[[package]]
+name = "cargo-near"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6951d3f90db15d9d68e4437b874688873ffee9473cb1da69e5644c5b550582"
+dependencies = [
+ "atty",
+ "bs58 0.5.1",
+ "camino",
+ "cargo_metadata",
+ "clap",
+ "color-eyre",
+ "colored",
+ "derive_more",
+ "dunce",
+ "env_logger",
+ "inquire",
+ "interactive-clap",
+ "interactive-clap-derive",
+ "libloading",
+ "linked-hash-map",
+ "log",
+ "names",
+ "near-abi",
+ "near-cli-rs",
+ "rustc_version",
+ "schemars",
+ "serde_json",
+ "sha2 0.10.8",
+ "shell-words",
+ "strum",
+ "strum_macros",
+ "symbolic-debuginfo",
  "zstd 0.13.2",
 ]
 
@@ -3420,7 +3420,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bs58 0.5.1",
- "cargo-near 0.6.3",
+ "cargo-near 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono",
  "fs2",
  "json-patch",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,6 +762,40 @@ dependencies = [
  "derive_more",
  "dunce",
  "env_logger",
+ "inquire",
+ "interactive-clap",
+ "interactive-clap-derive",
+ "libloading",
+ "linked-hash-map",
+ "log",
+ "names",
+ "near-abi",
+ "near-cli-rs",
+ "rustc_version",
+ "schemars",
+ "serde_json",
+ "sha2 0.10.8",
+ "shell-words",
+ "strum",
+ "strum_macros",
+ "symbolic-debuginfo",
+ "zstd 0.13.2",
+]
+
+[[package]]
+name = "cargo-near"
+version = "0.6.4"
+dependencies = [
+ "atty",
+ "bs58 0.5.1",
+ "camino",
+ "cargo_metadata",
+ "clap",
+ "color-eyre",
+ "colored",
+ "derive_more",
+ "dunce",
+ "env_logger",
  "git2",
  "hex 0.4.3",
  "home",
@@ -789,40 +823,6 @@ dependencies = [
  "tmp_env",
  "unix_path",
  "url",
- "zstd 0.13.2",
-]
-
-[[package]]
-name = "cargo-near"
-version = "0.6.4"
-dependencies = [
- "atty",
- "bs58 0.5.1",
- "camino",
- "cargo_metadata",
- "clap",
- "color-eyre",
- "colored",
- "derive_more",
- "dunce",
- "env_logger",
- "inquire",
- "interactive-clap",
- "interactive-clap-derive",
- "libloading",
- "linked-hash-map",
- "log",
- "names",
- "near-abi",
- "near-cli-rs",
- "rustc_version",
- "schemars",
- "serde_json",
- "sha2 0.10.8",
- "shell-words",
- "strum",
- "strum_macros",
- "symbolic-debuginfo",
  "zstd 0.13.2",
 ]
 

--- a/cargo-near/src/commands/build_command/docker/docker_checks.rs
+++ b/cargo-near/src/commands/build_command/docker/docker_checks.rs
@@ -1,3 +1,5 @@
+use std::process::Command;
+
 use colored::Colorize;
 
 pub use self::hello_world::check as sanity_check;
@@ -45,6 +47,14 @@ fn print_installation_links() {
                 "Please, follow instructions to correctly install Docker Engine on".cyan(),
                 "https://docs.docker.com/engine/install/".magenta()
             );
+            if is_wsl_linux() {
+                println!();
+                println!(
+                    "{} {}",
+                    "Also the following page may be helpful as you're running linux in WSL ".cyan(),
+                    "https://docs.docker.com/desktop/wsl".magenta(),
+                );
+            }
         }
 
         "macos" => {
@@ -68,6 +78,22 @@ fn print_installation_links() {
             );
         }
     }
+}
+
+fn is_wsl_linux() -> bool {
+    let mut uname_cmd = Command::new("uname");
+    uname_cmd.arg("-a");
+
+    let output = uname_cmd.output().ok();
+    if let Some(output) = output {
+        if output.status.success() {
+            let out = String::from_utf8_lossy(&output.stdout);
+            if out.contains("microsoft") || out.contains("Microsoft") {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 fn print_linux_postinstall_steps() {


### PR DESCRIPTION
unfortunately, `cargo 1.80.0` has a bug, it successfully installs 0.6.4 version with `--locked` build, 
which has incorrect [dependencies](https://github.com/near/cargo-near/blob/source-scan-integration/Cargo.lock#L795-L827) specified

![image](https://github.com/user-attachments/assets/22d4246e-c0d5-43e3-84d5-981a86fd7da5)

---

![image](https://github.com/user-attachments/assets/4f7b823a-44c5-450e-bd48-691d800c323a)
![image](https://github.com/user-attachments/assets/93c093dc-2a82-4256-b0f1-21b19f0b0b0b)
