### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/near/cargo-near/compare/cargo-near-v0.6.4...cargo-near-v0.7.0) - 2024-08-06
+
+### Added
+- Added ability to use SourceScan ([#134](https://github.com/near/cargo-near/pull/134))
+
+### Fixed
+- Replacing atty unmaintained dependency ([#194](https://github.com/near/cargo-near/pull/194))
+
+### Other
+- update default docker images tags + digests ([#191](https://github.com/near/cargo-near/pull/191))
+
 ## [0.6.4](https://github.com/near/cargo-near/compare/cargo-near-v0.6.3...cargo-near-v0.6.4) - 2024-07-22
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,6 +749,42 @@ dependencies = [
 [[package]]
 name = "cargo-near"
 version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6951d3f90db15d9d68e4437b874688873ffee9473cb1da69e5644c5b550582"
+dependencies = [
+ "atty",
+ "bs58 0.5.1",
+ "camino",
+ "cargo_metadata",
+ "clap",
+ "color-eyre",
+ "colored",
+ "derive_more",
+ "dunce",
+ "env_logger",
+ "inquire",
+ "interactive-clap",
+ "interactive-clap-derive",
+ "libloading",
+ "linked-hash-map",
+ "log",
+ "names",
+ "near-abi",
+ "near-cli-rs",
+ "rustc_version",
+ "schemars",
+ "serde_json",
+ "sha2 0.10.8",
+ "shell-words",
+ "strum",
+ "strum_macros",
+ "symbolic-debuginfo",
+ "zstd 0.13.2",
+]
+
+[[package]]
+name = "cargo-near"
+version = "0.7.0"
 dependencies = [
  "bs58 0.5.1",
  "camino",
@@ -790,48 +826,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo-near"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e6951d3f90db15d9d68e4437b874688873ffee9473cb1da69e5644c5b550582"
-dependencies = [
- "atty",
- "bs58 0.5.1",
- "camino",
- "cargo_metadata",
- "clap",
- "color-eyre",
- "colored",
- "derive_more",
- "dunce",
- "env_logger",
- "inquire",
- "interactive-clap",
- "interactive-clap-derive",
- "libloading",
- "linked-hash-map",
- "log",
- "names",
- "near-abi",
- "near-cli-rs",
- "rustc_version",
- "schemars",
- "serde_json",
- "sha2 0.10.8",
- "shell-words",
- "strum",
- "strum_macros",
- "symbolic-debuginfo",
- "zstd 0.13.2",
-]
-
-[[package]]
 name = "cargo-near-integration-tests"
 version = "0.1.0"
 dependencies = [
  "borsh",
  "camino",
- "cargo-near 0.6.4",
+ "cargo-near 0.7.0",
  "color-eyre",
  "const_format",
  "env_logger",
@@ -3419,7 +3419,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bs58 0.5.1",
- "cargo-near 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo-near 0.6.4",
  "chrono",
  "fs2",
  "json-patch",

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.6.4"
+version = "0.7.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.76.0"


### PR DESCRIPTION
## 🤖 New release
* `cargo-near`: 0.6.4 -> 0.7.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.0](https://github.com/near/cargo-near/compare/cargo-near-v0.6.4...cargo-near-v0.7.0) - 2024-08-06

### Added
- Added ability to use SourceScan ([#134](https://github.com/near/cargo-near/pull/134))

### Fixed
- Replacing atty unmaintained dependency ([#194](https://github.com/near/cargo-near/pull/194))

### Other
- update default docker images tags + digests ([#191](https://github.com/near/cargo-near/pull/191))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).