### PR TITLE
chore: add `package.cargo-near.debug = true` to release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ lto = true
 strip = true
 codegen-units = 1
 
+[profile.release]
+# needed for src line-info in `color-eyre` backtraces
+package.cargo-near.debug = true
+
 # The profile that 'cargo dist' will build with
 [profile.dist]
 inherits = "release"


### PR DESCRIPTION
it was noticed that default suggestions to enable backtrace only produce confusion, as backtrace info
without source code is more confusing than helpful:

current  (in main) `RUST_BACKTRACE=1 cargo near build`
![backtrace_current_release_build_1](https://github.com/user-attachments/assets/d81e2611-6d0e-4158-a3a4-dd460e8fd267)
current (in main) `RUST_BACKTRACE=full cargo near build`
![current_full](https://github.com/user-attachments/assets/7b881267-0621-42c5-861d-2c172f59130e)

---
from this pr `RUST_BACKTRACE=1 cargo near build`
![1_after_change](https://github.com/user-attachments/assets/5f179cea-a860-432c-a578-c38bff6d094b)
from this pr `RUST_BACKTRACE=full cargo near build`
![after_full](https://github.com/user-attachments/assets/cf559f49-805b-4f33-b0d7-31a16559b969)


this beefs up the binary size twice, doing a plain `debug = true` for release profile results in 250 MB binary
```bash
# installed with
# cargo install --locked --path cargo-near
❯ du -sk $(which cargo-near)
28984   /home/jerrick/.cargo/bin/cargo-near
```

```bash
# installed with (`package.cargo-near.debug = true`)
# cargo install --locked --path cargo-near
❯ du -sk $(which cargo-near)
51236   /home/jerrick/.cargo/bin/cargo-near
```

---

alternative to this is  #196 