### PR TITLE
chore: disable env section of `color_eyre` report

### DIFF
--- a/cargo-near/src/main.rs
+++ b/cargo-near/src/main.rs
@@ -50,8 +50,13 @@ fn main() -> CliResult {
 
     let config = near_cli_rs::config::Config::get_config_toml()?;
 
-    color_eyre::install()?;
-
+    #[cfg(not(debug_assertions))]
+    let display_env_section = false;
+    #[cfg(debug_assertions)]
+    let display_env_section = true;
+    color_eyre::config::HookBuilder::default()
+        .display_env_section(display_env_section)
+        .install()?;
     let cli = match Cmd::try_parse() {
         Ok(cli) => cli,
         Err(error) => error.exit(),


### PR DESCRIPTION
alternative to #195 

this pr removes this section for non-debug (dev profile) builds:
![env_section_suggestion](https://github.com/user-attachments/assets/5851a347-ba20-4b6d-a9b7-6fa453853bfc)

it's enabled when binary is installed with `cargo install --locked --profile dev cargo-near`, 
when backtraces have source code info
