### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/near/cargo-near/compare/cargo-near-v0.7.0...cargo-near-v0.8.0) - 2024-08-14
+
+### Other
+- [**breaking**] Updated near-* to 0.24, interactive clap to 0.3 ([#201](https://github.com/near/cargo-near/pull/201))
+- disable env section of `color_eyre` report ([#196](https://github.com/near/cargo-near/pull/196))
+
 ## [0.7.0](https://github.com/near/cargo-near/compare/cargo-near-v0.6.4...cargo-near-v0.7.0) - 2024-08-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bs58 0.5.1",
  "camino",
@@ -841,7 +841,7 @@ version = "0.1.0"
 dependencies = [
  "borsh",
  "camino",
- "cargo-near 0.7.0",
+ "cargo-near 0.8.0",
  "color-eyre",
  "const_format",
  "env_logger",

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.78.0"


### PR DESCRIPTION
## 🤖 New release
* `cargo-near`: 0.7.0 -> 0.8.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.0](https://github.com/near/cargo-near/compare/cargo-near-v0.7.0...cargo-near-v0.8.0) - 2024-08-14

### Other
- [**breaking**] Updated near-* to 0.24, interactive clap to 0.3 ([#201](https://github.com/near/cargo-near/pull/201))
- disable env section of `color_eyre` report ([#196](https://github.com/near/cargo-near/pull/196))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).