### PR TITLE
chore: release v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2](https://github.com/near/cargo-near/compare/cargo-near-v0.8.1...cargo-near-v0.8.2) - 2024-08-16
+
+### Other
+- updated near-workspaces-rs ([#205](https://github.com/near/cargo-near/pull/205))
+
 ## [0.8.1](https://github.com/near/cargo-near/compare/cargo-near-v0.8.0...cargo-near-v0.8.1) - 2024-08-15
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,6 +568,8 @@ dependencies = [
 [[package]]
 name = "cargo-near"
 version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6679c4e4bd40fdac1bd6cc705f23b03f6a5a081db2ee8dcea06cc8c88ce8c2"
 dependencies = [
  "bs58 0.5.1",
  "camino",
@@ -610,9 +612,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6679c4e4bd40fdac1bd6cc705f23b03f6a5a081db2ee8dcea06cc8c88ce8c2"
+version = "0.8.2"
 dependencies = [
  "bs58 0.5.1",
  "camino",
@@ -659,7 +659,7 @@ version = "0.1.0"
 dependencies = [
  "borsh",
  "camino",
- "cargo-near 0.8.1",
+ "cargo-near 0.8.2",
  "color-eyre",
  "const_format",
  "env_logger",
@@ -3123,7 +3123,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bs58 0.5.1",
- "cargo-near 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo-near 0.8.1",
  "chrono",
  "fs2",
  "json-patch",

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.78.0"


### PR DESCRIPTION
## 🤖 New release
* `cargo-near`: 0.8.1 -> 0.8.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.2](https://github.com/near/cargo-near/compare/cargo-near-v0.8.1...cargo-near-v0.8.2) - 2024-08-16

### Other
- updated near-workspaces-rs ([#205](https://github.com/near/cargo-near/pull/205))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).