### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/near/cargo-near/compare/cargo-near-v0.8.2...cargo-near-v0.9.0) - 2024-09-02
+
+### Added
+- Extracted cargo-near-build into a standalone crate to be able to use it in near-workspaces and other places without the rest of the heavy dependencies of cargo-near ([#198](https://github.com/near/cargo-near/pull/198))
+- Added tracking of `cargo near new` usage to collect statistics of the command usage ([#192](https://github.com/near/cargo-near/pull/192))
+
 ## [0.8.2](https://github.com/near/cargo-near/compare/cargo-near-v0.8.1...cargo-near-v0.8.2) - 2024-08-16
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,33 +568,6 @@ dependencies = [
 [[package]]
 name = "cargo-near"
 version = "0.8.2"
-dependencies = [
- "cargo-near-build",
- "clap",
- "color-eyre",
- "colored",
- "derive_more",
- "env_logger",
- "inquire",
- "interactive-clap",
- "interactive-clap-derive",
- "linked-hash-map",
- "log",
- "names",
- "near-cli-rs",
- "reqwest",
- "serde",
- "shell-words",
- "strum",
- "strum_macros",
- "tokio",
- "tracing",
- "tracing-test",
-]
-
-[[package]]
-name = "cargo-near"
-version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b7d99422c06c754d57a42c301f0d3d8a1c8e8d6d62799107bccf83f32e6571"
 dependencies = [
@@ -638,6 +611,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-near"
+version = "0.9.0"
+dependencies = [
+ "cargo-near-build",
+ "clap",
+ "color-eyre",
+ "colored",
+ "derive_more",
+ "env_logger",
+ "inquire",
+ "interactive-clap",
+ "interactive-clap-derive",
+ "linked-hash-map",
+ "log",
+ "names",
+ "near-cli-rs",
+ "reqwest",
+ "serde",
+ "shell-words",
+ "strum",
+ "strum_macros",
+ "tokio",
+ "tracing",
+ "tracing-test",
+]
+
+[[package]]
 name = "cargo-near-build"
 version = "0.1.0"
 dependencies = [
@@ -673,7 +673,7 @@ version = "0.1.0"
 dependencies = [
  "borsh",
  "camino",
- "cargo-near 0.8.2",
+ "cargo-near 0.9.0",
  "cargo-near-build",
  "color-eyre",
  "const_format",
@@ -3137,7 +3137,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bs58 0.5.1",
- "cargo-near 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo-near 0.8.2",
  "chrono",
  "fs2",
  "json-patch",

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.8.2"
+version = "0.9.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.78.0"


### PR DESCRIPTION
## 🤖 New release
* `cargo-near`: 0.8.2 -> 0.9.0
* `cargo-near-build`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `cargo-near`
<blockquote>

## [0.9.0](https://github.com/near/cargo-near/compare/cargo-near-v0.8.2...cargo-near-v0.9.0) - 2024-09-02

### Added
- Extracted cargo-near-build into a standalone crate to be able to use it in near-workspaces and other places without the rest of the heavy dependencies of cargo-near ([#198](https://github.com/near/cargo-near/pull/198))
- Added tracking of `cargo near new` usage to collect statistics of the command usage ([#192](https://github.com/near/cargo-near/pull/192))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).