### PR TITLE
ci: disable github release for `cargo-near-build` via cargo-dist

### DIFF
--- a/cargo-near-build/Cargo.toml
+++ b/cargo-near-build/Cargo.toml
@@ -38,6 +38,9 @@ nix = { version = "0.29.0", features = ["user", "process"], optional = true }
 features = ["build_script"]
 targets = ["x86_64-unknown-linux-gnu"]
 
+[package.metadata.dist]
+dist = false
+
 [features]
 default = []
 build_script = []

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -12,4 +12,3 @@ changelog_path = "./CHANGELOG.md"
 name = "cargo-near-build"
 changelog_update = true
 changelog_path = "./cargo-near-build/CHANGELOG.md"
-git_release_enable = false


### PR DESCRIPTION
attempt 2

![image](https://github.com/user-attachments/assets/bed91798-2a33-42b9-bffe-d6f29642466e)

https://github.com/near/cargo-near/actions/runs/10670519858/job/29574678361

![image](https://github.com/user-attachments/assets/582dc7fd-f7c9-4ae8-8eec-b340b3e721e6)

https://github.com/near/cargo-near/actions/runs/10845014216
