### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/near/cargo-near/compare/cargo-near-v0.9.0...cargo-near-v0.10.0) - 2024-10-16
+
+### Added
+
+- [**breaking**] use `wasm-opt -O` (via wasm-opt-rs) as post-step of build ([#231](https://github.com/near/cargo-near/pull/231))
+- `env` flag for external parameters of docker build and regular build ([#226](https://github.com/near/cargo-near/pull/226))
+
+### Other
+
+- Use Posthog instead of Mixpanel to collect stats on new projects creation ([#227](https://github.com/near/cargo-near/pull/227))
+- Fix tracking usage ([#225](https://github.com/near/cargo-near/pull/225))
+
 ## [0.9.0](https://github.com/near/cargo-near/compare/cargo-near-v0.8.2...cargo-near-v0.9.0) - 2024-09-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,10 +450,10 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "base64 0.22.1",
- "cargo-near-build 0.1.1",
+ "cargo-near-build 0.2.0",
  "clap",
  "color-eyre",
  "colored",
@@ -483,6 +483,30 @@ dependencies = [
 [[package]]
 name = "cargo-near-build"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd00f13698319e43d9af5b1afc7045131342f3097dd78320a09bb6303bbf2d06"
+dependencies = [
+ "bs58 0.5.1",
+ "camino",
+ "cargo_metadata",
+ "colored",
+ "dunce",
+ "eyre",
+ "hex",
+ "libloading",
+ "near-abi",
+ "rustc_version",
+ "schemars",
+ "serde_json",
+ "sha2 0.10.8",
+ "symbolic-debuginfo",
+ "tracing",
+ "zstd 0.13.2",
+]
+
+[[package]]
+name = "cargo-near-build"
+version = "0.2.0"
 dependencies = [
  "bs58 0.5.1",
  "camino",
@@ -514,37 +538,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo-near-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd00f13698319e43d9af5b1afc7045131342f3097dd78320a09bb6303bbf2d06"
-dependencies = [
- "bs58 0.5.1",
- "camino",
- "cargo_metadata",
- "colored",
- "dunce",
- "eyre",
- "hex",
- "libloading",
- "near-abi",
- "rustc_version",
- "schemars",
- "serde_json",
- "sha2 0.10.8",
- "symbolic-debuginfo",
- "tracing",
- "zstd 0.13.2",
-]
-
-[[package]]
 name = "cargo-near-integration-tests"
 version = "0.1.0"
 dependencies = [
  "borsh",
  "camino",
  "cargo-near",
- "cargo-near-build 0.1.1",
+ "cargo-near-build 0.2.0",
  "color-eyre",
  "const_format",
  "env_logger",
@@ -2900,7 +2900,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bs58 0.5.1",
- "cargo-near-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo-near-build 0.1.1",
  "chrono",
  "fs2",
  "json-patch",

--- a/cargo-near-build/CHANGELOG.md
+++ b/cargo-near-build/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/near/cargo-near/compare/cargo-near-build-v0.1.1...cargo-near-build-v0.2.0) - 2024-10-16
+
+### Added
+
+- [**breaking**] use `wasm-opt -O` (via wasm-opt-rs) as post-step of build ([#231](https://github.com/near/cargo-near/pull/231))
+- `env` flag for external parameters of docker build and regular build ([#226](https://github.com/near/cargo-near/pull/226))
+
+### Other
+
+- disable github release for `cargo-near-build` via cargo-dist ([#222](https://github.com/near/cargo-near/pull/222))
+
 ## [0.1.1](https://github.com/near/cargo-near/compare/cargo-near-build-v0.1.0...cargo-near-build-v0.1.1) - 2024-09-12
 
 ### Added

--- a/cargo-near-build/Cargo.toml
+++ b/cargo-near-build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-near-build"
 edition = "2021"
-version = "0.1.1"
+version = "0.2.0"
 description = "Library for building Rust smart contracts on NEAR, basis of `cargo-near` crate/CLI"
 repository = "https://github.com/near/cargo-near"
 license = "MIT OR Apache-2.0"

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.78.0"
@@ -23,7 +23,7 @@ license = false
 eula = false
 
 [dependencies]
-cargo-near-build = { version = "0.1.1", path = "../cargo-near-build", features = [
+cargo-near-build = { version = "0.2.0", path = "../cargo-near-build", features = [
     "abi_build",
     "docker",
 ] }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -6,13 +6,13 @@ publish = false
 
 [dependencies]
 const_format = "0.2"
-cargo-near-build = { version = "0.1.1", path = "../cargo-near-build" }
+cargo-near-build = { version = "0.2.0", path = "../cargo-near-build" }
 
 [dev-dependencies]
 borsh = { version = "1.0.0", features = ["derive", "unstable__schema"] }
 camino = "1.1.1"
 cargo-near = { path = "../cargo-near" }
-cargo-near-build = { version = "0.1.1", path = "../cargo-near-build" }
+cargo-near-build = { version = "0.2.0", path = "../cargo-near-build" }
 color-eyre = "0.6"
 function_name = "0.3"
 git2 = "0.19"


### PR DESCRIPTION
## 🤖 New release
* `cargo-near`: 0.9.0 -> 0.10.0 (⚠️ API breaking changes)
* `cargo-near-build`: 0.1.1 -> 0.2.0 (⚠️ API breaking changes)

### ⚠️ `cargo-near` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field InteractiveClapContextScopeForBuildCommand.no_wasmopt in /tmp/.tmp9RlqrE/cargo-near/cargo-near/src/commands/build_command/mod.rs:5
  field InteractiveClapContextScopeForBuildCommand.env in /tmp/.tmp9RlqrE/cargo-near/cargo-near/src/commands/build_command/mod.rs:5
  field CliBuildCommand.no_wasmopt in /tmp/.tmp9RlqrE/cargo-near/cargo-near/src/commands/build_command/mod.rs:5
  field CliBuildCommand.env in /tmp/.tmp9RlqrE/cargo-near/cargo-near/src/commands/build_command/mod.rs:5
```

### ⚠️ `cargo-near-build` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Opts.no_wasmopt in /tmp/.tmp9RlqrE/cargo-near/cargo-near-build/src/types/near/build/input/mod.rs:34
  field Opts.env in /tmp/.tmp9RlqrE/cargo-near/cargo-near-build/src/types/near/build/input/mod.rs:51

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/method_parameter_count_changed.ron

Failed in:
  cargo_near_build::BuildOpts::get_cli_build_command_in_docker now takes 3 parameters instead of 2, in /tmp/.tmp9RlqrE/cargo-near/cargo-near-build/src/types/near/build/input/docker_context.rs:19
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `cargo-near`
<blockquote>

## [0.10.0](https://github.com/near/cargo-near/compare/cargo-near-v0.9.0...cargo-near-v0.10.0) - 2024-10-16

### Added

- [**breaking**] use `wasm-opt -O` (via wasm-opt-rs) as post-step of build ([#231](https://github.com/near/cargo-near/pull/231))
- `env` flag for external parameters of docker build and regular build ([#226](https://github.com/near/cargo-near/pull/226))

### Other

- Use Posthog instead of Mixpanel to collect stats on new projects creation ([#227](https://github.com/near/cargo-near/pull/227))
- Fix tracking usage ([#225](https://github.com/near/cargo-near/pull/225))
</blockquote>

## `cargo-near-build`
<blockquote>

## [0.2.0](https://github.com/near/cargo-near/compare/cargo-near-build-v0.1.1...cargo-near-build-v0.2.0) - 2024-10-16

### Added

- [**breaking**] use `wasm-opt -O` (via wasm-opt-rs) as post-step of build ([#231](https://github.com/near/cargo-near/pull/231))
- `env` flag for external parameters of docker build and regular build ([#226](https://github.com/near/cargo-near/pull/226))

### Other

- disable github release for `cargo-near-build` via cargo-dist ([#222](https://github.com/near/cargo-near/pull/222))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).