### PR TITLE
Remove multivalue and reference-types features from rustc >= 1.82.0

### DIFF
--- a/cargo-near-build/src/near/build/mod.rs
+++ b/cargo-near-build/src/near/build/mod.rs
@@ -50,7 +50,13 @@ pub fn run(args: Opts) -> eyre::Result<CompilationArtifact> {
 
     let out_dir = crate_metadata.resolve_output_dir(args.out_dir.map(Into::into))?;
 
-    let mut build_env = vec![("RUSTFLAGS", "-C link-arg=-s")];
+    let mut build_env;
+    if rustc_version::version().unwrap() >= rustc_version::Version::parse("1.82.0").unwrap() {
+        build_env = vec![("RUSTFLAGS", "-C link-arg=-s -C target-feature=-multivalue,-reference-types")];
+    } else {
+        build_env = vec![("RUSTFLAGS", "-C link-arg=-s")];
+    }
+
     build_env.extend(
         args.env
             .iter()


### PR DESCRIPTION
According to: https://blog.rust-lang.org/2024/09/24/webassembly-targets-change-in-default-target-features.html