### PR TITLE
feat: use `wasm-opt -O` (via wasm-opt-rs) as post-step of build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,7 @@ dependencies = [
  "tracing",
  "unix_path",
  "url",
+ "wasm-opt",
  "zstd 0.13.2",
 ]
 
@@ -694,6 +695,16 @@ name = "clap_lex"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
 
 [[package]]
 name = "color-eyre"
@@ -941,6 +952,50 @@ name = "curve25519-dalek-derive"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54ccead7d199d584d139148b04b4a368d1ec7556a1d9ea2548febb1b9d49f9a4"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77953e99f01508f89f55c494bfa867171ef3a6c8cea03d26975368f2121a5c1"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65777e06cc48f0cb0152024c77d6cf9e4bdb4408e7b48bea993d42fa0f5b02b6"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.128"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98532a60dedaebc4848cb2cba5023337cc9ea3af16a5b062633fabfd9f18fb60"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2229,6 +2284,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d240c6f7e1ba3a28b0249f774e6a9dd0175054b52dfbb61b16eb8505c3785c9"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3793,6 +3857,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scratch"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3cf7c11c38cb994f3d40e8a8cde3bbd1f72a435e4c49e85d6553d8312306152"
+
+[[package]]
 name = "scroll"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4421,6 +4491,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5040,6 +5119,46 @@ name = "wasm-bindgen-shared"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+
+[[package]]
+name = "wasm-opt"
+version = "0.116.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd87a4c135535ffed86123b6fb0f0a5a0bc89e50416c942c5f0662c645f679c"
+dependencies = [
+ "anyhow",
+ "libc",
+ "strum",
+ "strum_macros",
+ "tempfile",
+ "thiserror",
+ "wasm-opt-cxx-sys",
+ "wasm-opt-sys",
+]
+
+[[package]]
+name = "wasm-opt-cxx-sys"
+version = "0.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c57b28207aa724318fcec6575fe74803c23f6f266fce10cbc9f3f116762f12e"
+dependencies = [
+ "anyhow",
+ "cxx",
+ "cxx-build",
+ "wasm-opt-sys",
+]
+
+[[package]]
+name = "wasm-opt-sys"
+version = "0.116.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a1cce564dc768dacbdb718fc29df2dba80bd21cb47d8f77ae7e3d95ceb98cbe"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cxx",
+ "cxx-build",
+]
 
 [[package]]
 name = "wasmparser"

--- a/cargo-near-build/Cargo.toml
+++ b/cargo-near-build/Cargo.toml
@@ -31,6 +31,7 @@ pathdiff = { version = "0.2.1", features = ["camino"], optional = true }
 unix_path = { version = "1.0.1", optional = true }
 tempfile = { version = "3.10.1", optional = true }
 shell-words = { version = "1.0.0", optional = true}
+wasm-opt = "0.116.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = { version = "0.29.0", features = ["user", "process"], optional = true }

--- a/cargo-near-build/src/near/abi/generate/mod.rs
+++ b/cargo-near-build/src/near/abi/generate/mod.rs
@@ -63,6 +63,10 @@ pub fn procedure(
         if !no_locked {
             args.push("--locked");
         }
+        // TODO: add extenal no_release flag and react to it
+        if false {
+            args.push("--release");
+        }
 
         args
     };

--- a/cargo-near-build/src/near/build/mod.rs
+++ b/cargo-near-build/src/near/build/mod.rs
@@ -145,6 +145,11 @@ pub fn run(args: Opts) -> eyre::Result<CompilationArtifact> {
     )?;
 
     wasm_artifact.path = crate::fs::copy(&wasm_artifact.path, &out_dir)?;
+
+    if !args.no_wasmopt {
+        wasm_opt::OptimizationOptions::new_optimize_for_size()
+            .run(&wasm_artifact.path, &wasm_artifact.path)?;
+    }
     wasm_artifact.builder_version_mismatch = builder_version_mismatch;
 
     // todo! if we embedded, check that the binary exports the __contract_abi symbol

--- a/cargo-near-build/src/types/near/build/input/docker_context.rs
+++ b/cargo-near-build/src/types/near/build/input/docker_context.rs
@@ -85,6 +85,7 @@ impl super::Opts {
         cli_args.extend(self.no_abi.then_some("--no-abi".into()));
         cli_args.extend(self.no_embed_abi.then_some("--no-embed-abi".into()));
         cli_args.extend(self.no_doc.then_some("--no-doc".into()));
+        cli_args.extend(self.no_wasmopt.then_some("--no-wasmopt".into()));
 
         if let Some(ref features) = self.features {
             cli_args.extend(["--features".into(), features.clone()]);
@@ -135,6 +136,13 @@ impl super::Opts {
             return Err(eyre::eyre!(format!(
                 "`{}` {}",
                 "--no-doc",
+                Self::BUILD_COMMAND_CLI_CONFIG_ERR
+            )));
+        }
+        if self.no_wasmopt {
+            return Err(eyre::eyre!(format!(
+                "`{}` {}",
+                "--no-wasmopt ",
                 Self::BUILD_COMMAND_CLI_CONFIG_ERR
             )));
         }

--- a/cargo-near-build/src/types/near/build/input/mod.rs
+++ b/cargo-near-build/src/types/near/build/input/mod.rs
@@ -30,6 +30,8 @@ pub struct Opts {
     pub no_embed_abi: bool,
     /// Do not include rustdocs in the embedded ABI
     pub no_doc: bool,
+    /// do not run `wasm-opt -O` on the generated output as a post-step
+    pub no_wasmopt: bool,
     /// Copy final artifacts to this directory
     pub out_dir: Option<camino::Utf8PathBuf>,
     /// Path to the `Cargo.toml` of the contract to build
@@ -93,6 +95,9 @@ impl Opts {
         }
         if self.no_doc {
             cargo_args.push("--no-doc");
+        }
+        if self.no_wasmopt {
+            cargo_args.push("--no-wasmopt");
         }
         if let Some(ref out_dir) = self.out_dir {
             cargo_args.extend_from_slice(&["--out-dir", out_dir.as_str()]);

--- a/cargo-near/src/commands/build_command/mod.rs
+++ b/cargo-near/src/commands/build_command/mod.rs
@@ -24,6 +24,9 @@ pub struct BuildCommand {
     /// Do not include rustdocs in the embedded ABI
     #[interactive_clap(long)]
     pub no_doc: bool,
+    /// Do not run `wasm-opt -O` on the generated output as a post-step
+    #[interactive_clap(long)]
+    pub no_wasmopt: bool,
     /// Copy final artifacts to this directory
     #[interactive_clap(long)]
     #[interactive_clap(skip_interactive_input)]
@@ -93,6 +96,7 @@ impl From<CliBuildCommand> for BuildCommand {
             no_abi: value.no_abi,
             no_embed_abi: value.no_embed_abi,
             no_doc: value.no_doc,
+            no_wasmopt: value.no_wasmopt,
             features: value.features,
             no_default_features: value.no_default_features,
             out_dir: value.out_dir,
@@ -125,6 +129,7 @@ impl From<BuildCommand> for BuildOpts {
             no_abi: value.no_abi,
             no_embed_abi: value.no_embed_abi,
             no_doc: value.no_doc,
+            no_wasmopt: value.no_wasmopt,
             features: value.features,
             no_default_features: value.no_default_features,
             out_dir: value.out_dir.map(Into::into),
@@ -150,6 +155,7 @@ impl BuildCommandlContext {
             no_abi: scope.no_abi,
             no_embed_abi: scope.no_embed_abi,
             no_doc: scope.no_doc,
+            no_wasmopt: scope.no_wasmopt,
             out_dir: scope.out_dir.clone(),
             manifest_path: scope.manifest_path.clone(),
             features: scope.features.clone(),


### PR DESCRIPTION
- **feat: add `wasm-opt` post-step to build**
- **todo: no_release flag for abi generation**
