### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/near/cargo-near/compare/cargo-near-v0.10.1...cargo-near-v0.11.0) - 2024-10-29
+
+### Other
+
+- add `passed_env` to default docker template ([#242](https://github.com/near/cargo-near/pull/242))
+- update `cargo near new` template `image` and `image_digest` ([#241](https://github.com/near/cargo-near/pull/241))
+- cargo near new integration test + gh workflow to autorenew image tag/digest ([#235](https://github.com/near/cargo-near/pull/235))
+- [**breaking**] remove unsafe `std::env::set_var` ([#228](https://github.com/near/cargo-near/pull/228))
+
 ## [0.10.1](https://github.com/near/cargo-near/compare/cargo-near-v0.10.0...cargo-near-v0.10.1) - 2024-10-17
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,10 +473,10 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "base64 0.22.1",
- "cargo-near-build 0.2.0",
+ "cargo-near-build 0.3.0",
  "clap",
  "color-eyre",
  "colored",
@@ -506,6 +506,32 @@ dependencies = [
 [[package]]
 name = "cargo-near-build"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e969adcb72ace16b0048c1d73bbd2824cf931236473ec7f606b3f635334a34"
+dependencies = [
+ "bs58 0.5.1",
+ "camino",
+ "cargo_metadata",
+ "colored",
+ "dunce",
+ "eyre",
+ "hex",
+ "humantime",
+ "libloading",
+ "near-abi",
+ "rustc_version",
+ "schemars",
+ "serde_json",
+ "sha2 0.10.8",
+ "symbolic-debuginfo",
+ "tracing",
+ "wasm-opt",
+ "zstd 0.13.2",
+]
+
+[[package]]
+name = "cargo-near-build"
+version = "0.3.0"
 dependencies = [
  "bon",
  "bs58 0.5.1",
@@ -538,39 +564,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo-near-build"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e969adcb72ace16b0048c1d73bbd2824cf931236473ec7f606b3f635334a34"
-dependencies = [
- "bs58 0.5.1",
- "camino",
- "cargo_metadata",
- "colored",
- "dunce",
- "eyre",
- "hex",
- "humantime",
- "libloading",
- "near-abi",
- "rustc_version",
- "schemars",
- "serde_json",
- "sha2 0.10.8",
- "symbolic-debuginfo",
- "tracing",
- "wasm-opt",
- "zstd 0.13.2",
-]
-
-[[package]]
 name = "cargo-near-integration-tests"
 version = "0.1.0"
 dependencies = [
  "borsh",
  "camino",
  "cargo-near",
- "cargo-near-build 0.2.0",
+ "cargo-near-build 0.3.0",
  "color-eyre",
  "colored",
  "const_format",
@@ -2906,7 +2906,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bs58 0.5.1",
- "cargo-near-build 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo-near-build 0.2.0",
  "chrono",
  "fs2",
  "json-patch",

--- a/cargo-near-build/CHANGELOG.md
+++ b/cargo-near-build/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/near/cargo-near/compare/cargo-near-build-v0.2.0...cargo-near-build-v0.3.0) - 2024-10-29
+
+### Other
+
+- cargo near new integration test + gh workflow to autorenew image tag/digest ([#235](https://github.com/near/cargo-near/pull/235))
+- [**breaking**] remove unsafe `std::env::set_var` ([#228](https://github.com/near/cargo-near/pull/228))
+
 ## [0.2.0](https://github.com/near/cargo-near/compare/cargo-near-build-v0.1.1...cargo-near-build-v0.2.0) - 2024-10-16
 
 ### Added

--- a/cargo-near-build/Cargo.toml
+++ b/cargo-near-build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-near-build"
 edition = "2021"
-version = "0.2.0"
+version = "0.3.0"
 description = "Library for building Rust smart contracts on NEAR, basis of `cargo-near` crate/CLI"
 repository = "https://github.com/near/cargo-near"
 license = "MIT OR Apache-2.0"

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.10.1"
+version = "0.11.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.79.0"
@@ -23,7 +23,7 @@ license = false
 eula = false
 
 [dependencies]
-cargo-near-build = { version = "0.2.0", path = "../cargo-near-build", features = [
+cargo-near-build = { version = "0.3.0", path = "../cargo-near-build", features = [
     "abi_build",
     "docker",
 ] }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 const_format = "0.2"
-cargo-near-build = { version = "0.2.0", path = "../cargo-near-build" }
+cargo-near-build = { version = "0.3.0", path = "../cargo-near-build" }
 cargo-near = { path = "../cargo-near" }
 colored = "2.0"
 tracing = "0.1.40"
@@ -16,7 +16,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 borsh = { version = "1.0.0", features = ["derive", "unstable__schema"] }
 camino = "1.1.1"
 cargo-near = { path = "../cargo-near" }
-cargo-near-build = { version = "0.2.0", path = "../cargo-near-build", features = ["test_code"] }
+cargo-near-build = { version = "0.3.0", path = "../cargo-near-build", features = ["test_code"] }
 color-eyre = "0.6"
 function_name = "0.3"
 git2 = "0.19"


### PR DESCRIPTION
## 🤖 New release
* `cargo-near`: 0.10.1 -> 0.11.0 (✓ API compatible changes)
* `cargo-near-build`: 0.2.0 -> 0.3.0 (⚠️ API breaking changes)

### ⚠️ `cargo-near-build` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Opts.no_locked in /tmp/.tmpsyrpWn/cargo-near/cargo-near-build/src/types/near/docker_build/mod.rs:17
  field Opts.no_release in /tmp/.tmpsyrpWn/cargo-near/cargo-near-build/src/types/near/docker_build/mod.rs:20
  field Opts.no_abi in /tmp/.tmpsyrpWn/cargo-near/cargo-near-build/src/types/near/docker_build/mod.rs:23
  field Opts.no_embed_abi in /tmp/.tmpsyrpWn/cargo-near/cargo-near-build/src/types/near/docker_build/mod.rs:26
  field Opts.no_doc in /tmp/.tmpsyrpWn/cargo-near/cargo-near-build/src/types/near/docker_build/mod.rs:29
  field Opts.no_wasmopt in /tmp/.tmpsyrpWn/cargo-near/cargo-near-build/src/types/near/docker_build/mod.rs:32
  field Opts.out_dir in /tmp/.tmpsyrpWn/cargo-near/cargo-near-build/src/types/near/docker_build/mod.rs:34
  field Opts.manifest_path in /tmp/.tmpsyrpWn/cargo-near/cargo-near-build/src/types/near/docker_build/mod.rs:36
  field Opts.features in /tmp/.tmpsyrpWn/cargo-near/cargo-near-build/src/types/near/docker_build/mod.rs:39
  field Opts.no_default_features in /tmp/.tmpsyrpWn/cargo-near/cargo-near-build/src/types/near/docker_build/mod.rs:42
  field Opts.color in /tmp/.tmpsyrpWn/cargo-near/cargo-near-build/src/types/near/docker_build/mod.rs:45
  field Opts.cli_description in /tmp/.tmpsyrpWn/cargo-near/cargo-near-build/src/types/near/docker_build/mod.rs:49
  field Opts.env in /tmp/.tmpsyrpWn/cargo-near/cargo-near-build/src/types/near/docker_build/mod.rs:53
  field Opts.override_nep330_contract_path in /tmp/.tmpsyrpWn/cargo-near/cargo-near-build/src/types/near/build/input/mod.rs:63
  field Opts.override_cargo_target_dir in /tmp/.tmpsyrpWn/cargo-near/cargo-near-build/src/types/near/build/input/mod.rs:71

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/inherent_method_missing.ron

Failed in:
  Opts::contract_path, previously in file /tmp/.tmpMuCw8i/cargo-near-build/src/types/near/build/input/docker_context.rs:6
  Opts::get_cli_build_command_in_docker, previously in file /tmp/.tmpMuCw8i/cargo-near-build/src/types/near/build/input/docker_context.rs:19

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field workdir of struct OptsExtended, previously in file /tmp/.tmpMuCw8i/cargo-near-build/src/types/near/build_extended/mod.rs:8
  field env of struct OptsExtended, previously in file /tmp/.tmpMuCw8i/cargo-near-build/src/types/near/build_extended/mod.rs:10
  field distinct_target_dir of struct Opts, previously in file /tmp/.tmpMuCw8i/cargo-near-build/src/types/near/build_extended/build_script.rs:28
  field build_opts of struct Opts, previously in file /tmp/.tmpMuCw8i/cargo-near-build/src/types/near/docker_build/mod.rs:13
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `cargo-near`
<blockquote>

## [0.11.0](https://github.com/near/cargo-near/compare/cargo-near-v0.10.1...cargo-near-v0.11.0) - 2024-10-29

### Other

- add `passed_env` to default docker template ([#242](https://github.com/near/cargo-near/pull/242))
- update `cargo near new` template `image` and `image_digest` ([#241](https://github.com/near/cargo-near/pull/241))
- cargo near new integration test + gh workflow to autorenew image tag/digest ([#235](https://github.com/near/cargo-near/pull/235))
- [**breaking**] remove unsafe `std::env::set_var` ([#228](https://github.com/near/cargo-near/pull/228))
</blockquote>

## `cargo-near-build`
<blockquote>

## [0.3.0](https://github.com/near/cargo-near/compare/cargo-near-build-v0.2.0...cargo-near-build-v0.3.0) - 2024-10-29

### Other

- cargo near new integration test + gh workflow to autorenew image tag/digest ([#235](https://github.com/near/cargo-near/pull/235))
- [**breaking**] remove unsafe `std::env::set_var` ([#228](https://github.com/near/cargo-near/pull/228))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).