### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/near/cargo-near/compare/cargo-near-v0.11.0...cargo-near-v0.12.0) - 2024-11-14
+
+### Added
+
+- Added the ability to use the TEACH-ME mode ([#221](https://github.com/near/cargo-near/pull/221))
+
+### Other
+
+- Gracefully handle missing `git` on `cargo near new` ([#246](https://github.com/near/cargo-near/pull/246))
+- update `cargo near new` template `image` and `image_digest` ([#244](https://github.com/near/cargo-near/pull/244))
+
 ## [0.11.0](https://github.com/near/cargo-near/compare/cargo-near-v0.10.1...cargo-near-v0.11.0) - 2024-10-29
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,10 +473,10 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64 0.22.1",
- "cargo-near-build 0.3.0",
+ "cargo-near-build 0.3.1",
  "clap",
  "color-eyre",
  "colored",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near-build"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bon",
  "bs58 0.5.1",
@@ -571,7 +571,7 @@ dependencies = [
  "borsh",
  "camino",
  "cargo-near",
- "cargo-near-build 0.3.0",
+ "cargo-near-build 0.3.1",
  "color-eyre",
  "colored",
  "const_format",

--- a/cargo-near-build/CHANGELOG.md
+++ b/cargo-near-build/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/near/cargo-near/compare/cargo-near-build-v0.3.0...cargo-near-build-v0.3.1) - 2024-11-14
+
+### Added
+
+- Added the ability to use the TEACH-ME mode ([#221](https://github.com/near/cargo-near/pull/221))
+
 ## [0.3.0](https://github.com/near/cargo-near/compare/cargo-near-build-v0.2.0...cargo-near-build-v0.3.0) - 2024-10-29
 
 ### Other

--- a/cargo-near-build/Cargo.toml
+++ b/cargo-near-build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-near-build"
 edition = "2021"
-version = "0.3.0"
+version = "0.3.1"
 description = "Library for building Rust smart contracts on NEAR, basis of `cargo-near` crate/CLI"
 repository = "https://github.com/near/cargo-near"
 license = "MIT OR Apache-2.0"

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.79.0"
@@ -23,7 +23,7 @@ license = false
 eula = false
 
 [dependencies]
-cargo-near-build = { version = "0.3.0", path = "../cargo-near-build", features = [
+cargo-near-build = { version = "0.3.1", path = "../cargo-near-build", features = [
     "abi_build",
     "docker",
 ] }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 const_format = "0.2"
-cargo-near-build = { version = "0.3.0", path = "../cargo-near-build" }
+cargo-near-build = { version = "0.3.1", path = "../cargo-near-build" }
 cargo-near = { path = "../cargo-near" }
 colored = "2.0"
 tracing = "0.1.40"
@@ -16,7 +16,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 borsh = { version = "1.0.0", features = ["derive", "unstable__schema"] }
 camino = "1.1.1"
 cargo-near = { path = "../cargo-near" }
-cargo-near-build = { version = "0.3.0", path = "../cargo-near-build", features = ["test_code"] }
+cargo-near-build = { version = "0.3.1", path = "../cargo-near-build", features = ["test_code"] }
 color-eyre = "0.6"
 function_name = "0.3"
 git2 = "0.19"


### PR DESCRIPTION
## 🤖 New release
* `cargo-near`: 0.11.0 -> 0.12.0 (⚠️ API breaking changes)
* `cargo-near-build`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

### ⚠️ `cargo-near` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CliNearArgs.teach_me in /tmp/.tmp06Ielo/cargo-near/cargo-near/src/lib.rs:30
  field InteractiveClapContextScopeForNearArgs.teach_me in /tmp/.tmp06Ielo/cargo-near/cargo-near/src/lib.rs:30

--- failure constructible_struct_adds_private_field: struct no longer constructible due to new private field ---

Description:
A struct constructible with a struct literal has a new non-public field. It can no longer be constructed using a struct literal outside of its crate.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/constructible_struct_adds_private_field.ron

Failed in:
  field NearArgs.teach_me in /tmp/.tmp06Ielo/cargo-near/cargo-near/src/lib.rs:35
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `cargo-near`
<blockquote>

## [0.12.0](https://github.com/near/cargo-near/compare/cargo-near-v0.11.0...cargo-near-v0.12.0) - 2024-11-14

### Added

- Added the ability to use the TEACH-ME mode ([#221](https://github.com/near/cargo-near/pull/221))

### Other

- Gracefully handle missing `git` on `cargo near new` ([#246](https://github.com/near/cargo-near/pull/246))
- update `cargo near new` template `image` and `image_digest` ([#244](https://github.com/near/cargo-near/pull/244))
</blockquote>

## `cargo-near-build`
<blockquote>

## [0.3.1](https://github.com/near/cargo-near/compare/cargo-near-build-v0.3.0...cargo-near-build-v0.3.1) - 2024-11-14

### Added

- Added the ability to use the TEACH-ME mode ([#221](https://github.com/near/cargo-near/pull/221))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).