### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1](https://github.com/near/cargo-near/compare/cargo-near-v0.12.0...cargo-near-v0.12.1) - 2024-11-19
+
+### Other
+
+- updates near-* dependencies to 0.27 release ([#251](https://github.com/near/cargo-near/pull/251))
+- update `cargo near new` template `image` and `image_digest` ([#250](https://github.com/near/cargo-near/pull/250))
+
 ## [0.12.0](https://github.com/near/cargo-near/compare/cargo-near-v0.11.0...cargo-near-v0.12.0) - 2024-11-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "base64 0.22.1",
  "cargo-near-build",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near-build"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bon",
  "bs58 0.5.1",

--- a/cargo-near-build/CHANGELOG.md
+++ b/cargo-near-build/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/near/cargo-near/compare/cargo-near-build-v0.3.1...cargo-near-build-v0.3.2) - 2024-11-19
+
+### Fixed
+
+- Replaced --teach-me printing from docker_args to docker_cmd ([#248](https://github.com/near/cargo-near/pull/248))
+
 ## [0.3.1](https://github.com/near/cargo-near/compare/cargo-near-build-v0.3.0...cargo-near-build-v0.3.1) - 2024-11-14
 
 ### Added

--- a/cargo-near-build/Cargo.toml
+++ b/cargo-near-build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-near-build"
 edition = "2021"
-version = "0.3.1"
+version = "0.3.2"
 description = "Library for building Rust smart contracts on NEAR, basis of `cargo-near` crate/CLI"
 repository = "https://github.com/near/cargo-near"
 license = "MIT OR Apache-2.0"

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.80.0"
@@ -23,7 +23,7 @@ license = false
 eula = false
 
 [dependencies]
-cargo-near-build = { version = "0.3.1", path = "../cargo-near-build", features = [
+cargo-near-build = { version = "0.3.2", path = "../cargo-near-build", features = [
     "abi_build",
     "docker",
 ] }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 const_format = "0.2"
-cargo-near-build = { version = "0.3.1", path = "../cargo-near-build" }
+cargo-near-build = { version = "0.3.2", path = "../cargo-near-build" }
 cargo-near = { path = "../cargo-near" }
 colored = "2.0"
 tracing = "0.1.40"
@@ -16,7 +16,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 borsh = { version = "1.0.0", features = ["derive", "unstable__schema"] }
 camino = "1.1.1"
 cargo-near = { path = "../cargo-near" }
-cargo-near-build = { version = "0.3.1", path = "../cargo-near-build", features = [
+cargo-near-build = { version = "0.3.2", path = "../cargo-near-build", features = [
     "test_code",
 ] }
 color-eyre = "0.6"


### PR DESCRIPTION
## 🤖 New release
* `cargo-near`: 0.12.0 -> 0.12.1 (✓ API compatible changes)
* `cargo-near-build`: 0.3.1 -> 0.3.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `cargo-near`
<blockquote>

## [0.12.1](https://github.com/near/cargo-near/compare/cargo-near-v0.12.0...cargo-near-v0.12.1) - 2024-11-19

### Other

- updates near-* dependencies to 0.27 release ([#251](https://github.com/near/cargo-near/pull/251))
- update `cargo near new` template `image` and `image_digest` ([#250](https://github.com/near/cargo-near/pull/250))
</blockquote>

## `cargo-near-build`
<blockquote>

## [0.3.2](https://github.com/near/cargo-near/compare/cargo-near-build-v0.3.1...cargo-near-build-v0.3.2) - 2024-11-19

### Fixed

- Replaced --teach-me printing from docker_args to docker_cmd ([#248](https://github.com/near/cargo-near/pull/248))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).