### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0](https://github.com/near/cargo-near/compare/cargo-near-v0.12.2...cargo-near-v0.13.0) - 2024-12-17
+
+### Added
+
+- reproducible choice interactive (#262)
+
+### Other
+
+- update `cargo near new` template `image` and `image_digest` ([#259](https://github.com/near/cargo-near/pull/259))
+- update `cargo near new` template `image` and `image_digest` ([#257](https://github.com/near/cargo-near/pull/257))
+
 ## [0.12.2](https://github.com/near/cargo-near/compare/cargo-near-v0.12.1...cargo-near-v0.12.2) - 2024-11-20
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "base64 0.22.1",
  "cargo-near-build",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near-build"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "bon",
  "bs58 0.5.1",

--- a/cargo-near-build/CHANGELOG.md
+++ b/cargo-near-build/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/near/cargo-near/compare/cargo-near-build-v0.3.2...cargo-near-build-v0.4.0) - 2024-12-17
+
+### Added
+
+- reproducible choice interactive (#262)
+
+### Other
+
+- fix 1.83clippy, audit (#260)
+
 ## [0.3.2](https://github.com/near/cargo-near/compare/cargo-near-build-v0.3.1...cargo-near-build-v0.3.2) - 2024-11-19
 
 ### Fixed

--- a/cargo-near-build/Cargo.toml
+++ b/cargo-near-build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-near-build"
 edition = "2021"
-version = "0.3.2"
+version = "0.4.0"
 description = "Library for building Rust smart contracts on NEAR, basis of `cargo-near` crate/CLI"
 repository = "https://github.com/near/cargo-near"
 license = "MIT OR Apache-2.0"

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.12.2"
+version = "0.13.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.80.0"
@@ -23,7 +23,7 @@ license = false
 eula = false
 
 [dependencies]
-cargo-near-build = { version = "0.3.2", path = "../cargo-near-build", features = [
+cargo-near-build = { version = "0.4.0", path = "../cargo-near-build", features = [
     "abi_build",
     "docker",
 ] }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 const_format = "0.2"
 color-eyre = "0.6"
-cargo-near-build = { version = "0.3.2", path = "../cargo-near-build" }
+cargo-near-build = { version = "0.4.0", path = "../cargo-near-build" }
 cargo-near = { path = "../cargo-near" }
 colored = "2.0"
 tracing = "0.1.40"
@@ -18,7 +18,7 @@ syn = "2"
 borsh = { version = "1.0.0", features = ["derive", "unstable__schema"] }
 camino = "1.1.1"
 cargo-near = { path = "../cargo-near" }
-cargo-near-build = { version = "0.3.2", path = "../cargo-near-build", features = [
+cargo-near-build = { version = "0.4.0", path = "../cargo-near-build", features = [
     "test_code",
 ] }
 color-eyre = "0.6"


### PR DESCRIPTION
## 🤖 New release
* `cargo-near`: 0.12.2 -> 0.13.0 (⚠️ API breaking changes)
* `cargo-near-build`: 0.3.2 -> 0.4.0 (⚠️ API breaking changes)

### ⚠️ `cargo-near` breaking changes

```
--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/module_missing.ron

Failed in:
  mod cargo_near::commands::build_command, previously in file /tmp/.tmpamrxDt/cargo-near/src/commands/build_command/mod.rs:1
  mod cargo_near::commands::abi_command, previously in file /tmp/.tmpamrxDt/cargo-near/src/commands/abi_command/mod.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/struct_missing.ron

Failed in:
  struct cargo_near::commands::abi_command::AbiCommandlContext, previously in file /tmp/.tmpamrxDt/cargo-near/src/commands/abi_command/mod.rs:45
  struct cargo_near::commands::deploy::CliContract, previously in file /tmp/.tmpamrxDt/cargo-near/src/commands/deploy/mod.rs:5
  struct cargo_near::commands::abi_command::AbiCommand, previously in file /tmp/.tmpamrxDt/cargo-near/src/commands/abi_command/mod.rs:6
  struct cargo_near::commands::build_command::InteractiveClapContextScopeForBuildCommand, previously in file /tmp/.tmpamrxDt/cargo-near/src/commands/build_command/mod.rs:6
  struct cargo_near::commands::abi_command::CliAbiCommand, previously in file /tmp/.tmpamrxDt/cargo-near/src/commands/abi_command/mod.rs:3
  struct cargo_near::commands::build_command::CliBuildCommand, previously in file /tmp/.tmpamrxDt/cargo-near/src/commands/build_command/mod.rs:6
  struct cargo_near::commands::build_command::BuildCommandlContext, previously in file /tmp/.tmpamrxDt/cargo-near/src/commands/build_command/mod.rs:173
  struct cargo_near::commands::deploy::ContractContext, previously in file /tmp/.tmpamrxDt/cargo-near/src/commands/deploy/mod.rs:24
  struct cargo_near::commands::deploy::InteractiveClapContextScopeForContract, previously in file /tmp/.tmpamrxDt/cargo-near/src/commands/deploy/mod.rs:5
  struct cargo_near::commands::abi_command::InteractiveClapContextScopeForAbiCommand, previously in file /tmp/.tmpamrxDt/cargo-near/src/commands/abi_command/mod.rs:3
  struct cargo_near::commands::deploy::Contract, previously in file /tmp/.tmpamrxDt/cargo-near/src/commands/deploy/mod.rs:9
  struct cargo_near::commands::build_command::BuildCommand, previously in file /tmp/.tmpamrxDt/cargo-near/src/commands/build_command/mod.rs:9
```

### ⚠️ `cargo-near-build` breaking changes

```
--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field no_release of struct Opts, previously in file /tmp/.tmpamrxDt/cargo-near-build/src/types/near/docker_build/mod.rs:20
  field no_abi of struct Opts, previously in file /tmp/.tmpamrxDt/cargo-near-build/src/types/near/docker_build/mod.rs:23
  field no_embed_abi of struct Opts, previously in file /tmp/.tmpamrxDt/cargo-near-build/src/types/near/docker_build/mod.rs:26
  field no_doc of struct Opts, previously in file /tmp/.tmpamrxDt/cargo-near-build/src/types/near/docker_build/mod.rs:29
  field no_wasmopt of struct Opts, previously in file /tmp/.tmpamrxDt/cargo-near-build/src/types/near/docker_build/mod.rs:32
  field features of struct Opts, previously in file /tmp/.tmpamrxDt/cargo-near-build/src/types/near/docker_build/mod.rs:39
  field no_default_features of struct Opts, previously in file /tmp/.tmpamrxDt/cargo-near-build/src/types/near/docker_build/mod.rs:42
  field cli_description of struct Opts, previously in file /tmp/.tmpamrxDt/cargo-near-build/src/types/near/docker_build/mod.rs:49
  field env of struct Opts, previously in file /tmp/.tmpamrxDt/cargo-near-build/src/types/near/docker_build/mod.rs:53
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `cargo-near`
<blockquote>

## [0.13.0](https://github.com/near/cargo-near/compare/cargo-near-v0.12.2...cargo-near-v0.13.0) - 2024-12-17

### Added

- reproducible choice interactive (#262)

### Other

- update `cargo near new` template `image` and `image_digest` ([#259](https://github.com/near/cargo-near/pull/259))
- update `cargo near new` template `image` and `image_digest` ([#257](https://github.com/near/cargo-near/pull/257))
</blockquote>

## `cargo-near-build`
<blockquote>

## [0.4.0](https://github.com/near/cargo-near/compare/cargo-near-build-v0.3.2...cargo-near-build-v0.4.0) - 2024-12-17

### Added

- reproducible choice interactive (#262)

### Other

- fix 1.83clippy, audit (#260)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).