### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1](https://github.com/near/cargo-near/compare/cargo-near-v0.13.0...cargo-near-v0.13.1) - 2024-12-18
+
+### Other
+
+- update `cargo near new` template `image` and `image_digest` ([#269](https://github.com/near/cargo-near/pull/269))
+
 ## [0.13.0](https://github.com/near/cargo-near/compare/cargo-near-v0.12.2...cargo-near-v0.13.0) - 2024-12-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "base64 0.22.1",
  "cargo-near-build",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near-build"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bon",
  "bs58 0.5.1",

--- a/cargo-near-build/CHANGELOG.md
+++ b/cargo-near-build/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/near/cargo-near/compare/cargo-near-build-v0.4.0...cargo-near-build-v0.4.1) - 2024-12-18
+
+### Fixed
+
+- running `near_workspaces::compile_project` concurrently in tests (#266)
+
 ## [0.4.0](https://github.com/near/cargo-near/compare/cargo-near-build-v0.3.2...cargo-near-build-v0.4.0) - 2024-12-17
 
 ### Added

--- a/cargo-near-build/Cargo.toml
+++ b/cargo-near-build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-near-build"
 edition = "2021"
-version = "0.4.0"
+version = "0.4.1"
 description = "Library for building Rust smart contracts on NEAR, basis of `cargo-near` crate/CLI"
 repository = "https://github.com/near/cargo-near"
 license = "MIT OR Apache-2.0"

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.80.0"
@@ -23,7 +23,7 @@ license = false
 eula = false
 
 [dependencies]
-cargo-near-build = { version = "0.4.0", path = "../cargo-near-build", features = [
+cargo-near-build = { version = "0.4.1", path = "../cargo-near-build", features = [
     "abi_build",
     "docker",
 ] }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 const_format = "0.2"
 color-eyre = "0.6"
-cargo-near-build = { version = "0.4.0", path = "../cargo-near-build" }
+cargo-near-build = { version = "0.4.1", path = "../cargo-near-build" }
 cargo-near = { path = "../cargo-near" }
 colored = "2.0"
 tracing = "0.1.40"
@@ -18,7 +18,7 @@ syn = "2"
 borsh = { version = "1.0.0", features = ["derive", "unstable__schema"] }
 camino = "1.1.1"
 cargo-near = { path = "../cargo-near" }
-cargo-near-build = { version = "0.4.0", path = "../cargo-near-build", features = [
+cargo-near-build = { version = "0.4.1", path = "../cargo-near-build", features = [
     "test_code",
 ] }
 color-eyre = "0.6"


### PR DESCRIPTION
## 🤖 New release
* `cargo-near`: 0.13.0 -> 0.13.1 (✓ API compatible changes)
* `cargo-near-build`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `cargo-near`
<blockquote>

## [0.13.1](https://github.com/near/cargo-near/compare/cargo-near-v0.13.0...cargo-near-v0.13.1) - 2024-12-18

### Other

- update `cargo near new` template `image` and `image_digest` ([#269](https://github.com/near/cargo-near/pull/269))
</blockquote>

## `cargo-near-build`
<blockquote>

## [0.4.1](https://github.com/near/cargo-near/compare/cargo-near-build-v0.4.0...cargo-near-build-v0.4.1) - 2024-12-18

### Fixed

- running `near_workspaces::compile_project` concurrently in tests (#266)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).