### PR TITLE
fix: remove from env CARGO_ENCODED_RUSTFLAGS for easier nested builds, simplify RUSTFLAGS computation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,44 @@ This forwards to [reproducible-wasm](#reproducible-wasm) variant of `build` comm
 2. has been pushed to remote repository, identified by 
    [`package.repository`](https://github.com/near/cargo-near/blob/main/cargo-near/src/commands/new/new-project-template/Cargo.template.toml#L9).
 
+## Special `cargo` environment variables
+
+Both of the following are mentioned on https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags
+
+### `RUSTFLAGS`  
+
+running e.g.
+
+```bash
+RUSTFLAGS="your_custom_value" cargo near build non-reproducible-wasm
+```
+won't result in `"your_custom_value"` affecting the build.
+
+`RUSTFLAGS="-Awarnings"` is always used for abi build stage, and `RUSTFLAGS="-C link-arg=-s"` for wasm build stage.
+
+Logic for concatenating default values of this variable with values from env was removed in `cargo-near-0.13.3`/`cargo-near-build-0.4.3`, as it was seen as
+an unnecessary complication.
+
+There's still a way to override this parameter for wasm build stage, e.g.:
+
+```lang
+cargo near build non-reproducible-wasm --env 'RUSTFLAGS=--verbose'
+RUST_LOG=info cargo near build non-reproducible-wasm --env 'RUSTFLAGS=--verbose -C link-arg=-s'
+```
+
+### `CARGO_ENCODED_RUSTFLAGS`
+
+This variable is always unset during build, so
+
+```bash
+CARGO_ENCODED_RUSTFLAGS="your_custom_value" cargo near build non-reproducible-wasm
+```
+won't result in `"your_custom_value"` affecting the build.
+
+This is so to avoid weird issues like [#287](https://github.com/near/cargo-near/issues/287) when composing multiple builds via build scripts.
+
+
+
 
 ## Contribution
 

--- a/cargo-near-build/src/cargo_native/compile.rs
+++ b/cargo-near-build/src/cargo_native/compile.rs
@@ -25,15 +25,12 @@ where
     let final_env = {
         let mut env: BTreeMap<_, _> = env.into_iter().collect();
         if hide_warnings {
-            env.insert("RUSTFLAGS", "-Awarnings");
+            env.insert(crate::env_keys::RUSTFLAGS, "-Awarnings");
         }
         env
     };
-    // removing env, which may be implicitly passed when bulding from within a build-script
-    // see https://github.com/near/cargo-near/issues/287
-    // CARGO_ENCODED_RUSTFLAGS="-Awarnings" and RUSTFLAGS="-Awarnings" both result
-    // in mysterious failures of `cargo build --target wasm32-unknown-unknown` (**cargo** bug)
-    let removed_env = ["CARGO_ENCODED_RUSTFLAGS"];
+
+    let removed_env = [crate::env_keys::CARGO_ENCODED_RUSTFLAGS];
 
     let artifacts = invoke_cargo(
         "build",

--- a/cargo-near-build/src/cargo_native/compile.rs
+++ b/cargo-near-build/src/cargo_native/compile.rs
@@ -118,6 +118,11 @@ where
     let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
     let mut cmd = Command::new(cargo);
 
+    // removing env, which may be implicitly passed when bulding from within a build-script
+    // see https://github.com/near/cargo-near/issues/287
+    // CARGO_ENCODED_RUSTFLAGS="-Awarnings" and RUSTFLAGS="-Awarnings" both result
+    // in mysterious failures of `cargo build --target wasm32-unknown-unknown` (rustc bug)
+    cmd.env_remove("CARGO_ENCODED_RUSTFLAGS");
     cmd.envs(env);
 
     if let Some(path) = working_dir {

--- a/cargo-near-build/src/cargo_native/compile.rs
+++ b/cargo-near-build/src/cargo_native/compile.rs
@@ -24,28 +24,14 @@ where
 {
     let mut final_env = BTreeMap::new();
 
+    // this will overwrite any other RUSTFLAGS specified
     if hide_warnings {
         env.push(("RUSTFLAGS", "-Awarnings"));
     }
 
+    // last instance of a key gets inserted
     for (key, value) in env {
-        match key {
-            "RUSTFLAGS" => {
-                let rustflags: &mut String = final_env
-                    .entry(key)
-                    .or_insert_with(|| std::env::var(key).unwrap_or_default());
-                // helps avoids situation on complete match `RUSTFLAGS="-C link-arg=-s -C link-arg=-s"`
-                if !rustflags.contains(value) {
-                    if !rustflags.is_empty() {
-                        rustflags.push(' ');
-                    }
-                    rustflags.push_str(value);
-                }
-            }
-            _ => {
-                final_env.insert(key, value.to_string());
-            }
-        }
+        final_env.insert(key, value.to_string());
     }
 
     let artifacts = invoke_cargo(

--- a/cargo-near-build/src/env_keys.rs
+++ b/cargo-near-build/src/env_keys.rs
@@ -3,6 +3,25 @@ pub const CARGO_TARGET_DIR: &str = "CARGO_TARGET_DIR";
 /// this variable is set to `"true"` during ABI generation operation  
 pub const BUILD_RS_ABI_STEP_HINT: &str = "CARGO_NEAR_ABI_GENERATION";
 
+/// <https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags>
+///
+/// this behaviour that
+/// 1. default value for RUSTFLAGS for wasm build is "-C link-arg=-s"
+/// 2. it can be overriden with values from --env arguments
+/// 3. default RUSTFLAGS for abi gen are "-Awarnings"
+/// 4. RUSTFLAGS aren't concatenated (implicitly) with values from environment
+///
+/// is documented in RUSTFLAGS section of README.md
+pub const RUSTFLAGS: &str = "RUSTFLAGS";
+
+/// <https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags>
+///
+/// this behaviour that
+/// 1. CARGO_ENCODED_RUSTFLAGS gets unset by default
+///
+/// is documented in CARGO_ENCODED_RUSTFLAGS section of README.md
+pub const CARGO_ENCODED_RUSTFLAGS: &str = "CARGO_ENCODED_RUSTFLAGS";
+
 pub(crate) const CARGO_NEAR_ABI_PATH: &str = "CARGO_NEAR_ABI_PATH";
 
 pub(crate) const CARGO_NEAR_VERSION: &str = "CARGO_NEAR_VERSION";

--- a/cargo-near-build/src/near/build/mod.rs
+++ b/cargo-near-build/src/near/build/mod.rs
@@ -142,7 +142,7 @@ pub fn run(args: Opts) -> eyre::Result<CompilationArtifact> {
     let abi_path_env = buildtime_env::AbiPath::new(args.no_embed_abi, &min_abi_path);
 
     let build_env = {
-        let mut build_env = vec![("RUSTFLAGS", "-C link-arg=-s")];
+        let mut build_env = vec![(env_keys::RUSTFLAGS, "-C link-arg=-s")];
         build_env.extend(
             args.env
                 .iter()

--- a/cargo-near-build/src/types/near/docker_build/metadata.rs
+++ b/cargo-near-build/src/types/near/docker_build/metadata.rs
@@ -109,7 +109,7 @@ impl ReproducibleBuild {
         for command_token in build_command {
             if command_token
                 .chars()
-                .any(|c| !c.is_ascii() || c.is_ascii_control() || c.is_ascii_whitespace())
+                .any(|c| !c.is_ascii() || c.is_ascii_control())
             {
                 return Err(eyre::eyre!(
                     "{}: `{}`\n{}",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/544ecaba-bf95-4080-bc8d-47db93394ab0)

resolves  #287 

this stuff gets set for build-scripts https://github.com/rust-lang/cargo/blob/master/src/cargo/core/compiler/custom_build.rs#L378, while `RUSTFLAGS` is unset

---

tested to help resolve problem in #287 on https://github.com/dj8yfo/neardevhub-treasury-dashboard/commit/56bcbcfe3a11e77af16f0b6e6fa4356955b42cd8