### PR TITLE
ci: make on.push.tags value more precise for ./.github/workflows/release.yml job

### DIFF
--- a/.github/workflows/cargo-near-v-release.yml
+++ b/.github/workflows/cargo-near-v-release.yml
@@ -42,7 +42,7 @@ on:
   pull_request:
   push:
     tags:
-      - 'cargo-near-v[0-9]+.[0-9]+.[0-9]+*'
+      - 'cargo-near-v**[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ on:
   pull_request:
   push:
     tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
+      - 'cargo-near-v[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ lto = "thin"
 [workspace.metadata.dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
 cargo-dist-version = "0.28.0"
-# CI backends to support
+
+allow-dirty = ["ci"]# CI backends to support
+
 ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell", "npm", "msi"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ lto = "thin"
 [workspace.metadata.dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
 cargo-dist-version = "0.28.0"
-
-allow-dirty = ["ci"]# CI backends to support
-
+# A prefix git tags must include for dist to care about them
+tag-namespace = "cargo-near-v"
+# CI backends to support
 ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell", "npm", "msi"]


### PR DESCRIPTION
this is to avoid getting failed jobs of `cargo-dist` https://github.com/near/cargo-near/actions/runs/14329921815, 

triggered by tag for `cargo-near-build` created by `releaze-plz` job
https://github.com/near/cargo-near/actions/runs/14329795161/job/40162981199
![image](https://github.com/user-attachments/assets/f3817548-f315-4686-a49b-e323c56d83d9)

And removing tag creation completely for `cargo-near-build` isn't cool too, it's kind of nice to pinpoint `cargo-near-build` release version
