### PR TITLE
chore: release cargo-near 0.14.0, cargo-near-build 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0](https://github.com/near/cargo-near/compare/cargo-near-v0.13.6...cargo-near-v0.14.0) - 2025-04-21
+
+### Added
+
+- [**breaking**] pass in external nep330_wasm_output path from env as override ([#328](https://github.com/near/cargo-near/pull/328))
+- populate `output_wasm_path` into `ContractSourceMetadata` ([#323](https://github.com/near/cargo-near/pull/323))
+
+### Other
+
+- update `cargo near new` template `image` and `image_digest` ([#327](https://github.com/near/cargo-near/pull/327))
+
 ## [0.13.6](https://github.com/near/cargo-near/compare/cargo-near-v0.13.5...cargo-near-v0.13.6) - 2025-04-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.13.6"
+version = "0.14.0"
 dependencies = [
  "base64 0.22.1",
  "cargo-near-build",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near-build"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "bon",
  "bs58 0.5.1",

--- a/cargo-near-build/CHANGELOG.md
+++ b/cargo-near-build/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/near/cargo-near/compare/cargo-near-build-v0.4.6...cargo-near-build-v0.5.0) - 2025-04-21
+
+### Added
+
+- [**breaking**] pass in external nep330_wasm_output path from env as override ([#328](https://github.com/near/cargo-near/pull/328))
+- populate `output_wasm_path` into `ContractSourceMetadata` ([#323](https://github.com/near/cargo-near/pull/323))
+
 ## [0.4.6](https://github.com/near/cargo-near/compare/cargo-near-build-v0.4.5...cargo-near-build-v0.4.6) - 2025-04-08
 
 ### Added

--- a/cargo-near-build/Cargo.toml
+++ b/cargo-near-build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-near-build"
 edition = "2021"
-version = "0.4.6"
+version = "0.5.0"
 description = "Library for building Rust smart contracts on NEAR, basis of `cargo-near` crate/CLI"
 repository = "https://github.com/near/cargo-near"
 license = "MIT OR Apache-2.0"

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.13.6"
+version = "0.14.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.81.0"
@@ -23,7 +23,7 @@ license = false
 eula = false
 
 [dependencies]
-cargo-near-build = { version = "0.4.6", path = "../cargo-near-build", features = [
+cargo-near-build = { version = "0.5.0", path = "../cargo-near-build", features = [
     "abi_build",
     "docker",
 ] }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 const_format = "0.2"
 color-eyre = "0.6"
-cargo-near-build = { version = "0.4.6", path = "../cargo-near-build" }
+cargo-near-build = { version = "0.5.0", path = "../cargo-near-build" }
 cargo-near = { path = "../cargo-near" }
 colored = "2.0"
 tracing = "0.1.40"
@@ -18,7 +18,7 @@ syn = "2"
 borsh = { version = "1.0.0", features = ["derive", "unstable__schema"] }
 camino = "1.1.1"
 cargo-near = { path = "../cargo-near" }
-cargo-near-build = { version = "0.4.6", path = "../cargo-near-build", features = [
+cargo-near-build = { version = "0.5.0", path = "../cargo-near-build", features = [
     "test_code",
 ] }
 color-eyre = "0.6"


### PR DESCRIPTION



## 🤖 New release

* `cargo-near-build`: 0.4.6 -> 0.5.0 (⚠ API breaking changes)
* `cargo-near`: 0.13.6 -> 0.14.0 (✓ API compatible changes)

### ⚠ `cargo-near-build` breaking changes

```text
--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/feature_missing.ron

Failed in:
  feature build_script in the package's Cargo.toml

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/function_missing.ron

Failed in:
  function cargo_near_build::extended::build, previously in file /tmp/.tmp1ismMb/cargo-near-build/src/near/build_extended/mod.rs:25

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/function_parameter_count_changed.ron

Failed in:
  cargo_near_build::docker::build now takes 2 parameters instead of 1, in /tmp/.tmpEceL24/cargo-near/cargo-near-build/src/near/docker_build/mod.rs:16

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/struct_missing.ron

Failed in:
  struct cargo_near_build::extended::EnvPairs, previously in file /tmp/.tmp1ismMb/cargo-near-build/src/types/near/build_extended/build_script.rs:31
  struct cargo_near_build::extended::BuildScriptOpts, previously in file /tmp/.tmp1ismMb/cargo-near-build/src/types/near/build_extended/build_script.rs:2
  struct cargo_near_build::extended::BuildOptsExtended, previously in file /tmp/.tmp1ismMb/cargo-near-build/src/types/near/build_extended/mod.rs:7
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `cargo-near-build`

<blockquote>

## [0.5.0](https://github.com/near/cargo-near/compare/cargo-near-build-v0.4.6...cargo-near-build-v0.5.0) - 2025-04-21

### Added

- [**breaking**] pass in external nep330_wasm_output path from env as override ([#328](https://github.com/near/cargo-near/pull/328))
- populate `output_wasm_path` into `ContractSourceMetadata` ([#323](https://github.com/near/cargo-near/pull/323))
</blockquote>

## `cargo-near`

<blockquote>

## [0.14.0](https://github.com/near/cargo-near/compare/cargo-near-v0.13.6...cargo-near-v0.14.0) - 2025-04-21

### Added

- [**breaking**] pass in external nep330_wasm_output path from env as override ([#328](https://github.com/near/cargo-near/pull/328))
- populate `output_wasm_path` into `ContractSourceMetadata` ([#323](https://github.com/near/cargo-near/pull/323))

### Other

- update `cargo near new` template `image` and `image_digest` ([#327](https://github.com/near/cargo-near/pull/327))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).