### PR TITLE
fix: doc publish. Change reference to `latest` instead of specific version

### DIFF
--- a/cargo-near-build/Cargo.toml
+++ b/cargo-near-build/Cargo.toml
@@ -40,7 +40,7 @@ regex = "1.11.1"
 
 
 [package.metadata.docs.rs]
-features = ["build_script"]
+features = []
 targets = ["x86_64-unknown-linux-gnu"]
 
 [package.metadata.dist]

--- a/cargo-near-build/src/near/docker_build/warn_versions_upgrades.rs
+++ b/cargo-near-build/src/near/docker_build/warn_versions_upgrades.rs
@@ -167,7 +167,7 @@ mod output_wasm_path {
                 println!(
                     "{} {}",
                     "See examples at: ".yellow(),
-                    "https://docs.rs/cargo-near-build/0.5.0/cargo_near_build/extended/index.html"
+                    "https://docs.rs/cargo-near-build/latest/cargo_near_build/extended/index.html"
                         .cyan()
                 );
                 println!();


### PR DESCRIPTION
fixes https://docs.rs/crate/cargo-near-build/0.5.0/builds/2021086 
(`build_script` feature was removed in scope of #328 )