### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.2](https://github.com/near/cargo-near/compare/cargo-near-v0.14.1...cargo-near-v0.14.2) - 2025-05-03
+
+### Added
+
+- [cargo_near_build::build_with_cli] method in `build_external` default feature ([#333](https://github.com/near/cargo-near/pull/333))
+- [cargo_near_build::extended::build_with_cli] for build.rs of factories ([#334](https://github.com/near/cargo-near/pull/334))
+
+### Other
+
+- update `cargo near new` template `image` and `image_digest` ([#331](https://github.com/near/cargo-near/pull/331))
+
 ## [0.14.1](https://github.com/near/cargo-near/compare/cargo-near-v0.14.0...cargo-near-v0.14.1) - 2025-04-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "base64 0.22.1",
  "cargo-near-build",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near-build"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "bon",
  "bs58 0.5.1",

--- a/cargo-near-build/CHANGELOG.md
+++ b/cargo-near-build/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/near/cargo-near/compare/cargo-near-build-v0.5.1...cargo-near-build-v0.6.0) - 2025-05-03
+
+### Added
+
+- [cargo_near_build::extended::build_with_cli] for build.rs of factories ([#334](https://github.com/near/cargo-near/pull/334))
+- [cargo_near_build::build_with_cli] method in `build_external` default feature ([#333](https://github.com/near/cargo-near/pull/333))
+
 ## [0.5.1](https://github.com/near/cargo-near/compare/cargo-near-build-v0.5.0...cargo-near-build-v0.5.1) - 2025-04-21
 
 ### Fixed

--- a/cargo-near-build/Cargo.toml
+++ b/cargo-near-build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-near-build"
 edition = "2021"
-version = "0.5.1"
+version = "0.6.0"
 description = "Library for building Rust smart contracts on NEAR, basis of `cargo-near` crate/CLI"
 repository = "https://github.com/near/cargo-near"
 license = "MIT OR Apache-2.0"

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.14.1"
+version = "0.14.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.81.0"
@@ -23,7 +23,7 @@ license = false
 eula = false
 
 [dependencies]
-cargo-near-build = { version = "0.5.1", path = "../cargo-near-build", features = [
+cargo-near-build = { version = "0.6.0", path = "../cargo-near-build", features = [
     "build_internal",
     "docker",
 ] }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 const_format = "0.2"
 color-eyre = "0.6"
-cargo-near-build = { version = "0.5.1", path = "../cargo-near-build" }
+cargo-near-build = { version = "0.6.0", path = "../cargo-near-build" }
 cargo-near = { path = "../cargo-near" }
 colored = "2.0"
 tracing = "0.1.40"
@@ -18,7 +18,7 @@ syn = "2"
 borsh = { version = "1.0.0", features = ["derive", "unstable__schema"] }
 camino = "1.1.1"
 cargo-near = { path = "../cargo-near" }
-cargo-near-build = { version = "0.5.1", path = "../cargo-near-build", features = [
+cargo-near-build = { version = "0.6.0", path = "../cargo-near-build", features = [
     "test_code",
 ] }
 color-eyre = "0.6"


### PR DESCRIPTION



## 🤖 New release

* `cargo-near-build`: 0.5.1 -> 0.6.0 (⚠ API breaking changes)
* `cargo-near`: 0.14.1 -> 0.14.2 (✓ API compatible changes)

### ⚠ `cargo-near-build` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Opts.override_nep330_output_wasm_path in /tmp/.tmpxzoEcM/cargo-near/cargo-near-build/src/types/near/build/input/mod.rs:76

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_missing.ron

Failed in:
  enum cargo_near_build::BuildContext, previously in file /tmp/.tmpxW1jVS/cargo-near-build/src/types/near/build/input/mod.rs:6

--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/feature_missing.ron

Failed in:
  feature abi_build in the package's Cargo.toml
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `cargo-near-build`

<blockquote>

## [0.6.0](https://github.com/near/cargo-near/compare/cargo-near-build-v0.5.1...cargo-near-build-v0.6.0) - 2025-05-03

### Added

- [cargo_near_build::extended::build_with_cli] for build.rs of factories ([#334](https://github.com/near/cargo-near/pull/334))
- [cargo_near_build::build_with_cli] method in `build_external` default feature ([#333](https://github.com/near/cargo-near/pull/333))
</blockquote>

## `cargo-near`

<blockquote>

## [0.14.2](https://github.com/near/cargo-near/compare/cargo-near-v0.14.1...cargo-near-v0.14.2) - 2025-05-03

### Added

- [cargo_near_build::build_with_cli] method in `build_external` default feature ([#333](https://github.com/near/cargo-near/pull/333))
- [cargo_near_build::extended::build_with_cli] for build.rs of factories ([#334](https://github.com/near/cargo-near/pull/334))

### Other

- update `cargo near new` template `image` and `image_digest` ([#331](https://github.com/near/cargo-near/pull/331))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).