### PR TITLE
chore: release `cargo-near 0.15.0`, `cargo-near-build 0.7.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0](https://github.com/near/cargo-near/compare/cargo-near-v0.14.2...cargo-near-v0.15.0) - 2025-05-16
+
+### Other
+
+- updates near-* dependencies to 0.30 release ([#341](https://github.com/near/cargo-near/pull/341))
+- use 1.86.0 toolchain for contracts tests with live node ([#340](https://github.com/near/cargo-near/pull/340))
+- `cargo-near-build` crate badge + install cli in integration tests (for `test_cargo_test_on_generated_project`) ([#337](https://github.com/near/cargo-near/pull/337))
+- update `cargo near new` template `image` and `image_digest` ([#335](https://github.com/near/cargo-near/pull/335))
+
 ## [0.14.2](https://github.com/near/cargo-near/compare/cargo-near-v0.14.1...cargo-near-v0.14.2) - 2025-05-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "base64 0.22.1",
  "cargo-near-build",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near-build"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bon",
  "bs58 0.5.1",

--- a/cargo-near-build/CHANGELOG.md
+++ b/cargo-near-build/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/near/cargo-near/compare/cargo-near-build-v0.6.0...cargo-near-build-v0.7.0) - 2025-05-16
+
+### Other
+
+- use 1.86.0 toolchain for contracts tests with live node ([#340](https://github.com/near/cargo-near/pull/340))
+
 ## [0.6.0](https://github.com/near/cargo-near/compare/cargo-near-build-v0.5.1...cargo-near-build-v0.6.0) - 2025-05-03
 
 ### Added

--- a/cargo-near-build/Cargo.toml
+++ b/cargo-near-build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-near-build"
 edition = "2021"
-version = "0.6.0"
+version = "0.7.0"
 description = "Library for building Rust smart contracts on NEAR, basis of `cargo-near` crate/CLI"
 repository = "https://github.com/near/cargo-near"
 license = "MIT OR Apache-2.0"

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.14.2"
+version = "0.15.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.85.0"
@@ -23,7 +23,7 @@ license = false
 eula = false
 
 [dependencies]
-cargo-near-build = { version = "0.6.0", path = "../cargo-near-build", features = [
+cargo-near-build = { version = "0.7.0", path = "../cargo-near-build", features = [
     "build_internal",
     "docker",
 ] }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 const_format = "0.2"
 color-eyre = "0.6"
-cargo-near-build = { version = "0.6.0", path = "../cargo-near-build" }
+cargo-near-build = { version = "0.7.0", path = "../cargo-near-build" }
 cargo-near = { path = "../cargo-near" }
 colored = "2.0"
 tracing = "0.1.40"
@@ -18,7 +18,7 @@ syn = "2"
 borsh = { version = "1.0.0", features = ["derive", "unstable__schema"] }
 camino = "1.1.1"
 cargo-near = { path = "../cargo-near" }
-cargo-near-build = { version = "0.6.0", path = "../cargo-near-build", features = [
+cargo-near-build = { version = "0.7.0", path = "../cargo-near-build", features = [
     "test_code",
 ] }
 color-eyre = "0.6"


### PR DESCRIPTION



## 🤖 New release

* `cargo-near-build`: 0.6.0 -> 0.7.0 (⚠ API breaking changes)
* `cargo-near`: 0.14.2 -> 0.15.0 (⚠ API breaking changes)

### ⚠ `cargo-near-build` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Opts.override_toolchain in /tmp/.tmpy3xYMR/cargo-near/cargo-near-build/src/types/near/build/input/mod.rs:79

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/method_parameter_count_changed.ron

Failed in:
  cargo_near_build::CrateMetadata::collect now takes 4 parameters instead of 3, in /tmp/.tmpy3xYMR/cargo-near/cargo-near-build/src/types/cargo/metadata.rs:44
```

### ⚠ `cargo-near` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field InteractiveClapContextScopeForBuildOpts.override_toolchain in /tmp/.tmpy3xYMR/cargo-near/cargo-near/src/commands/build/actions/non_reproducible_wasm/mod.rs:3
  field BuildOpts.override_toolchain in /tmp/.tmpy3xYMR/cargo-near/cargo-near/src/commands/build/actions/non_reproducible_wasm/mod.rs:110
  field CliBuildOpts.override_toolchain in /tmp/.tmpy3xYMR/cargo-near/cargo-near/src/commands/build/actions/non_reproducible_wasm/mod.rs:3
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `cargo-near-build`

<blockquote>

## [0.7.0](https://github.com/near/cargo-near/compare/cargo-near-build-v0.6.0...cargo-near-build-v0.7.0) - 2025-05-16

### Other

- use 1.86.0 toolchain for contracts tests with live node ([#340](https://github.com/near/cargo-near/pull/340))
</blockquote>

## `cargo-near`

<blockquote>

## [0.15.0](https://github.com/near/cargo-near/compare/cargo-near-v0.14.2...cargo-near-v0.15.0) - 2025-05-16

### Other

- updates near-* dependencies to 0.30 release ([#341](https://github.com/near/cargo-near/pull/341))
- use 1.86.0 toolchain for contracts tests with live node ([#340](https://github.com/near/cargo-near/pull/340))
- `cargo-near-build` crate badge + install cli in integration tests (for `test_cargo_test_on_generated_project`) ([#337](https://github.com/near/cargo-near/pull/337))
- update `cargo near new` template `image` and `image_digest` ([#335](https://github.com/near/cargo-near/pull/335))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).