### PR TITLE
ci: `cargo-near-build` crate badge + install cli in integration tests (for `test_cargo_test_on_generated_project`)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,8 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install --assume-yes libudev-dev
 
+      - name: Install latest (released) cargo-near CLI (dependency of `cargo-near-integration-tests::cargo_near_new::test_cargo_test_on_generated_project`)
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/latest/download/cargo-near-installer.sh | sh
       - name: Run tests
         run: |
           git config --global user.email "nearprotocol-ci@near.org"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,7 +761,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1354,7 +1354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2215,7 +2215,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2422,7 +2422,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3080,9 +3080,9 @@ dependencies = [
 
 [[package]]
 name = "near-workspaces"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43e44fc77e3491076daaec62c9be3a1b4d63c299702569b5eca3dd2057f8330"
+checksum = "5eafc835a6ceb28f427ef7168986f70f07c3e235b45a9797802825f684fa6650"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3938,7 +3938,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3951,7 +3951,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4675,7 +4675,7 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix 0.38.44",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5475,7 +5475,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
     <a href="https://github.com/near/cargo-near/actions/workflows/test.yml?query=branch%3Amain"><img src="https://github.com/near/cargo-near/actions/workflows/test.yml/badge.svg" alt="Github CI Build" /></a>
     <a href="https://crates.io/crates/cargo-near"><img src="https://img.shields.io/crates/v/cargo-near.svg?style=flat-square" alt="Crates.io version" /></a>
     <a href="https://crates.io/crates/cargo-near"><img src="https://img.shields.io/crates/d/cargo-near.svg?style=flat-square" alt="Download" /></a>
+    <a href="https://crates.io/crates/cargo-near-build"><img src="https://img.shields.io/crates/v/cargo-near-build.svg?style=flat-square" alt="Crates.io version" /></a>
+
   </p>
 
 </div>

--- a/cargo-near/src/commands/new/new-project-template/.github/workflows/test.yml
+++ b/cargo-near/src/commands/new/new-project-template/.github/workflows/test.yml
@@ -28,5 +28,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Install cargo-near CLI
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-vcargo-near-new-ci-tool-version-self/cargo-near-installer.sh | sh
       - name: Run cargo test
         run: cargo test

--- a/cargo-near/src/commands/new/new-project-template/Cargo.template.toml
+++ b/cargo-near/src/commands/new/new-project-template/Cargo.template.toml
@@ -36,11 +36,11 @@ container_build_command = [
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-near-sdk = "5.12.0"
+near-sdk = "5.13.0"
 
 [dev-dependencies]
-near-sdk = { version = "5.12.0", features = ["unit-testing"] }
-near-workspaces = { version = "0.18", features = ["unstable"] }
+near-sdk = { version = "5.13.0", features = ["unit-testing"] }
+near-workspaces = { version = "0.19", features = ["unstable"] }
 tokio = { version = "1.12.0", features = ["full"] }
 serde_json = "1"
 

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -33,6 +33,6 @@ syn = "2"
 tempfile = "3.3"
 tokio = { version = "1.12.0", features = ["full"] }
 quote = "1.0"
-near-workspaces = "0.18"
+near-workspaces = "0.19"
 zstd = "0.13"
 toml = "0.8.19"

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -6,7 +6,7 @@ use cargo_near_build::camino;
 pub mod from_crates_io {
     use const_format::formatcp;
 
-    pub const SDK_VERSION: &str = "5.12.0";
+    pub const SDK_VERSION: &str = "5.13.0";
     pub const SDK_VERSION_TOML: &str = formatcp!(r#"version = "{SDK_VERSION}""#);
 }
 
@@ -18,8 +18,8 @@ pub fn setup_tracing() {
 pub mod from_git {
     use const_format::formatcp;
 
-    pub const SDK_VERSION: &str = "5.12.0";
-    pub const SDK_REVISION: &str = "2af331f4c5f7107e9199ac7715122c6eec42bb66";
+    pub const SDK_VERSION: &str = "5.13.0";
+    pub const SDK_REVISION: &str = "4e453178d1c640137665147ed82b5c400393d120";
     pub const SDK_SHORT_VERSION_TOML: &str = formatcp!(r#"version = "{SDK_VERSION}""#);
     pub const SDK_REPO: &str = "https://github.com/near/near-sdk-rs.git";
     pub const SDK_VERSION_TOML: &str =

--- a/integration-tests/tests/cargo_near_new.rs
+++ b/integration-tests/tests/cargo_near_new.rs
@@ -100,7 +100,7 @@ fn test_cargo_test_on_generated_project() -> Result<(), Box<dyn std::error::Erro
 /// differs from [test_cargo_test_on_generated_project] in the aspect, that current test
 /// uses [cargo_near_build::build] from current *cargo-near* branch, whereas
 /// [test_cargo_test_on_generated_project] uses [cargo_near_build::build] logic from
-/// latest published [near_workspaces::compile_project]  
+/// [near_workspaces::compile_project] corresponding to the template's project manifest
 #[tokio::test]
 async fn test_regular_build() -> Result<(), Box<dyn std::error::Error>> {
     setup_tracing();


### PR DESCRIPTION
after updating `near-workspaces` to 0.19 the ci of this project starts to depend on installing `cargo-near` for test job 
https://github.com/near/cargo-near/actions/runs/14865274164/job/41740403384, 
as `cargo-near-integration-tests::cargo_near_new::test_cargo_test_on_generated_project` tests an end-to-end scenario from an external user's point of view, who runs

```
cargo near new skeleton
cd skeleton
cargo test
```

---

this pr is better be merged before #338 to be able to release it separately (template update)