### PR TITLE
chore: update `near-cli` install in template workflows to 0.20.0; update `sign-with-plaintext-private-key` cli flag -> argument usage

### DIFF
--- a/cargo-near/src/commands/new/new-project-template/.github/workflows/deploy-production.yml
+++ b/cargo-near/src/commands/new/new-project-template/.github/workflows/deploy-production.yml
@@ -21,7 +21,5 @@ jobs:
           cargo near deploy build-reproducible-wasm "${{ vars.NEAR_CONTRACT_PRODUCTION_ACCOUNT_ID }}" \
             without-init-call \
             network-config "${{ vars.NEAR_CONTRACT_PRODUCTION_NETWORK }}" \
-            sign-with-plaintext-private-key \
-              --signer-public-key "${{ vars.NEAR_CONTRACT_PRODUCTION_ACCOUNT_PUBLIC_KEY }}" \
-              --signer-private-key "${{ secrets.NEAR_CONTRACT_PRODUCTION_ACCOUNT_PRIVATE_KEY }}" \
+            sign-with-plaintext-private-key "${{ secrets.NEAR_CONTRACT_PRODUCTION_ACCOUNT_PRIVATE_KEY }}" \
             send

--- a/cargo-near/src/commands/new/new-project-template/.github/workflows/deploy-staging.yml
+++ b/cargo-near/src/commands/new/new-project-template/.github/workflows/deploy-staging.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install near CLI
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/near-cli-rs/releases/download/v0.11.1/near-cli-rs-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/near-cli-rs/releases/download/v0.20.0/near-cli-rs-installer.sh | sh
       - name: Create staging account
         if: github.event.action == 'opened' || github.event.action == 'reopened'
         run: |
@@ -28,9 +28,7 @@ jobs:
             use-manually-provided-public-key "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_PUBLIC_KEY }}" \
             sign-as "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_ID }}" \
             network-config "${{ vars.NEAR_CONTRACT_STAGING_NETWORK }}" \
-            sign-with-plaintext-private-key \
-              --signer-public-key "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_PUBLIC_KEY }}" \
-              --signer-private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}" \
+            sign-with-plaintext-private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}" \
             send
 
       - name: Install cargo-near CLI
@@ -44,9 +42,7 @@ jobs:
           cargo near deploy build-reproducible-wasm --skip-git-remote-check "${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }}" \
             without-init-call \
             network-config "${{ vars.NEAR_CONTRACT_STAGING_NETWORK }}" \
-            sign-with-plaintext-private-key \
-              --signer-public-key "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_PUBLIC_KEY }}" \
-              --signer-private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}" \
+            sign-with-plaintext-private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}" \
             send
 
       - name: Comment on pull request

--- a/cargo-near/src/commands/new/new-project-template/.github/workflows/undeploy-staging.yml
+++ b/cargo-near/src/commands/new/new-project-template/.github/workflows/undeploy-staging.yml
@@ -13,13 +13,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install near CLI
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/near-cli-rs/releases/download/v0.11.1/near-cli-rs-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/near-cli-rs/releases/download/v0.20.0/near-cli-rs-installer.sh | sh
       - name: Remove staging account
         run: |
           near account delete-account "${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }}" \
             beneficiary "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_ID }}" \
             network-config "${{ vars.NEAR_CONTRACT_STAGING_NETWORK }}" \
-            sign-with-plaintext-private-key \
-              --signer-public-key "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_PUBLIC_KEY }}" \
-              --signer-private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}" \
+            sign-with-plaintext-private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}" \
             send

--- a/cargo-near/src/commands/new/new-project-template/rust-toolchain.toml
+++ b/cargo-near/src/commands/new/new-project-template/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.86.0"
-components = ["rustfmt"]
+components = ["rustfmt", "clippy", "rust-analyzer"]
 targets = ["wasm32-unknown-unknown"]

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -6,7 +6,6 @@ Example production account values:
 # variables
 NEAR_CONTRACT_PRODUCTION_ACCOUNT_ID=cargo_near_test_workflows.testnet
 NEAR_CONTRACT_PRODUCTION_NETWORK=testnet
-NEAR_CONTRACT_PRODUCTION_ACCOUNT_PUBLIC_KEY=ed25519:EvCRvguSjeaTGuzQPQmLg1GqWLqgihBKKcSHT4xtS8K
 # secrets
 NEAR_CONTRACT_PRODUCTION_ACCOUNT_PRIVATE_KEY=ed25519:4diBhcs9ECg3sDPE97gCFhHbB21BSRheWSzrqt1UVciEoMhpecnFjqapeSfrxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
@@ -23,3 +22,7 @@ NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY=ed25519:4diBhcs9ECg3sDPE97gCFhHbB21BSR
 ```
 
 NOTE: last chars of both private keys examples are redacted/replaced with `'x'` char. 
+
+**WARNING**: this simple setup isn't expected to work with pull requests
+from forks for deploy/undeploy to per-PR staging accounts, as workflows triggered by PRs from forks
+don't have access to forked repository's variables. 


### PR DESCRIPTION
This fixes template after a small breaking change in `near-cli-rs`, which has slipped in unnoticed. 

tested in 
- ok, deploy production in https://github.com/near/cargo-near-new-project-template/actions/runs/15110669333 after update in https://github.com/near/cargo-near-new-project-template/commit/c1b1d6dde10865e12bdb704dfae60cc0426b8a16
- fails, staging deploy from [pr](https://github.com/near/cargo-near-new-project-template/pull/20) from fork https://github.com/near/cargo-near-new-project-template/actions/runs/15112189405 (this fails as pr has no access to repository variables)
- ok, staging deploy from [pr](https://github.com/near/cargo-near-new-project-template/pull/21)  the same repo https://github.com/near/cargo-near-new-project-template/actions/runs/15112293518
- ok, staging undeploy https://github.com/near/cargo-near-new-project-template/actions/runs/15112581589 on closing [pr](https://github.com/near/cargo-near-new-project-template/pull/21) 