### PR TITLE
Minor contract template updates

### DIFF
--- a/cargo-near/src/commands/new/new-project-template/README.md
+++ b/cargo-near/src/commands/new/new-project-template/README.md
@@ -21,6 +21,12 @@ cargo test
 Deployment is automated with GitHub Actions CI/CD pipeline.
 To deploy manually, install [`cargo-near`](https://github.com/near/cargo-near) and run:
 
+If you deploy for debugging purposes:
+```bash
+cargo near deploy build-non-reproducible-wasm <account-id>
+```
+
+If you deploy production ready smart contract:
 ```bash
 cargo near deploy build-reproducible-wasm <account-id>
 ```

--- a/cargo-near/src/commands/new/new-project-template/tests/test_basics.rs
+++ b/cargo-near/src/commands/new/new-project-template/tests/test_basics.rs
@@ -8,5 +8,21 @@ async fn test_contract_is_operational() -> Result<(), Box<dyn std::error::Error>
     Ok(())
 }
 
-TEST_BASICS_ON_INCLUDE
+async fn test_basics_on(contract_wasm: &[u8]) -> Result<(), Box<dyn std::error::Error>> {
+    let sandbox = near_workspaces::sandbox().await?;
+    let contract = sandbox.dev_deploy(contract_wasm).await?;
 
+    let user_account = sandbox.dev_create_account().await?;
+
+    let outcome = user_account
+        .call(contract.id(), "set_greeting")
+        .args_json(json!({"greeting": "Hello World!"}))
+        .transact()
+        .await?;
+    assert!(outcome.is_success());
+
+    let user_message_outcome = contract.view("get_greeting").args_json(json!({})).await?;
+    assert_eq!(user_message_outcome.json::<String>()?, "Hello World!");
+
+    Ok(())
+}


### PR DESCRIPTION
1. README - added command to deploy non-reproducible build. I think it's useful because when people create a contract for the first time, they don't want to deal with immediate pushing code to the repository that's necessary while deploying a reproducible build

2. I'm not sure why there is a placeholder `TEST_BASICS_ON_INCLUDE` instead of test function, but we integrate this template to create-near-app module, and without test function the building process fails.