### PR TITLE
feat: halt wrong building

### DIFF
--- a/cargo-near/src/commands/new/mod.rs
+++ b/cargo-near/src/commands/new/mod.rs
@@ -213,6 +213,10 @@ const NEW_PROJECT_FILES: &[NewProjectFile] = &[
         content: include_str!("new-project-template/Cargo.template.toml"),
     },
     NewProjectFile {
+        file_path: "build.rs",
+        content: include_str!("new-project-template/build.rs"),
+    },
+    NewProjectFile {
         file_path: "README.md",
         content: include_str!("new-project-template/README.md"),
     },

--- a/cargo-near/src/commands/new/new-project-template/Cargo.template.toml
+++ b/cargo-near/src/commands/new/new-project-template/Cargo.template.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cargo-near-new-project-name"
+build = "build.rs"
 description = "cargo-near-new-project-description"
 version = "0.1.0"
 edition = "2021"

--- a/cargo-near/src/commands/new/new-project-template/build.rs
+++ b/cargo-near/src/commands/new/new-project-template/build.rs
@@ -1,0 +1,16 @@
+fn main() {
+    // Only show the warning if we're not using cargo-near (cargo-near sets the env var)
+    let using_cargo_near = std::env::var("CARGO_NEAR").is_ok();
+
+    if !using_cargo_near {
+        println!("");
+        println!("\x1b[1;33m>> ⚠️  Please build using `cargo near build` instead << \n\x1b[0m");
+        println!("- \x1b[1;32mInstall\x1b[0m cargo NEAR (https://github.com/near/cargo-near)");
+        println!("- \x1b[1;34mBuild\x1b[0m your contract with `\x1b[1;37mcargo near build\x1b[0m`");
+        println!("- Deploy your contract with `cargo near deploy`");
+        println!("");
+
+        // exit with an error code
+        std::process::exit(1);
+    }
+}


### PR DESCRIPTION
Currently contracts need to be compiled using `cargo near build`, since using `cargo build` will end up in a built contract that cannot be used

This PR adds a `build.rs` file that forces users to use `cargo near build`, and configures `cargo near` to set a unique `ENVIRONMENTAL VARIABLE` when building