### PR TITLE
feat: Added instructions for users on compiling the project on unsupported versions of Rust.

### DIFF
--- a/cargo-near-build/src/near/build/mod.rs
+++ b/cargo-near-build/src/near/build/mod.rs
@@ -18,7 +18,7 @@ use crate::{
 
 use super::abi;
 
-fn warning_unsupported_toolchain(rustc_version: &rustc_version::Version) {
+fn checking_unsupported_toolchain(rustc_version: &rustc_version::Version) -> eyre::Result<()> {
     if *rustc_version >= MIN_VERSION_WITH_BULK_MEMORY_NTRAPPING_FLOAT_TO_INT {
         println!(
             "{}: {} {} {}",
@@ -29,16 +29,25 @@ fn warning_unsupported_toolchain(rustc_version: &rustc_version::Version) {
                 .cyan(),
             "or newer rust toolchain is currently not compatible with nearcore VM".yellow()
         );
+        let info_str = format!(
+            "Step 1 - Set the Specific Rust Version for Your Project:\n{}Step 2 - Install the wasm32-unknown-unknown Target:\n{}",
+            pretty_print::indent_payload(
+                "cd /path/to/your/contract/project\nrustup override set 1.86"
+            ),
+            pretty_print::indent_payload("rustup target add wasm32-unknown-unknown")
+        );
         println!(
-            "{}: {} {} {}",
+            "{}: {} {} {}\n{}",
             "WARNING".red(),
             "please downgrade to".yellow(),
             MAX_VERSION_NO_BULK_MEMORY.to_string().cyan(),
-            "toolchain for compiling contracts".yellow()
+            "toolchain for compiling contracts:".yellow(),
+            pretty_print::indent_payload(&info_str)
         );
 
-        std::thread::sleep(std::time::Duration::new(15, 0));
+        eyre::bail!("wasm, compiled with {MIN_VERSION_WITH_BULK_MEMORY_NTRAPPING_FLOAT_TO_INT} or newer rust toolchain is currently not compatible with nearcore VM");
     }
+    Ok(())
 }
 
 /// builds a contract whose crate root is current workdir, or identified by [`Cargo.toml`/BuildOpts::manifest_path](crate::BuildOpts::manifest_path) location
@@ -47,7 +56,9 @@ pub fn run(args: Opts) -> eyre::Result<CompilationArtifact> {
 
     let rustc_version = version_meta_with_override(args.override_toolchain.clone())?.semver;
 
-    warning_unsupported_toolchain(&rustc_version);
+    if !args.skip_rust_version_check {
+        checking_unsupported_toolchain(&rustc_version)?;
+    }
 
     let override_cargo_target_path_env =
         common_buildtime_env::CargoTargetDir::new(args.override_cargo_target_dir.clone());

--- a/cargo-near-build/src/types/near/build/input/mod.rs
+++ b/cargo-near-build/src/types/near/build/input/mod.rs
@@ -77,6 +77,9 @@ pub struct Opts {
     /// override value of [`crate::env_keys::RUSTUP_TOOLCHAIN`] environment variable, used for all invoked `rustc`, `cargo` and `rustup` commands
     #[builder(into)]
     pub override_toolchain: Option<String>,
+    /// Disable Rust version checking
+    #[builder(default)]
+    pub skip_rust_version_check: bool,
 }
 
 /// used as field in [`BuildOpts`](crate::BuildOpts)

--- a/cargo-near/src/commands/build/actions/non_reproducible_wasm/mod.rs
+++ b/cargo-near/src/commands/build/actions/non_reproducible_wasm/mod.rs
@@ -108,6 +108,9 @@ pub struct BuildOpts {
     #[interactive_clap(long)]
     #[interactive_clap(skip_interactive_input)]
     pub override_toolchain: Option<String>,
+    /// Skip Rust version check
+    #[interactive_clap(long)]
+    pub skip_rust_version_check: bool,
 }
 
 impl From<CliBuildOpts> for BuildOpts {
@@ -126,6 +129,7 @@ impl From<CliBuildOpts> for BuildOpts {
             color: value.color,
             env: value.env,
             override_toolchain: value.override_toolchain,
+            skip_rust_version_check: value.skip_rust_version_check,
         }
     }
 }
@@ -154,6 +158,7 @@ pub mod context {
                 manifest_path: scope.manifest_path.clone(),
                 color: scope.color.clone(),
                 override_toolchain: scope.override_toolchain.clone(),
+                skip_rust_version_check: scope.skip_rust_version_check,
             };
             super::run(opts)?;
             Ok(Self)
@@ -181,6 +186,7 @@ impl From<BuildOpts> for cargo_near_build::BuildOpts {
             override_cargo_target_dir: None,
             override_nep330_output_wasm_path: None,
             override_toolchain: value.override_toolchain,
+            skip_rust_version_check: value.skip_rust_version_check,
         }
     }
 }


### PR DESCRIPTION
Currently, Wasm compiled with version 1.87.0 or later is not compatible with NearCore VM.
Added instructions for downgrading to version 1.86.0 in the contract compilation toolkit.
Added a separate flag  `--skip-rust-version-check` to allow skipping this check.