### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0](https://github.com/near/cargo-near/compare/cargo-near-v0.16.2...cargo-near-v0.17.0) - 2025-09-14
+
+### Added
+
+- support `--profile` flag ([#362](https://github.com/near/cargo-near/pull/362))
+
+### Other
+
+- update `cargo near new` template `image` and `image_digest` ([#359](https://github.com/near/cargo-near/pull/359))
+
 ## [0.16.2](https://github.com/near/cargo-near/compare/cargo-near-v0.16.1...cargo-near-v0.16.2) - 2025-08-31
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "base64 0.22.1",
  "cargo-near-build",
@@ -510,7 +510,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near-build"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bon",
  "bs58 0.5.1",

--- a/cargo-near-build/CHANGELOG.md
+++ b/cargo-near-build/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/near/cargo-near/compare/cargo-near-build-v0.8.0...cargo-near-build-v0.9.0) - 2025-09-14
+
+### Added
+
+- support `--profile` flag ([#362](https://github.com/near/cargo-near/pull/362))
+
 ## [0.8.0](https://github.com/near/cargo-near/compare/cargo-near-build-v0.7.2...cargo-near-build-v0.8.0) - 2025-08-31
 
 ### Added

--- a/cargo-near-build/Cargo.toml
+++ b/cargo-near-build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-near-build"
 edition = "2021"
-version = "0.8.0"
+version = "0.9.0"
 description = "Library for building Rust smart contracts on NEAR, basis of `cargo-near` crate/CLI"
 repository = "https://github.com/near/cargo-near"
 license = "MIT OR Apache-2.0"

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.16.2"
+version = "0.17.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.86.0"
@@ -23,7 +23,7 @@ license = false
 eula = false
 
 [dependencies]
-cargo-near-build = { version = "0.8.0", path = "../cargo-near-build", features = [
+cargo-near-build = { version = "0.9.0", path = "../cargo-near-build", features = [
     "build_internal",
     "docker",
 ] }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 const_format = "0.2"
 color-eyre = "0.6"
-cargo-near-build = { version = "0.8.0", path = "../cargo-near-build" }
+cargo-near-build = { version = "0.9.0", path = "../cargo-near-build" }
 cargo-near = { path = "../cargo-near" }
 colored = "2.0"
 tracing = "0.1.40"
@@ -18,7 +18,7 @@ syn = "2"
 borsh = { version = "1.0.0", features = ["derive", "unstable__schema"] }
 camino = "1.1.1"
 cargo-near = { path = "../cargo-near" }
-cargo-near-build = { version = "0.8.0", path = "../cargo-near-build", features = [
+cargo-near-build = { version = "0.9.0", path = "../cargo-near-build", features = [
     "test_code",
 ] }
 color-eyre = "0.6"


### PR DESCRIPTION



## 🤖 New release

* `cargo-near-build`: 0.8.0 -> 0.9.0 (⚠ API breaking changes)
* `cargo-near`: 0.16.2 -> 0.17.0 (⚠ API breaking changes)

### ⚠ `cargo-near-build` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Opts.profile in /tmp/.tmppdQvJS/cargo-near/cargo-near-build/src/types/near/build/input/mod.rs:27
```

### ⚠ `cargo-near` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field InteractiveClapContextScopeForBuildOpts.profile in /tmp/.tmppdQvJS/cargo-near/cargo-near/src/commands/build/actions/non_reproducible_wasm/mod.rs:3
  field InteractiveClapContextScopeForBuildOpts.profile in /tmp/.tmppdQvJS/cargo-near/cargo-near/src/commands/build/actions/reproducible_wasm/mod.rs:6
  field BuildOpts.profile in /tmp/.tmppdQvJS/cargo-near/cargo-near/src/commands/build/actions/reproducible_wasm/mod.rs:27
  field CliBuildOpts.profile in /tmp/.tmppdQvJS/cargo-near/cargo-near/src/commands/build/actions/non_reproducible_wasm/mod.rs:3
  field CliBuildOpts.profile in /tmp/.tmppdQvJS/cargo-near/cargo-near/src/commands/build/actions/reproducible_wasm/mod.rs:6
  field BuildOpts.profile in /tmp/.tmppdQvJS/cargo-near/cargo-near/src/commands/build/actions/non_reproducible_wasm/mod.rs:30
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `cargo-near-build`

<blockquote>

## [0.9.0](https://github.com/near/cargo-near/compare/cargo-near-build-v0.8.0...cargo-near-build-v0.9.0) - 2025-09-14

### Added

- support `--profile` flag ([#362](https://github.com/near/cargo-near/pull/362))
</blockquote>

## `cargo-near`

<blockquote>

## [0.17.0](https://github.com/near/cargo-near/compare/cargo-near-v0.16.2...cargo-near-v0.17.0) - 2025-09-14

### Added

- support `--profile` flag ([#362](https://github.com/near/cargo-near/pull/362))

### Other

- update `cargo near new` template `image` and `image_digest` ([#359](https://github.com/near/cargo-near/pull/359))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).