### PR TITLE
chore: added DevEx to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dj8yfo @FroVolod @akorchyn @PolyProgrammist @frol
+* @near/devex


### PR DESCRIPTION
This PR updates the `CODEOWNERS` file to reflect the maintenance structure moving forward: https://github.com/near/devex/issues/7