### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.1](https://github.com/near/cargo-near/compare/cargo-near-v0.19.0...cargo-near-v0.19.1) - 2026-02-03
+
+### Fixed
+
+- use profile flag for get_cli_command_for_lib_context ([#393](https://github.com/near/cargo-near/pull/393))
+- toolchain version detection and ensure consistent toolchain usage across build operations ([#383](https://github.com/near/cargo-near/pull/383))
+
+### Other
+
+- update workspace and project template to Rust edition 2024 ([#394](https://github.com/near/cargo-near/pull/394))
+- update `cargo near new` template `image` and `image_digest` ([#389](https://github.com/near/cargo-near/pull/389))
+
 ## [0.19.0](https://github.com/near/cargo-near/compare/cargo-near-v0.18.0...cargo-near-v0.19.0) - 2026-01-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "base64 0.22.1",
  "cargo-near-build",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near-build"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bon",
  "bs58 0.5.1",

--- a/cargo-near-build/CHANGELOG.md
+++ b/cargo-near-build/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1](https://github.com/near/cargo-near/compare/cargo-near-build-v0.11.0...cargo-near-build-v0.11.1) - 2026-02-03
+
+### Fixed
+
+- use profile flag for get_cli_command_for_lib_context ([#393](https://github.com/near/cargo-near/pull/393))
+- toolchain version detection and ensure consistent toolchain usage across build operations ([#383](https://github.com/near/cargo-near/pull/383))
+
+### Other
+
+- update workspace and project template to Rust edition 2024 ([#394](https://github.com/near/cargo-near/pull/394))
+
 ## [0.11.0](https://github.com/near/cargo-near/compare/cargo-near-build-v0.10.0...cargo-near-build-v0.11.0) - 2026-01-12
 
 ### Added

--- a/cargo-near-build/Cargo.toml
+++ b/cargo-near-build/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-near-build"
 edition.workspace = true
 rust-version = "1.86"
-version = "0.11.0"
+version = "0.11.1"
 description = "Library for building Rust smart contracts on NEAR, basis of `cargo-near` crate/CLI"
 repository = "https://github.com/near/cargo-near"
 license = "MIT OR Apache-2.0"

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition.workspace = true
 rust-version = "1.87.0"
@@ -23,7 +23,7 @@ license = false
 eula = false
 
 [dependencies]
-cargo-near-build = { version = "0.11.0", path = "../cargo-near-build", features = [
+cargo-near-build = { version = "0.11.1", path = "../cargo-near-build", features = [
     "build_internal",
     "docker",
 ] }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 const_format = "0.2"
-cargo-near-build = { version = "0.11.0", path = "../cargo-near-build" }
+cargo-near-build = { version = "0.11.1", path = "../cargo-near-build" }
 cargo-near = { path = "../cargo-near", default-features = false }
 tracing = "0.1.40"
 prettyplease = "0.2"
@@ -15,7 +15,7 @@ syn = "2"
 [dev-dependencies]
 borsh = { version = "1.0.0", features = ["derive", "unstable__schema"] }
 camino = "1.1.1"
-cargo-near-build = { version = "0.11.0", path = "../cargo-near-build", features = [
+cargo-near-build = { version = "0.11.1", path = "../cargo-near-build", features = [
     "test_code",
 ] }
 near-api = "0.8"


### PR DESCRIPTION



## 🤖 New release

* `cargo-near-build`: 0.11.0 -> 0.11.1 (✓ API compatible changes)
* `cargo-near`: 0.19.0 -> 0.19.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `cargo-near-build`

<blockquote>

## [0.11.1](https://github.com/near/cargo-near/compare/cargo-near-build-v0.11.0...cargo-near-build-v0.11.1) - 2026-02-03

### Fixed

- use profile flag for get_cli_command_for_lib_context ([#393](https://github.com/near/cargo-near/pull/393))
- toolchain version detection and ensure consistent toolchain usage across build operations ([#383](https://github.com/near/cargo-near/pull/383))

### Other

- update workspace and project template to Rust edition 2024 ([#394](https://github.com/near/cargo-near/pull/394))
</blockquote>

## `cargo-near`

<blockquote>

## [0.19.1](https://github.com/near/cargo-near/compare/cargo-near-v0.19.0...cargo-near-v0.19.1) - 2026-02-03

### Fixed

- use profile flag for get_cli_command_for_lib_context ([#393](https://github.com/near/cargo-near/pull/393))
- toolchain version detection and ensure consistent toolchain usage across build operations ([#383](https://github.com/near/cargo-near/pull/383))

### Other

- update workspace and project template to Rust edition 2024 ([#394](https://github.com/near/cargo-near/pull/394))
- update `cargo near new` template `image` and `image_digest` ([#389](https://github.com/near/cargo-near/pull/389))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).