### PR TITLE
fix: pin time dependency to avoid MSRV mismatch in new projects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,9 +421,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytesize"

--- a/cargo-near/src/commands/new/new-project-template/Cargo.template.toml
+++ b/cargo-near/src/commands/new/new-project-template/Cargo.template.toml
@@ -39,7 +39,7 @@ container_build_command = [
 near-sdk = "5.23"
 # Pin: time 0.3.46+ requires rustc 1.88.0, but wasm built with rustc 1.87.0+
 # is incompatible with nearcore VM. Pin to last 1.86.0-compatible version.
-time = "<=0.3.45"
+time = ">=0.3.37, <=0.3.45"
 
 [dev-dependencies]
 near-sdk = { version = "5.23", features = ["unit-testing"] }


### PR DESCRIPTION
## Summary

Hotfix for new projects created with `cargo near new` failing `cargo test` due to MSRV mismatch.

## Problem

- `time@0.3.46` requires rustc 1.88.0
- New projects pin rustc to 1.86.0 via `rust-toolchain.toml`
- WASM compiled with rustc 1.87.0+ is incompatible with nearcore VM

## Solution

Pin `time` to `<=0.3.45` in the new project template, which is the last version compatible with rustc 1.86.0.

## Note

This is a minimal hotfix. PR #394 provides a more comprehensive solution using Rust edition 2024 with MSRV-aware dependency resolution, which handles this and future MSRV conflicts automatically.

Fixes near/near-sdk-rs#1481