### PR TITLE
fix: migrate integration test templates to edition 2024

### DIFF
--- a/integration-tests/templates/_Cargo.toml
+++ b/integration-tests/templates/_Cargo.toml
@@ -1,8 +1,7 @@
 [package]
 name = "::name::"
 version = "0.1.0"
-edition = "2021"
-resolver = "3"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/integration-tests/templates/abi/_Cargo_features.toml
+++ b/integration-tests/templates/abi/_Cargo_features.toml
@@ -1,8 +1,7 @@
 [package]
 name = "::name::"
 version = "0.1.0"
-edition = "2021"
-resolver = "3"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/integration-tests/templates/negative/_Cargo_malformed.toml
+++ b/integration-tests/templates/negative/_Cargo_malformed.toml
@@ -1,7 +1,7 @@
 [package]
 name = "::name::"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/integration-tests/templates/negative/_Cargo_old_sdk.toml
+++ b/integration-tests/templates/negative/_Cargo_old_sdk.toml
@@ -1,7 +1,7 @@
 [package]
 name = "::name::"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/integration-tests/templates/sdk-dependency/_Cargo_explicit.toml
+++ b/integration-tests/templates/sdk-dependency/_Cargo_explicit.toml
@@ -1,7 +1,7 @@
 [package]
 name = "::name::"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/integration-tests/templates/sdk-dependency/_Cargo_local_path.toml
+++ b/integration-tests/templates/sdk-dependency/_Cargo_local_path.toml
@@ -1,7 +1,7 @@
 [package]
 name = "::name::"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/integration-tests/templates/sdk-dependency/_Cargo_local_path_with_version.toml
+++ b/integration-tests/templates/sdk-dependency/_Cargo_local_path_with_version.toml
@@ -1,7 +1,7 @@
 [package]
 name = "::name::"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/integration-tests/templates/sdk-dependency/_Cargo_multiple_features.toml
+++ b/integration-tests/templates/sdk-dependency/_Cargo_multiple_features.toml
@@ -1,7 +1,7 @@
 [package]
 name = "::name::"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/integration-tests/templates/sdk-dependency/_Cargo_no_default_features.toml
+++ b/integration-tests/templates/sdk-dependency/_Cargo_no_default_features.toml
@@ -1,7 +1,7 @@
 [package]
 name = "::name::"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/integration-tests/templates/sdk-dependency/_Cargo_not_a_table.toml
+++ b/integration-tests/templates/sdk-dependency/_Cargo_not_a_table.toml
@@ -1,7 +1,7 @@
 [package]
 name = "::name::"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/integration-tests/templates/sdk-dependency/_Cargo_patch.toml
+++ b/integration-tests/templates/sdk-dependency/_Cargo_patch.toml
@@ -1,7 +1,7 @@
 [package]
 name = "::name::"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/integration-tests/templates/sdk-dependency/_Cargo_platform_specific.toml
+++ b/integration-tests/templates/sdk-dependency/_Cargo_platform_specific.toml
@@ -1,7 +1,7 @@
 [package]
 name = "::name::"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/integration-tests/templates/sdk-dependency/_Cargo_renamed.toml
+++ b/integration-tests/templates/sdk-dependency/_Cargo_renamed.toml
@@ -1,7 +1,7 @@
 [package]
 name = "::name::"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
## Summary

- PR #405 added `edition = "2024"` to the main project template but missed the integration test templates, causing test failures with rustc 1.86.0.
- Instead of just adding `resolver = "3"` (which edition 2024 implies by default), this migrates all integration test templates from edition 2021 to 2024 — consistent with the root `Cargo.toml` and the `cargo near new` project template.

## Test plan

- [x] CI passes: tests, MSRV check, lint, builds all green