### PR TITLE
ci: trusted publishing to crates.io via release-plz + OIDC

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,31 +1,78 @@
 name: Release-plz
 
-permissions:
-  pull-requests: write
-  contents: write
-
 on:
   push:
     branches:
       - main
 
+permissions: {}
+
 jobs:
-  release-plz:
-    name: Release-plz
+  release-plz-pr:
+    name: Release-plz PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-pr-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: recursive
-          token: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
-      - name: Install packages (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install --assume-yes libudev-dev
-      - name: Run release-plz
-        uses: MarcoIeni/release-plz-action@v0.5
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz (release-pr)
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
         env:
-          # https://release-plz.ieni.dev/docs/github/trigger
+          # Uses a PAT (not the default GITHUB_TOKEN) so the release PR
+          # triggers required status checks on push/PR events.
           GITHUB_TOKEN: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+      id-token: write
+      attestations: write
+    # Never cancel an in-flight publish — half-published releases are worse than waiting.
+    concurrency:
+      group: release-plz-release-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install packages (Linux)
+        run: sudo apt-get update && sudo apt-get install --assume-yes libudev-dev
+      - name: Run release-plz (release)
+        id: release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # release-plz doesn't expose the produced .crate paths, so re-package locally.
+      # The crate tarballs are reproducible from the same commit, so the attestations
+      # still bind the published artifacts to this run. Packages publishable members
+      # explicitly (excludes integration-tests which is publish = false).
+      - name: Re-package crates for attestation
+        if: steps.release-plz.outputs.releases_created == 'true'
+        run: cargo package --no-verify -p cargo-near -p cargo-near-build
+      - name: Attest build provenance
+        if: steps.release-plz.outputs.releases_created == 'true'
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: target/package/*.crate

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -62,7 +62,12 @@ jobs:
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Uses a PAT so that tags pushed by release-plz trigger the
+          # cargo-near-v-release.yml binary release workflow (downstream
+          # workflows don't fire when triggered by the default GITHUB_TOKEN).
+          # OIDC handles the actual crates.io publish; the PAT only covers
+          # the git tag push and GitHub Release creation.
+          GITHUB_TOKEN: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
 
       # release-plz doesn't expose the produced .crate paths, so re-package locally.
       # The crate tarballs are reproducible from the same commit, so the attestations

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -8,70 +8,15 @@ on:
 permissions: {}
 
 jobs:
-  release-plz-pr:
-    name: Release-plz PR
-    runs-on: ubuntu-latest
+  release:
+    uses: near/shared-workflows/.github/workflows/release-plz.yml@v1
     permissions:
       contents: write
       pull-requests: write
-    concurrency:
-      group: release-plz-pr-${{ github.ref }}
-      cancel-in-progress: true
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: Run release-plz (release-pr)
-        uses: release-plz/action@v0.5
-        with:
-          command: release-pr
-        env:
-          # Uses a PAT (not the default GITHUB_TOKEN) so the release PR
-          # triggers required status checks on push/PR events.
-          GITHUB_TOKEN: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
-
-  release-plz-release:
-    name: Release-plz release
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: read
       id-token: write
       attestations: write
-    # Never cancel an in-flight publish — half-published releases are worse than waiting.
-    concurrency:
-      group: release-plz-release-${{ github.ref }}
-      cancel-in-progress: false
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: Install packages (Linux)
-        run: sudo apt-get update && sudo apt-get install --assume-yes libudev-dev
-      - name: Run release-plz (release)
-        id: release-plz
-        uses: release-plz/action@v0.5
-        with:
-          command: release
-        env:
-          # Uses a PAT so that tags pushed by release-plz trigger the
-          # cargo-near-v-release.yml binary release workflow (downstream
-          # workflows don't fire when triggered by the default GITHUB_TOKEN).
-          # OIDC handles the actual crates.io publish; the PAT only covers
-          # the git tag push and GitHub Release creation.
-          GITHUB_TOKEN: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
-
-      # Attest the archives produced by cargo publish.
-      - name: Attest build provenance
-        if: steps.release-plz.outputs.releases_created == 'true'
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-path: target/package/**/*.crate
+    with:
+      apt-packages: libudev-dev
+    secrets:
+      pr-token: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
+      release-token: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -74,4 +74,4 @@ jobs:
         if: steps.release-plz.outputs.releases_created == 'true'
         uses: actions/attest-build-provenance@v1
         with:
-          subject-path: target/package/*.crate
+          subject-path: target/package/**/*.crate

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -8,15 +8,70 @@ on:
 permissions: {}
 
 jobs:
-  release:
-    uses: near/shared-workflows/.github/workflows/release-plz.yml@v1
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
+    concurrency:
+      group: release-plz-pr-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Run release-plz (release-pr)
+        uses: near/shared-workflows/release-plz@main
+        with:
+          command: release-pr
+          crate-toolchain-version: stable
+          crate-build-target-arch: x86_64-unknown-linux-gnu
+        env:
+          # Uses a PAT (not the default GITHUB_TOKEN) so the release PR
+          # triggers required status checks on push/PR events.
+          GITHUB_TOKEN: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
+
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
       id-token: write
       attestations: write
-    with:
-      apt-packages: libudev-dev
-    secrets:
-      pr-token: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
-      release-token: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
+    # Never cancel an in-flight publish — half-published releases are worse than waiting.
+    concurrency:
+      group: release-plz-release-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install packages (Linux)
+        run: sudo apt-get update && sudo apt-get install --assume-yes libudev-dev
+      - name: Run release-plz (release)
+        id: release-plz
+        uses: near/shared-workflows/release-plz@main
+        with:
+          command: release
+          crate-toolchain-version: stable
+          crate-build-target-arch: x86_64-unknown-linux-gnu
+        env:
+          # Uses a PAT so that tags pushed by release-plz trigger the
+          # cargo-near-v-release.yml binary release workflow (downstream
+          # workflows don't fire when triggered by the default GITHUB_TOKEN).
+          # OIDC handles the actual crates.io publish; the PAT only covers
+          # the git tag push and GitHub Release creation.
+          GITHUB_TOKEN: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
+
+      # Attest the archives produced by cargo publish.
+      - name: Attest build provenance
+        if: steps.release-plz.outputs.releases_created == 'true'
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: target/package/**/*.crate

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -35,8 +35,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
 
   release-plz-release:
-    env:
-      CARGO_TARGET_DIR: ${{ github.workspace }}/target
     name: Release-plz release
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -27,8 +27,6 @@ jobs:
         uses: near/shared-workflows/release-plz@main
         with:
           command: release-pr
-          crate-toolchain-version: stable
-          crate-build-target-arch: x86_64-unknown-linux-gnu
         env:
           # Uses a PAT (not the default GITHUB_TOKEN) so the release PR
           # triggers required status checks on push/PR events.
@@ -59,8 +57,6 @@ jobs:
         uses: near/shared-workflows/release-plz@main
         with:
           command: release
-          crate-toolchain-version: stable
-          crate-build-target-arch: x86_64-unknown-linux-gnu
         env:
           # Uses a PAT so that tags pushed by release-plz trigger the
           # cargo-near-v-release.yml binary release workflow (downstream

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,17 +28,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,7 +87,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -109,7 +98,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -385,28 +374,6 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
-
-[[package]]
-name = "bytecheck"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "byteorder"
@@ -748,7 +715,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1332,7 +1299,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1499,7 +1466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1889,9 +1856,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1911,9 +1878,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2395,7 +2359,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2857,7 +2821,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3559,7 +3523,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3984,26 +3948,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4265,15 +4209,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
-name = "rend"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4373,46 +4308,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "rkyv"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
-dependencies = [
- "bitvec",
- "bytecheck",
- "bytes",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "rust_decimal"
-version = "1.42.1"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
+checksum = "7653272e75dcac41dc199fbea6f5797633994fafd339943c06c9af16bf29cd3a"
 dependencies = [
  "arrayvec",
  "borsh",
  "bytes",
  "num-traits",
  "rand 0.8.6",
- "rkyv",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "wasm-bindgen",
@@ -4449,7 +4355,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4508,7 +4414,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4644,12 +4550,6 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
-
-[[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "secp256k1"
@@ -5117,7 +5017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5362,7 +5262,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6302,7 +6202,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Use the shared Release-plz action with default inputs for trusted publishing and attestations. Keep only repository-specific release configuration.
