### PR TITLE
feat: inject `--cfg near` into wasm build by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ RUSTFLAGS="your_custom_value" cargo near build non-reproducible-wasm
 ```
 won't result in `"your_custom_value"` affecting the build.
 
-`RUSTFLAGS="-Awarnings"` is always used for abi build stage, and `RUSTFLAGS="-C link-arg=-s"` for wasm build stage.
+`RUSTFLAGS="-Awarnings"` is always used for abi build stage, and `RUSTFLAGS="-C link-arg=-s --cfg near"` for wasm build stage. The `--cfg near` flag is read by `near-sdk` (5.27+) to select the on-chain host-function path; see [near/near-sdk-rs#1534](https://github.com/near/near-sdk-rs/pull/1534).
 
 Logic for concatenating default values of this variable with values from env was removed in `cargo-near-0.13.3`/`cargo-near-build-0.4.3`, as it was seen as
 an unnecessary complication.
@@ -275,7 +275,7 @@ There's still a way to override this parameter for wasm build stage, e.g.:
 
 ```lang
 cargo near build non-reproducible-wasm --env 'RUSTFLAGS=--verbose'
-RUST_LOG=info cargo near build non-reproducible-wasm --env 'RUSTFLAGS=--verbose -C link-arg=-s'
+RUST_LOG=info cargo near build non-reproducible-wasm --env 'RUSTFLAGS=--verbose -C link-arg=-s --cfg near'
 ```
 
 ### `CARGO_ENCODED_RUSTFLAGS`

--- a/README.md
+++ b/README.md
@@ -266,17 +266,25 @@ RUSTFLAGS="your_custom_value" cargo near build non-reproducible-wasm
 ```
 won't result in `"your_custom_value"` affecting the build.
 
-`RUSTFLAGS="-Awarnings"` is always used for abi build stage, and `RUSTFLAGS="-C link-arg=-s --cfg near"` for wasm build stage. The `--cfg near` flag is read by `near-sdk` (5.27+) to select the on-chain host-function path; see [near/near-sdk-rs#1534](https://github.com/near/near-sdk-rs/pull/1534).
+`RUSTFLAGS="-Awarnings"` is always used for abi build stage. For the wasm build stage the
+default is `RUSTFLAGS="-C link-arg=-s"`, plus `--cfg near` is **force-appended** to whatever
+RUSTFLAGS ends up being (the default, or a user override via `--env`). The `--cfg near` flag is
+read by `near-sdk` (5.27+) to select the on-chain host-function path; see
+[near/near-sdk-rs#1534](https://github.com/near/near-sdk-rs/pull/1534). It cannot be dropped by
+overriding RUSTFLAGS, which prevents contracts from accidentally being built without the
+host-function path.
 
-Logic for concatenating default values of this variable with values from env was removed in `cargo-near-0.13.3`/`cargo-near-build-0.4.3`, as it was seen as
-an unnecessary complication.
+Logic for concatenating default values of this variable with values from env was removed in
+`cargo-near-0.13.3`/`cargo-near-build-0.4.3`, as it was seen as an unnecessary complication.
 
 There's still a way to override this parameter for wasm build stage, e.g.:
 
 ```lang
 cargo near build non-reproducible-wasm --env 'RUSTFLAGS=--verbose'
-RUST_LOG=info cargo near build non-reproducible-wasm --env 'RUSTFLAGS=--verbose -C link-arg=-s --cfg near'
+RUST_LOG=info cargo near build non-reproducible-wasm --env 'RUSTFLAGS=--verbose -C link-arg=-s'
 ```
+
+In both cases `--cfg near` is appended automatically to the resulting RUSTFLAGS.
 
 ### `CARGO_ENCODED_RUSTFLAGS`
 

--- a/README.md
+++ b/README.md
@@ -264,14 +264,16 @@ running e.g.
 ```bash
 RUSTFLAGS="your_custom_value" cargo near build non-reproducible-wasm
 ```
-won't result in `"your_custom_value"` affecting the build.
+won't result in `"your_custom_value"` affecting the build — the ambient RUSTFLAGS is stripped
+to keep builds reproducible.
 
-`RUSTFLAGS="-Awarnings"` is always used for abi build stage. For the wasm build stage the
-default is `RUSTFLAGS="-C link-arg=-s"`, plus `--cfg near` is **force-appended** to whatever
-RUSTFLAGS ends up being (the default, or a user override via `--env`). The `--cfg near` flag is
-read by `near-sdk` (5.27+) to select the on-chain host-function path; see
+`RUSTFLAGS="-Awarnings"` is always used for the abi build stage. For the wasm build stage the
+canonical carrier is `CARGO_ENCODED_RUSTFLAGS` (see below); the default token list is
+`-C link-arg=-s`, and `--cfg near` is **force-appended** to whatever rustflags end up being
+applied (the default, or a user override via `--env`). The `--cfg near` flag is read by
+`near-sdk` (5.27+) to select the on-chain host-function path; see
 [near/near-sdk-rs#1534](https://github.com/near/near-sdk-rs/pull/1534). It cannot be dropped by
-overriding RUSTFLAGS, which prevents contracts from accidentally being built without the
+overriding rustflags, which prevents contracts from accidentally being built without the
 host-function path.
 
 Logic for concatenating default values of this variable with values from env was removed in
@@ -284,18 +286,25 @@ cargo near build non-reproducible-wasm --env 'RUSTFLAGS=--verbose'
 RUST_LOG=info cargo near build non-reproducible-wasm --env 'RUSTFLAGS=--verbose -C link-arg=-s'
 ```
 
-In both cases `--cfg near` is appended automatically to the resulting RUSTFLAGS.
+In both cases `--cfg near` is appended automatically to the resulting rustflags.
 
 ### `CARGO_ENCODED_RUSTFLAGS`
 
-This variable is always unset during build, so
+The ambient `CARGO_ENCODED_RUSTFLAGS` from your shell is always stripped before invoking cargo,
+so
 
 ```bash
 CARGO_ENCODED_RUSTFLAGS="your_custom_value" cargo near build non-reproducible-wasm
 ```
-won't result in `"your_custom_value"` affecting the build.
+won't result in `"your_custom_value"` affecting the build (avoids issues like
+[#287](https://github.com/near/cargo-near/issues/287) when composing multiple builds via build
+scripts).
 
-This is so to avoid weird issues like [#287](https://github.com/near/cargo-near/issues/287) when composing multiple builds via build scripts.
+`cargo-near` then sets this variable explicitly with the resolved wasm rustflags
+(0x1f-separated tokens — see `--env` examples above). If you pass
+`--env 'CARGO_ENCODED_RUSTFLAGS=...'` it is honored and takes precedence over a
+`--env 'RUSTFLAGS=...'` override, matching cargo's own behavior. `--cfg near` is always
+appended.
 
 
 

--- a/cargo-near-build/src/env_keys.rs
+++ b/cargo-near-build/src/env_keys.rs
@@ -6,10 +6,12 @@ pub const BUILD_RS_ABI_STEP_HINT: &str = "CARGO_NEAR_ABI_GENERATION";
 /// <https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags>
 ///
 /// this behaviour that
-/// 1. default value for RUSTFLAGS for wasm build is "-C link-arg=-s --cfg near"
+/// 1. default value for RUSTFLAGS for wasm build is "-C link-arg=-s"
 /// 2. it can be overridden with values from --env arguments
-/// 3. default RUSTFLAGS for abi gen are "-Awarnings"
-/// 4. RUSTFLAGS aren't concatenated (implicitly) with values from environment
+/// 3. `--cfg near` is force-appended to the effective RUSTFLAGS (after any override) so
+///    `near-sdk` selects the on-chain host-function path
+/// 4. default RUSTFLAGS for abi gen are "-Awarnings"
+/// 5. RUSTFLAGS aren't concatenated (implicitly) with values from environment
 ///
 /// is documented in RUSTFLAGS section of README.md
 pub const RUSTFLAGS: &str = "RUSTFLAGS";

--- a/cargo-near-build/src/env_keys.rs
+++ b/cargo-near-build/src/env_keys.rs
@@ -6,7 +6,7 @@ pub const BUILD_RS_ABI_STEP_HINT: &str = "CARGO_NEAR_ABI_GENERATION";
 /// <https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags>
 ///
 /// this behaviour that
-/// 1. default value for RUSTFLAGS for wasm build is "-C link-arg=-s"
+/// 1. default value for RUSTFLAGS for wasm build is "-C link-arg=-s --cfg near"
 /// 2. it can be overridden with values from --env arguments
 /// 3. default RUSTFLAGS for abi gen are "-Awarnings"
 /// 4. RUSTFLAGS aren't concatenated (implicitly) with values from environment

--- a/cargo-near-build/src/env_keys.rs
+++ b/cargo-near-build/src/env_keys.rs
@@ -6,12 +6,16 @@ pub const BUILD_RS_ABI_STEP_HINT: &str = "CARGO_NEAR_ABI_GENERATION";
 /// <https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags>
 ///
 /// this behaviour that
-/// 1. default value for RUSTFLAGS for wasm build is "-C link-arg=-s"
-/// 2. it can be overridden with values from --env arguments
-/// 3. `--cfg near` is force-appended to the effective RUSTFLAGS (after any override) so
-///    `near-sdk` selects the on-chain host-function path
-/// 4. default RUSTFLAGS for abi gen are "-Awarnings"
-/// 5. RUSTFLAGS aren't concatenated (implicitly) with values from environment
+/// 1. for the wasm build stage, the canonical carrier is [`CARGO_ENCODED_RUSTFLAGS`]
+///    (more robust than RUSTFLAGS against args containing spaces). RUSTFLAGS supplied via
+///    `--env` is still honored — it gets translated into the encoded form, and
+///    CARGO_ENCODED_RUSTFLAGS-via-`--env` wins over RUSTFLAGS-via-`--env` (matching cargo's
+///    own precedence)
+/// 2. the default token list is `-C link-arg=-s`
+/// 3. `--cfg near` is force-appended to the effective tokens (after any override) so
+///    `near-sdk` selects the on-chain host-function path; it cannot be dropped by user override
+/// 4. for the abi gen stage, RUSTFLAGS is still used with `-Awarnings`
+/// 5. ambient RUSTFLAGS / CARGO_ENCODED_RUSTFLAGS from the user's shell are NOT inherited
 ///
 /// is documented in RUSTFLAGS section of README.md
 pub const RUSTFLAGS: &str = "RUSTFLAGS";
@@ -21,10 +25,9 @@ pub const RUSTUP_TOOLCHAIN: &str = "RUSTUP_TOOLCHAIN";
 
 /// <https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags>
 ///
-/// this behaviour that
-/// 1. CARGO_ENCODED_RUSTFLAGS gets unset by default
-///
-/// is documented in CARGO_ENCODED_RUSTFLAGS section of README.md
+/// See the doc on [`RUSTFLAGS`] for the full behaviour. Summary: this is the canonical carrier
+/// for wasm-build rustflags (set explicitly by cargo-near, 0x1f-separated), ambient values from
+/// the user's shell are stripped, and `--cfg near` is force-appended.
 pub const CARGO_ENCODED_RUSTFLAGS: &str = "CARGO_ENCODED_RUSTFLAGS";
 
 /// see `PROFILE` in <https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts>

--- a/cargo-near-build/src/near/build/mod.rs
+++ b/cargo-near-build/src/near/build/mod.rs
@@ -211,7 +211,7 @@ pub fn run(args: Opts) -> eyre::Result<CompilationArtifact> {
     let abi_path_env = buildtime_env::AbiPath::new(args.no_embed_abi, &min_abi_path);
 
     let build_env = {
-        let mut build_env = vec![(env_keys::RUSTFLAGS, "-C link-arg=-s")];
+        let mut build_env = vec![(env_keys::RUSTFLAGS, "-C link-arg=-s --cfg near")];
         build_env.extend(
             args.env
                 .iter()

--- a/cargo-near-build/src/near/build/mod.rs
+++ b/cargo-near-build/src/near/build/mod.rs
@@ -210,31 +210,57 @@ pub fn run(args: Opts) -> eyre::Result<CompilationArtifact> {
 
     let abi_path_env = buildtime_env::AbiPath::new(args.no_embed_abi, &min_abi_path);
 
-    // Resolve effective RUSTFLAGS: user-provided via `args.env` (last entry wins, per env-var
-    // convention) takes precedence over the default `-C link-arg=-s`. Then force-append
-    // `--cfg near` so a power user overriding RUSTFLAGS via `--env` can't accidentally drop it
-    // — `--cfg near` is semantically required to select the on-chain host-function path in
-    // near-sdk >= 5.27.
+    // Resolve effective wasm-build rustflags as a token list, in priority order:
+    //   1. default tokens: ["-C", "link-arg=-s"]
+    //   2. user-provided RUSTFLAGS via args.env, parsed as whitespace-split tokens
+    //   3. user-provided CARGO_ENCODED_RUSTFLAGS via args.env, parsed as 0x1f-split tokens
+    //      (ENCODED wins over RUSTFLAGS, matching cargo's own precedence)
+    // Then ["--cfg", "near"] is force-appended so it can't be dropped by user overrides —
+    // it's semantically required to select the on-chain host-function path in near-sdk >= 5.27.
     //
-    // (Switching the canonical carrier to `CARGO_ENCODED_RUSTFLAGS` for robustness against
-    // args-with-spaces is a separate, larger refactor and is deferred — see issue #416.)
-    let default_rustflags = "-C link-arg=-s";
-    let base_rustflags = args
+    // We carry the result as CARGO_ENCODED_RUSTFLAGS (0x1f-separated) for robustness against
+    // args containing spaces (e.g. paths in `-L`). Cargo prefers ENCODED over RUSTFLAGS when
+    // both are set, so we forward neither RUSTFLAGS nor CARGO_ENCODED_RUSTFLAGS from args.env
+    // afterward to avoid double-setting.
+    let user_encoded =
+        args.env.iter().rev().find_map(|(k, v)| {
+            (k.as_str() == env_keys::CARGO_ENCODED_RUSTFLAGS).then_some(v.as_str())
+        });
+    let user_rustflags = args
         .env
         .iter()
         .rev()
-        .find_map(|(k, v)| (k.as_str() == env_keys::RUSTFLAGS).then_some(v.as_str()))
-        .unwrap_or(default_rustflags);
-    let final_rustflags = format!("{base_rustflags} --cfg near");
+        .find_map(|(k, v)| (k.as_str() == env_keys::RUSTFLAGS).then_some(v.as_str()));
+
+    let mut rustflag_tokens: Vec<String> = if let Some(encoded) = user_encoded {
+        encoded
+            .split('\x1f')
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+            .collect()
+    } else if let Some(rustflags) = user_rustflags {
+        rustflags.split_whitespace().map(String::from).collect()
+    } else {
+        vec!["-C".into(), "link-arg=-s".into()]
+    };
+    rustflag_tokens.push("--cfg".into());
+    rustflag_tokens.push("near".into());
+    let encoded_rustflags = rustflag_tokens.join("\x1f");
 
     let build_env = {
-        let mut build_env = vec![(env_keys::RUSTFLAGS, final_rustflags.as_str())];
-        // Forward all other args.env entries, but skip RUSTFLAGS (already folded into
-        // `final_rustflags` above).
+        let mut build_env: Vec<(&str, &str)> = vec![(
+            env_keys::CARGO_ENCODED_RUSTFLAGS,
+            encoded_rustflags.as_str(),
+        )];
+        // Forward all other args.env entries, but skip the rustflags carriers — they've already
+        // been folded into `encoded_rustflags` above.
         build_env.extend(
             args.env
                 .iter()
-                .filter(|(k, _)| k.as_str() != env_keys::RUSTFLAGS)
+                .filter(|(k, _)| {
+                    k.as_str() != env_keys::RUSTFLAGS
+                        && k.as_str() != env_keys::CARGO_ENCODED_RUSTFLAGS
+                })
                 .map(|(key, value)| (key.as_str(), value.as_str())),
         );
 

--- a/cargo-near-build/src/near/build/mod.rs
+++ b/cargo-near-build/src/near/build/mod.rs
@@ -210,12 +210,32 @@ pub fn run(args: Opts) -> eyre::Result<CompilationArtifact> {
 
     let abi_path_env = buildtime_env::AbiPath::new(args.no_embed_abi, &min_abi_path);
 
+    // Resolve effective RUSTFLAGS: user-provided via `args.env` (last entry wins, per env-var
+    // convention) takes precedence over the default `-C link-arg=-s`. Then force-append
+    // `--cfg near` so a power user overriding RUSTFLAGS via `--env` can't accidentally drop it
+    // — `--cfg near` is semantically required to select the on-chain host-function path in
+    // near-sdk >= 5.27.
+    //
+    // (Switching the canonical carrier to `CARGO_ENCODED_RUSTFLAGS` for robustness against
+    // args-with-spaces is a separate, larger refactor and is deferred — see issue #416.)
+    let default_rustflags = "-C link-arg=-s";
+    let base_rustflags = args
+        .env
+        .iter()
+        .rev()
+        .find_map(|(k, v)| (k.as_str() == env_keys::RUSTFLAGS).then_some(v.as_str()))
+        .unwrap_or(default_rustflags);
+    let final_rustflags = format!("{base_rustflags} --cfg near");
+
     let build_env = {
-        let mut build_env = vec![(env_keys::RUSTFLAGS, "-C link-arg=-s --cfg near")];
+        let mut build_env = vec![(env_keys::RUSTFLAGS, final_rustflags.as_str())];
+        // Forward all other args.env entries, but skip RUSTFLAGS (already folded into
+        // `final_rustflags` above).
         build_env.extend(
             args.env
                 .iter()
-                .map(|(key, value)| (key.as_ref(), value.as_ref())),
+                .filter(|(k, _)| k.as_str() != env_keys::RUSTFLAGS)
+                .map(|(key, value)| (key.as_str(), value.as_str())),
         );
 
         abi_path_env.append_borrowed_to(&mut build_env);

--- a/cargo-near/src/commands/build/actions/non_reproducible_wasm/mod.rs
+++ b/cargo-near/src/commands/build/actions/non_reproducible_wasm/mod.rs
@@ -114,8 +114,13 @@ pub struct BuildOpts {
     /// This makes sense to be used to specify custom `RUSTFLAGS` for wasm build:
     /// ```bash
     /// cargo near build non-reproducible-wasm --env 'RUSTFLAGS=--verbose'
-    /// RUST_LOG=info cargo near build non-reproducible-wasm --env 'RUSTFLAGS=--verbose -C link-arg=-s --cfg near'
+    /// RUST_LOG=info cargo near build non-reproducible-wasm --env 'RUSTFLAGS=--verbose -C link-arg=-s'
     /// ```
+    /// In both cases `--cfg near` is force-appended to the resulting RUSTFLAGS by cargo-near, so
+    /// `near-sdk` selects the on-chain host-function path. You cannot override RUSTFLAGS in a way
+    /// that drops `--cfg near` — pass it via `--cfg near` in your RUSTFLAGS only if you want it
+    /// duplicated.
+    ///
     /// This is also used with `passed_env` config in Cargo.toml manifest during reproducible builds,
     /// as an internal detail, allowing to persist info about environment in contract's metadata.
     #[interactive_clap(verbatim_doc_comment)]

--- a/cargo-near/src/commands/build/actions/non_reproducible_wasm/mod.rs
+++ b/cargo-near/src/commands/build/actions/non_reproducible_wasm/mod.rs
@@ -114,7 +114,7 @@ pub struct BuildOpts {
     /// This makes sense to be used to specify custom `RUSTFLAGS` for wasm build:
     /// ```bash
     /// cargo near build non-reproducible-wasm --env 'RUSTFLAGS=--verbose'
-    /// RUST_LOG=info cargo near build non-reproducible-wasm --env 'RUSTFLAGS=--verbose -C link-arg=-s'
+    /// RUST_LOG=info cargo near build non-reproducible-wasm --env 'RUSTFLAGS=--verbose -C link-arg=-s --cfg near'
     /// ```
     /// This is also used with `passed_env` config in Cargo.toml manifest during reproducible builds,
     /// as an internal detail, allowing to persist info about environment in contract's metadata.


### PR DESCRIPTION
Sets `--cfg near` automatically for the wasm build stage so `near-sdk >= 5.27` selects the on-chain host-function code path. Closes #416 — see that issue for full context.

## What changes

- **Canonical carrier:** `CARGO_ENCODED_RUSTFLAGS` (0x1f-separated, robust against args with spaces) instead of `RUSTFLAGS`.
- **Default tokens:** `-C link-arg=-s` (unchanged).
- **User overrides:** `--env 'RUSTFLAGS=...'` and `--env 'CARGO_ENCODED_RUSTFLAGS=...'` are still honored; ENCODED wins over RUSTFLAGS, matching cargo's own precedence.
- **`--cfg near` is force-appended** to the effective rustflags. It cannot be dropped by a user override.

ABI build stage is unchanged (still uses `RUSTFLAGS="-Awarnings"`).

## Backwards compat

| cargo-near | near-sdk | Result |
| --- | --- | --- |
| new (this PR) | new (≥5.27) | Ideal — host functions used. |
| new | old (pre-#1534) | Works. Old SDK ignores `cfg(near)`. Only friction: `unexpected_cfgs` warning unless the SDK declares `check-cfg`. |
| old | new | Works, but pure-Rust hashing embeds in wasm (bigger binary, more gas). Same hash output. |
| old | old | Status quo. |

## Verified end-to-end

Built `examples/adder` from `near/near-sdk-rs` via the patched binary; per-crate build fingerprints show `rustflags = ["-C", "link-arg=-s", "--cfg", "near"]` — confirms the encoded form decodes correctly and `--cfg near` propagates through every dep.

## Follow-up

After this ships, the workaround in near/near-sdk-rs#1534 (the `.cargo/config.toml` rustflag edits and the `build_with_cfg_near` test helpers) can be reverted.