### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.2](https://github.com/near/cargo-near/compare/cargo-near-v0.20.1...cargo-near-v0.20.2) - 2026-05-26
+
+### Added
+
+- inject `--cfg near` into wasm build by default ([#417](https://github.com/near/cargo-near/pull/417))
+
+### Fixed
+
+- honor skip-rust-version-check for cargo-near-build ([#420](https://github.com/near/cargo-near/pull/420))
+
 ## [0.20.1](https://github.com/near/cargo-near/compare/cargo-near-v0.20.0...cargo-near-v0.20.1) - 2026-04-08
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "base64 0.22.1",
  "cargo-near-build",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near-build"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "bon",
  "bs58 0.5.1",

--- a/cargo-near-build/CHANGELOG.md
+++ b/cargo-near-build/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2](https://github.com/near/cargo-near/compare/cargo-near-build-v0.11.1...cargo-near-build-v0.11.2) - 2026-05-26
+
+### Added
+
+- inject `--cfg near` into wasm build by default ([#417](https://github.com/near/cargo-near/pull/417))
+
+### Fixed
+
+- honor skip-rust-version-check for cargo-near-build ([#420](https://github.com/near/cargo-near/pull/420))
+
 ## [0.11.1](https://github.com/near/cargo-near/compare/cargo-near-build-v0.11.0...cargo-near-build-v0.11.1) - 2026-02-03
 
 ### Fixed

--- a/cargo-near-build/Cargo.toml
+++ b/cargo-near-build/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-near-build"
 edition.workspace = true
 rust-version = "1.86"
-version = "0.11.1"
+version = "0.11.2"
 description = "Library for building Rust smart contracts on NEAR, basis of `cargo-near` crate/CLI"
 repository = "https://github.com/near/cargo-near"
 license = "MIT OR Apache-2.0"

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition.workspace = true
 rust-version = "1.88"
@@ -23,7 +23,7 @@ license = false
 eula = false
 
 [dependencies]
-cargo-near-build = { version = "0.11.1", path = "../cargo-near-build", features = [
+cargo-near-build = { version = "0.11.2", path = "../cargo-near-build", features = [
     "build_internal",
     "docker",
 ] }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 const_format = "0.2"
-cargo-near-build = { version = "0.11.1", path = "../cargo-near-build" }
+cargo-near-build = { version = "0.11.2", path = "../cargo-near-build" }
 cargo-near = { path = "../cargo-near", default-features = false }
 tracing = "0.1.40"
 prettyplease = "0.2"
@@ -15,7 +15,7 @@ syn = "2"
 [dev-dependencies]
 borsh = { version = "1.0.0", features = ["derive", "unstable__schema"] }
 camino = "1.1.1"
-cargo-near-build = { version = "0.11.1", path = "../cargo-near-build", features = [
+cargo-near-build = { version = "0.11.2", path = "../cargo-near-build", features = [
     "test_code",
 ] }
 near-api = "0.8"


### PR DESCRIPTION



## 🤖 New release

* `cargo-near-build`: 0.11.1 -> 0.11.2 (✓ API compatible changes)
* `cargo-near`: 0.20.1 -> 0.20.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `cargo-near-build`

<blockquote>

## [0.11.2](https://github.com/near/cargo-near/compare/cargo-near-build-v0.11.1...cargo-near-build-v0.11.2) - 2026-05-26

### Added

- inject `--cfg near` into wasm build by default ([#417](https://github.com/near/cargo-near/pull/417))

### Fixed

- honor skip-rust-version-check for cargo-near-build ([#420](https://github.com/near/cargo-near/pull/420))
</blockquote>

## `cargo-near`

<blockquote>

## [0.20.2](https://github.com/near/cargo-near/compare/cargo-near-v0.20.1...cargo-near-v0.20.2) - 2026-05-26

### Added

- inject `--cfg near` into wasm build by default ([#417](https://github.com/near/cargo-near/pull/417))

### Fixed

- honor skip-rust-version-check for cargo-near-build ([#420](https://github.com/near/cargo-near/pull/420))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).