### PR TITLE
refactor: rename Opts::get_cli_command_for_lib_context to to_argv

### DIFF
--- a/cargo-near-build/src/near/build_external/mod.rs
+++ b/cargo-near-build/src/near/build_external/mod.rs
@@ -2,7 +2,14 @@ use eyre::{Context, ContextCompat};
 
 use crate::types::{cargo::manifest_path::ManifestPath, near::build::input::Opts};
 
-/// Return value: [`Result::Ok`] is path to the wasm artifact obtained.
+/// Spawns `cargo near build` as a subprocess and returns the path to the wasm
+/// artifact it produced.
+///
+/// The subprocess is invoked via [`std::process::Command`]; its argv is built
+/// from [`Opts::to_argv`], which is the *only* path by which [`Opts`] fields
+/// reach the subprocess. If a field's value needs to influence the build, it
+/// must be emitted by [`Opts::to_argv`] — otherwise it is silently dropped at
+/// the process boundary.
 pub fn run(opts: Opts) -> eyre::Result<camino::Utf8PathBuf> {
     let command = {
         let mut cmd = std::process::Command::new("cargo");
@@ -10,7 +17,7 @@ pub fn run(opts: Opts) -> eyre::Result<camino::Utf8PathBuf> {
         let workdir = ManifestPath::get_manifest_workdir(opts.manifest_path.clone())?;
 
         cmd.current_dir(workdir);
-        cmd.args(opts.get_cli_command_for_lib_context().into_iter().skip(1));
+        cmd.args(opts.to_argv().into_iter().skip(1));
 
         if let Some(override_cargo_target_dir) = opts.override_cargo_target_dir {
             cmd.env(

--- a/cargo-near-build/src/near/build_external/mod.rs
+++ b/cargo-near-build/src/near/build_external/mod.rs
@@ -5,11 +5,18 @@ use crate::types::{cargo::manifest_path::ManifestPath, near::build::input::Opts}
 /// Spawns `cargo near build` as a subprocess and returns the path to the wasm
 /// artifact it produced.
 ///
-/// The subprocess is invoked via [`std::process::Command`]; its argv is built
-/// from [`Opts::to_argv`], which is the *only* path by which [`Opts`] fields
-/// reach the subprocess. If a field's value needs to influence the build, it
-/// must be emitted by [`Opts::to_argv`] — otherwise it is silently dropped at
-/// the process boundary.
+/// The subprocess is invoked via [`std::process::Command`]. [`Opts`] fields reach
+/// the subprocess via two channels:
+///
+/// - **argv** — most fields are serialized to CLI flags by [`Opts::to_argv`] and
+///   passed as subprocess arguments.
+/// - **process environment** — `manifest_path` becomes the subprocess's working
+///   directory, and `override_cargo_target_dir`, `override_nep330_*`, and
+///   `override_toolchain` are set as env vars below.
+///
+/// New [`Opts`] fields should typically be wired into [`Opts::to_argv`] — if a
+/// field is neither emitted there nor handled explicitly here, it is silently
+/// dropped at the process boundary.
 pub fn run(opts: Opts) -> eyre::Result<camino::Utf8PathBuf> {
     let command = {
         let mut cmd = std::process::Command::new("cargo");

--- a/cargo-near-build/src/types/near/build/buildtime_env/command.rs
+++ b/cargo-near-build/src/types/near/build/buildtime_env/command.rs
@@ -26,7 +26,7 @@ impl Nep330BuildCommand {
             _ => {
                 // NOTE: order of output of cli flags shouldn't be too important, as the version of
                 // `cargo-near` used as lib will be fixed in `Cargo.lock`
-                args.get_cli_command_for_lib_context()
+                args.to_argv()
             }
         };
 

--- a/cargo-near-build/src/types/near/build/input/mod.rs
+++ b/cargo-near-build/src/types/near/build/input/mod.rs
@@ -364,11 +364,11 @@ mod tests {
             ..Default::default()
         };
 
-        let cmd = opts.get_cli_command_for_lib_context();
+        let cmd = opts.to_argv();
         assert!(cmd.contains(&"--skip-rust-version-check".to_string()));
 
         let opts_unset = super::Opts::default();
-        let cmd_unset = opts_unset.get_cli_command_for_lib_context();
+        let cmd_unset = opts_unset.to_argv();
         assert!(!cmd_unset.contains(&"--skip-rust-version-check".to_string()));
     }
 
@@ -415,6 +415,7 @@ mod tests {
             color: Some(super::ColorPreference::Always),
             env: vec![("K".into(), "V".into())],
             override_toolchain: Some("nightly".into()),
+            skip_rust_version_check: true,
             // `profile` is intentionally None — it is mutually exclusive with
             // `no_release` and is covered by `test_opts_get_cli_build_command_for_custom_profile`
             ..Default::default()
@@ -434,5 +435,6 @@ mod tests {
         assert!(has_flag_with_value(&cmd, "--color", "always"));
         assert!(has_flag_with_value(&cmd, "--env", "K=V"));
         assert!(has_flag_with_value(&cmd, "--override-toolchain", "nightly"));
+        assert!(cmd.contains(&"--skip-rust-version-check".to_string()));
     }
 }

--- a/cargo-near-build/src/types/near/build/input/mod.rs
+++ b/cargo-near-build/src/types/near/build/input/mod.rs
@@ -18,6 +18,14 @@ pub enum BuildContext {
 /// - `None` - for `Option`-s
 /// - empty vector - for `Vec`
 /// - delegates to [`impl Default for CliDescription`](struct.CliDescription.html#impl-Default-for-CliDescription)
+///
+/// # Adding a new field
+///
+/// When [`build_with_cli`](crate::build_with_cli) is used, [`Opts`] is serialized to argv
+/// for the spawned `cargo near` subprocess via [`Opts::to_argv`]. Any new field whose value
+/// should reach that subprocess must be wired into [`Opts::to_argv`] explicitly — there is
+/// no env var or other propagation path, so a missing emit means the field is silently
+/// dropped at the process boundary.
 #[derive(Debug, Default, Clone, bon::Builder)]
 pub struct Opts {
     /// disable implicit `--locked` flag for all `cargo` commands, enabled by default
@@ -119,10 +127,16 @@ impl Default for CliDescription {
 }
 
 impl Opts {
-    /// this is just 1-to-1 mapping of each struct's field to a cli flag
-    /// in order of fields, as specified in struct's definition.
-    /// `Default` implementation corresponds to plain `cargo near build` command without any args
-    pub fn get_cli_command_for_lib_context(&self) -> Vec<String> {
+    /// Serializes [`Opts`] → argv for the `cargo near` subprocess spawned by
+    /// [`build_with_cli`](crate::build_with_cli).
+    ///
+    /// This is a 1-to-1 mapping of each field of [`Opts`] to a CLI flag, in field-declaration
+    /// order. `Opts::default()` round-trips to a plain `cargo near build` command with no args.
+    ///
+    /// This is the **only** path by which [`Opts`] fields reach the spawned subprocess —
+    /// fields that aren't emitted here are silently dropped at the process boundary. When
+    /// adding a new field to [`Opts`], add the corresponding emit here too.
+    pub fn to_argv(&self) -> Vec<String> {
         let cargo_args = self.cli_description.cli_command_prefix.clone();
         let mut cargo_args: Vec<&str> = cargo_args.iter().map(|ele| ele.as_str()).collect();
         // this logical NOT is needed to avoid writing manually `Default` trait impl for `Opts`
@@ -189,6 +203,11 @@ impl Opts {
             .into_iter()
             .map(|el| el.to_string())
             .collect::<Vec<_>>()
+    }
+
+    #[deprecated(since = "0.20.2", note = "renamed to `to_argv` for clarity")]
+    pub fn get_cli_command_for_lib_context(&self) -> Vec<String> {
+        self.to_argv()
     }
 }
 
@@ -261,7 +280,7 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(opts.get_cli_command_for_lib_context(), ["cargo".to_string(),
+        assert_eq!(opts.to_argv(), ["cargo".to_string(),
              "near".to_string(),
              "build".to_string(),
              "non-reproducible-wasm".to_string(),
@@ -284,7 +303,7 @@ mod tests {
             ..Default::default()
         };
 
-        let cmd = opts.get_cli_command_for_lib_context();
+        let cmd = opts.to_argv();
         assert!(has_flag_with_value(&cmd, "--features", "feature1"));
         assert!(has_flag_with_value(&cmd, "--abi-features", "feature1"));
     }
@@ -297,7 +316,7 @@ mod tests {
             ..Default::default()
         };
 
-        let cmd = opts.get_cli_command_for_lib_context();
+        let cmd = opts.to_argv();
         assert!(has_flag_with_value(&cmd, "--features", "feature1"));
         assert!(has_flag_with_value(&cmd, "--abi-features", "abi_feature1"));
     }
@@ -309,7 +328,7 @@ mod tests {
             ..Default::default()
         };
 
-        let cmd = opts.get_cli_command_for_lib_context();
+        let cmd = opts.to_argv();
         assert!(!cmd.contains(&"--features".to_string()));
         assert!(cmd.contains(&"--abi-features".to_string()));
         assert!(cmd.contains(&"abi_only_feature".to_string()));
@@ -322,7 +341,7 @@ mod tests {
             ..Default::default()
         };
 
-        let cmd = opts.get_cli_command_for_lib_context();
+        let cmd = opts.to_argv();
         assert!(cmd.contains(&"--profile".to_string()));
         assert!(cmd.contains(&"test-release".to_string()));
         assert!(!cmd.contains(&"--no-release".to_string()));
@@ -351,9 +370,59 @@ mod tests {
             ..Default::default()
         };
 
-        let cmd = opts.get_cli_command_for_lib_context();
+        let cmd = opts.to_argv();
         assert!(cmd.contains(&"--profile".to_string()));
         assert!(cmd.contains(&"test-release".to_string()));
         assert!(!cmd.contains(&"--no-release".to_string()));
+    }
+
+    /// Completeness assertion for [`super::Opts::to_argv`].
+    ///
+    /// Every field of [`super::Opts`] that has a CLI surface is exercised here
+    /// and the resulting flag is asserted. When you add a new field to
+    /// [`super::Opts`] whose value should reach the subprocess spawned by
+    /// [`crate::build_with_cli`], add a non-default value here and a matching
+    /// assertion — if this test fails after a field addition, your field is
+    /// being silently dropped at the process boundary.
+    ///
+    /// Fields without a CLI emit (e.g. `manifest_path`, `override_cargo_target_dir`,
+    /// `override_nep330_*`) are intentionally excluded — they reach the subprocess
+    /// through env vars or the process working directory rather than argv.
+    #[test]
+    fn test_opts_to_argv_emits_every_field_with_a_dedicated_flag() {
+        let opts = super::Opts {
+            // `no_locked: false` (default) so we also assert that `--locked` is
+            // emitted by default
+            no_release: true,
+            no_abi: true,
+            no_embed_abi: true,
+            no_doc: true,
+            no_wasmopt: true,
+            out_dir: Some("/tmp/out".into()),
+            features: Some("feat".into()),
+            abi_features: Some("abi-feat".into()),
+            no_default_features: true,
+            color: Some(super::ColorPreference::Always),
+            env: vec![("K".into(), "V".into())],
+            override_toolchain: Some("nightly".into()),
+            // `profile` is intentionally None — it is mutually exclusive with
+            // `no_release` and is covered by `test_opts_get_cli_build_command_for_custom_profile`
+            ..Default::default()
+        };
+
+        let cmd = opts.to_argv();
+        assert!(cmd.contains(&"--locked".to_string()));
+        assert!(cmd.contains(&"--no-release".to_string()));
+        assert!(cmd.contains(&"--no-abi".to_string()));
+        assert!(cmd.contains(&"--no-embed-abi".to_string()));
+        assert!(cmd.contains(&"--no-doc".to_string()));
+        assert!(cmd.contains(&"--no-wasmopt".to_string()));
+        assert!(has_flag_with_value(&cmd, "--out-dir", "/tmp/out"));
+        assert!(has_flag_with_value(&cmd, "--features", "feat"));
+        assert!(has_flag_with_value(&cmd, "--abi-features", "abi-feat"));
+        assert!(cmd.contains(&"--no-default-features".to_string()));
+        assert!(has_flag_with_value(&cmd, "--color", "always"));
+        assert!(has_flag_with_value(&cmd, "--env", "K=V"));
+        assert!(has_flag_with_value(&cmd, "--override-toolchain", "nightly"));
     }
 }

--- a/cargo-near-build/src/types/near/build/input/mod.rs
+++ b/cargo-near-build/src/types/near/build/input/mod.rs
@@ -21,11 +21,19 @@ pub enum BuildContext {
 ///
 /// # Adding a new field
 ///
-/// When [`build_with_cli`](crate::build_with_cli) is used, [`Opts`] is serialized to argv
-/// for the spawned `cargo near` subprocess via [`Opts::to_argv`]. Any new field whose value
-/// should reach that subprocess must be wired into [`Opts::to_argv`] explicitly — there is
-/// no env var or other propagation path, so a missing emit means the field is silently
-/// dropped at the process boundary.
+/// When [`build_with_cli`](crate::build_with_cli) is used, [`Opts`] fields reach the
+/// spawned `cargo near` subprocess through one of two channels:
+///
+/// 1. **argv** — most fields are serialized to CLI flags by [`Opts::to_argv`] and passed
+///    as subprocess arguments. This is the default path.
+/// 2. **process environment** — a small fixed set of fields are propagated instead (or
+///    additionally) via the subprocess's working directory (`manifest_path`) and env vars
+///    (`override_cargo_target_dir`, `override_nep330_*`, `override_toolchain`) in
+///    `build_external::run`.
+///
+/// New fields should default to the argv path — wire them into [`Opts::to_argv`]. If a
+/// field is neither emitted there nor explicitly handled by `build_external::run`, it is
+/// silently dropped at the process boundary.
 #[derive(Debug, Default, Clone, bon::Builder)]
 pub struct Opts {
     /// disable implicit `--locked` flag for all `cargo` commands, enabled by default
@@ -130,12 +138,14 @@ impl Opts {
     /// Serializes [`Opts`] → argv for the `cargo near` subprocess spawned by
     /// [`build_with_cli`](crate::build_with_cli).
     ///
-    /// This is a 1-to-1 mapping of each field of [`Opts`] to a CLI flag, in field-declaration
-    /// order. `Opts::default()` round-trips to a plain `cargo near build` command with no args.
+    /// 1-to-1 mapping of each field of [`Opts`] to a CLI flag, in field-declaration order.
+    /// `Opts::default()` round-trips to a plain `cargo near build` command with no args.
     ///
-    /// This is the **only** path by which [`Opts`] fields reach the spawned subprocess —
-    /// fields that aren't emitted here are silently dropped at the process boundary. When
-    /// adding a new field to [`Opts`], add the corresponding emit here too.
+    /// This is the primary propagation channel from [`Opts`] to the spawned subprocess. A
+    /// small set of fields (`manifest_path`, `override_*`) are propagated separately via
+    /// cwd/env in `build_external::run` and don't appear in the argv — see the docs on
+    /// [`Opts`] for details. For all other fields: if it isn't emitted here, it is silently
+    /// dropped at the process boundary, so add the emit when adding the field.
     pub fn to_argv(&self) -> Vec<String> {
         let cargo_args = self.cli_description.cli_command_prefix.clone();
         let mut cargo_args: Vec<&str> = cargo_args.iter().map(|ele| ele.as_str()).collect();
@@ -398,7 +408,7 @@ mod tests {
             no_embed_abi: true,
             no_doc: true,
             no_wasmopt: true,
-            out_dir: Some("/tmp/out".into()),
+            out_dir: Some("target/out".into()),
             features: Some("feat".into()),
             abi_features: Some("abi-feat".into()),
             no_default_features: true,
@@ -417,7 +427,7 @@ mod tests {
         assert!(cmd.contains(&"--no-embed-abi".to_string()));
         assert!(cmd.contains(&"--no-doc".to_string()));
         assert!(cmd.contains(&"--no-wasmopt".to_string()));
-        assert!(has_flag_with_value(&cmd, "--out-dir", "/tmp/out"));
+        assert!(has_flag_with_value(&cmd, "--out-dir", "target/out"));
         assert!(has_flag_with_value(&cmd, "--features", "feat"));
         assert!(has_flag_with_value(&cmd, "--abi-features", "abi-feat"));
         assert!(cmd.contains(&"--no-default-features".to_string()));

--- a/cargo-near/src/commands/build/actions/non_reproducible_wasm/mod.rs
+++ b/cargo-near/src/commands/build/actions/non_reproducible_wasm/mod.rs
@@ -280,8 +280,7 @@ pub mod rule {
     pub fn enforce_this_program_args() -> color_eyre::eyre::Result<()> {
         if cargo_near_build::env_keys::is_inside_docker_context() {
             let args = std::env::args().collect::<Vec<_>>();
-            let default_cmd =
-                cargo_near_build::BuildOpts::default().get_cli_command_for_lib_context();
+            let default_cmd = cargo_near_build::BuildOpts::default().to_argv();
             let default_cmd_len = default_cmd.len();
             if (args.len() < default_cmd_len)
                 || (args[1..default_cmd_len] != default_cmd[1..default_cmd_len])


### PR DESCRIPTION
## Summary

The method serializes `Opts` → argv for the cargo-near subprocess spawned by `build_with_cli`. The old name (`get_cli_command_for_lib_context`) buried that role and contributed to a recent misread of #420 — the subprocess boundary wasn't obvious from the call site. This renames it to `to_argv`, adds load-bearing docs on the relevant entrypoints, and adds a completeness test that fails if a new `Opts` field is added without wiring it into `to_argv`.

The old name is kept as a `#[deprecated]` thin wrapper, so this is non-breaking for downstream consumers.

## Test plan

- [x] `cargo build -p cargo-near-build -p cargo-near`
- [x] `cargo test -p cargo-near-build --lib` (7/7 pass, including new `test_opts_to_argv_emits_every_field_with_a_dedicated_flag`)
- [x] `cargo clippy --all-targets --locked -- -D warnings`
- [x] `cargo fmt --check`