### PR TITLE
⚡ perf: avoid string cloning when checking for wasm32 target

### DIFF
--- a/cargo-near-build/src/cargo_native/target.rs
+++ b/cargo-near-build/src/cargo_native/target.rs
@@ -6,8 +6,8 @@ use crate::{env_keys::RUSTUP_TOOLCHAIN, pretty_print};
 
 pub const COMPILATION_TARGET: &str = "wasm32-unknown-unknown";
 
-pub fn wasm32_exists(override_toolchain: Option<String>) -> bool {
-    let result = get_rustc_wasm32_unknown_unknown_target_libdir(override_toolchain.clone());
+pub fn wasm32_exists(override_toolchain: Option<&str>) -> bool {
+    let result = get_rustc_wasm32_unknown_unknown_target_libdir(override_toolchain);
 
     match result {
         Ok(wasm32_target_libdir_path) => {
@@ -44,7 +44,7 @@ pub fn wasm32_exists(override_toolchain: Option<String>) -> bool {
 }
 
 fn get_rustc_wasm32_unknown_unknown_target_libdir(
-    override_toolchain: Option<String>,
+    override_toolchain: Option<&str>,
 ) -> eyre::Result<PathBuf> {
     let mut command = Command::new("rustc");
 
@@ -72,7 +72,7 @@ fn get_rustc_wasm32_unknown_unknown_target_libdir(
     }
 }
 
-fn invoke_rustup<I, S>(args: I, override_toolchain: Option<String>) -> eyre::Result<Vec<u8>>
+fn invoke_rustup<I, S>(args: I, override_toolchain: Option<&str>) -> eyre::Result<Vec<u8>>
 where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,

--- a/cargo-near-build/src/near/build/mod.rs
+++ b/cargo-near-build/src/near/build/mod.rs
@@ -150,7 +150,7 @@ pub fn run(args: Opts) -> eyre::Result<CompilationArtifact> {
     }
 
     pretty_print::handle_step("Checking the host environment...", || {
-        if !cargo_native::target::wasm32_exists(effective_toolchain.clone()) {
+        if !cargo_native::target::wasm32_exists(effective_toolchain.as_deref()) {
             eyre::bail!("rust target `{}` is not installed", COMPILATION_TARGET);
         }
         Ok(())


### PR DESCRIPTION
💡 **What:** The optimization implemented
Updated the `wasm32_exists` function and its internal dependencies (`get_rustc_wasm32_unknown_unknown_target_libdir` and `invoke_rustup`) to accept `Option<&str>` instead of `Option<String>`. Modified the call site in `cargo-near-build/src/near/build/mod.rs` to pass `effective_toolchain.as_deref()` instead of `effective_toolchain.clone()`.

🎯 **Why:** The performance problem it solves
The previous implementation performed an unnecessary `.clone()` on `effective_toolchain` (an `Option<String>`) just to pass it to a boolean check function. This resulted in an unnecessary heap allocation and memory copy. Passing string slices (`&str`) instead of owned strings (`String`) when ownership is not required is a standard Rust micro-optimization.

📊 **Measured Improvement:**
Since this is a micro-optimization involving a single string clone on an execution path that is already dominated by I/O (spawning a `rustc` process) and occurs only once per build, the performance impact is not readily measurable using macro benchmarks. However, it resolves a clear inefficiency, aligns the code with idiomatic Rust practices, and reduces memory pressure by eliminating a heap allocation.

---
*PR created automatically by Jules for task [16535965677284666410](https://jules.google.com/task/16535965677284666410) started by @ricky-sb*