### PR TITLE
⚡ perf: avoid unnecessary out_dir cloning in output path resolution

### DIFF
--- a/cargo-near-build/src/near/abi/mod.rs
+++ b/cargo-near-build/src/near/abi/mod.rs
@@ -29,7 +29,7 @@ pub fn build(args: abi_types::Opts) -> eyre::Result<camino::Utf8PathBuf> {
     })?;
 
     let out_dir = crate_metadata
-        .get_legacy_cargo_near_output_path(args.out_dir)?
+        .get_legacy_cargo_near_output_path(args.out_dir.as_deref())?
         .get_out_dir()
         .clone();
 

--- a/cargo-near-build/src/near/build/mod.rs
+++ b/cargo-near-build/src/near/build/mod.rs
@@ -166,7 +166,7 @@ pub fn run(args: Opts) -> eyre::Result<CompilationArtifact> {
     }
     // NOTE important!: the way the output path for wasm is resolved now cannot change,
     // see more detail on [CrateMetadata::get_legacy_cargo_near_output_path]
-    let output_paths = crate_metadata.get_legacy_cargo_near_output_path(args.out_dir.clone())?;
+    let output_paths = crate_metadata.get_legacy_cargo_near_output_path(args.out_dir.as_deref())?;
 
     let mut cargo_args = vec!["--target", COMPILATION_TARGET];
 

--- a/cargo-near-build/src/types/cargo/metadata.rs
+++ b/cargo-near-build/src/types/cargo/metadata.rs
@@ -84,10 +84,10 @@ impl CrateMetadata {
 
     pub(in crate::types) fn resolve_output_dir(
         &self,
-        cli_override: Option<Utf8PathBuf>,
+        cli_override: Option<&camino::Utf8Path>,
     ) -> eyre::Result<Utf8PathBuf> {
         let result = if let Some(cli_override) = cli_override {
-            crate::fs::force_canonicalize_dir(&cli_override)?
+            crate::fs::force_canonicalize_dir(cli_override)?
         } else {
             self.target_directory.clone()
         };
@@ -113,7 +113,7 @@ impl CrateMetadata {
     /// and implementation of initial docker build also assumes the same destination
     pub fn get_legacy_cargo_near_output_path(
         &self,
-        cli_override: Option<Utf8PathBuf>,
+        cli_override: Option<&camino::Utf8Path>,
     ) -> eyre::Result<OutputPaths> {
         OutputPaths::new(self, cli_override)
     }

--- a/cargo-near-build/src/types/near/docker_build/cloned_repo.rs
+++ b/cargo-near-build/src/types/near/docker_build/cloned_repo.rs
@@ -114,7 +114,7 @@ impl ClonedRepo {
         };
 
         let destination_dir = destination_crate_metadata
-            .get_legacy_cargo_near_output_path(cli_override)?
+            .get_legacy_cargo_near_output_path(cli_override.as_deref())?
             .out_dir;
 
         copy(in_wasm_path, destination_dir)

--- a/cargo-near-build/src/types/near/mod.rs
+++ b/cargo-near-build/src/types/near/mod.rs
@@ -23,7 +23,7 @@ pub struct OutputPaths {
 impl OutputPaths {
     pub fn new(
         crate_metadata: &CrateMetadata,
-        cli_override: Option<Utf8PathBuf>,
+        cli_override: Option<&camino::Utf8Path>,
     ) -> eyre::Result<Self> {
         let out_dir = crate_metadata.resolve_output_dir(cli_override)?;
 


### PR DESCRIPTION
💡 **What:** 
- Changed `resolve_output_dir` and `get_legacy_cargo_near_output_path` in `cargo-near-build/src/types/cargo/metadata.rs` to accept `Option<&camino::Utf8Path>` instead of `Option<Utf8PathBuf>`.
- Updated `OutputPaths::new` in `cargo-near-build/src/types/near/mod.rs` to use `Option<&camino::Utf8Path>`.
- Updated callers in `cargo-near-build/src/near/build/mod.rs`, `cargo-near-build/src/near/abi/mod.rs`, and `cargo-near-build/src/types/near/docker_build/cloned_repo.rs` to use `as_deref()` instead of `clone()`.

🎯 **Why:** 
Removes an unnecessary `.clone()` on `args.out_dir`, reducing heap allocations and optimizing the data flow.

📊 **Measured Improvement:** 
This change replaces an owned object move (with deep clone if some) with a zero-cost reference (deref), avoiding a string allocation (Utf8PathBuf) on the heap for each invocation of `get_legacy_cargo_near_output_path` where `cli_override` is passed. This is a small performance improvement that adheres to standard Rust idiomatic usage for path resolution.

---
*PR created automatically by Jules for task [11828482623597862422](https://jules.google.com/task/11828482623597862422) started by @ricky-sb*