### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/cargo-near-v-release.yml
+++ b/.github/workflows/cargo-near-v-release.yml
@@ -287,9 +287,7 @@ jobs:
       - plan
       - host
     runs-on: "ubuntu-22.04"
-    # Publish to npm via OIDC trusted publishing instead of a long-lived NPM_TOKEN.
-    # `id-token: write` lets the job mint a short-lived OIDC token that npm exchanges
-    # for publish rights based on the trusted publisher configured on npmjs.com.
+    # OIDC trusted publishing (replaces NPM_TOKEN); id-token mints the short-lived token.
     permissions:
       contents: read
       id-token: write
@@ -308,8 +306,7 @@ jobs:
         with:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
-      # Trusted publishing requires npm >= 11.5.1; the version bundled with Node
-      # may be older, so upgrade explicitly.
+      # Trusted publishing needs npm >= 11.5.1.
       - name: Upgrade npm for trusted publishing support
         run: npm install -g npm@latest
       - run: |

--- a/.github/workflows/cargo-near-v-release.yml
+++ b/.github/workflows/cargo-near-v-release.yml
@@ -287,6 +287,12 @@ jobs:
       - plan
       - host
     runs-on: "ubuntu-22.04"
+    # Publish to npm via OIDC trusted publishing instead of a long-lived NPM_TOKEN.
+    # `id-token: write` lets the job mint a short-lived OIDC token that npm exchanges
+    # for publish rights based on the trusted publisher configured on npmjs.com.
+    permissions:
+      contents: read
+      id-token: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PLAN: ${{ needs.plan.outputs.val }}
@@ -300,15 +306,17 @@ jobs:
           merge-multiple: true
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
+      # Trusted publishing requires npm >= 11.5.1; the version bundled with Node
+      # may be older, so upgrade explicitly.
+      - name: Upgrade npm for trusted publishing support
+        run: npm install -g npm@latest
       - run: |
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do
             pkg=$(echo "$release" | jq '.artifacts[] | select(endswith("-npm-package.tar.gz"))' --raw-output)
             npm publish --access public "./npm/${pkg}"
           done
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   announce:
     needs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ windows-archive = ".tar.gz"
 unix-archive = ".tar.gz"
 # Which actions to run on pull requests
 pr-run-mode = "upload"
+# The publish-npm job in the generated release workflow is hand-edited to use
+# OIDC trusted publishing; allow-dirty keeps `dist` from reverting that on regen.
+allow-dirty = ["ci"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,7 @@ windows-archive = ".tar.gz"
 unix-archive = ".tar.gz"
 # Which actions to run on pull requests
 pr-run-mode = "upload"
-# The publish-npm job in the generated release workflow is hand-edited to use
-# OIDC trusted publishing; allow-dirty keeps `dist` from reverting that on regen.
+# publish-npm is hand-edited for OIDC trusted publishing; don't let dist revert it.
 allow-dirty = ["ci"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"


### PR DESCRIPTION
Switches the `publish-npm` job from a long-lived `NPM_TOKEN` to OIDC trusted publishing (which @frol set up on npmjs.com).

The token is dead, so `npm publish` has been 404ing for a couple releases — npm's `latest` is still 0.20.1 (0.20.2 and 0.20.3 never landed).

- grant `id-token: write` for the OIDC token
- Node `24.x` + npm `>= 11.5.1` (OIDC support)
- drop `NODE_AUTH_TOKEN`
- `allow-dirty = ["ci"]` so `dist` won't revert this hand-edit on regen

Note: a plain re-run won't fix 0.20.3 (re-runs use the tag's old YAML); backfilling needs a new tag. Assumes the npm trusted publisher is set for `near/cargo-near`, workflow `cargo-near-v-release.yml`, no environment.