### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.21.2](https://github.com/near/cargo-near/compare/cargo-near-v0.21.1...cargo-near-v0.21.2) - 2026-07-02
+## [0.22.0-rc.1](https://github.com/near/cargo-near/compare/cargo-near-v0.21.1...cargo-near-v0.22.0-rc.1) - 2026-07-02
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.2](https://github.com/near/cargo-near/compare/cargo-near-v0.21.1...cargo-near-v0.21.2) - 2026-07-02
+
+### Added
+
+- support nearcore 2.13 / post-quantum ML-DSA-65 ([#436](https://github.com/near/cargo-near/pull/436))
+
+### Other
+
+- update template to include `cfg(near)` as valid cfg ([#438](https://github.com/near/cargo-near/pull/438))
+- update `cargo near new` template `image` and `image_digest` ([#434](https://github.com/near/cargo-near/pull/434))
+- rename Opts::get_cli_command_for_lib_context to to_argv ([#422](https://github.com/near/cargo-near/pull/422))
+
 ## [0.21.1](https://github.com/near/cargo-near/compare/cargo-near-v0.21.0...cargo-near-v0.21.1) - 2026-06-03
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.21.2"
+version = "0.22.0-rc.1"
 dependencies = [
  "base64 0.22.1",
  "cargo-near-build",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "base64 0.22.1",
  "cargo-near-build",
@@ -474,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near-build"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "bon",
  "bs58 0.5.1",

--- a/cargo-near-build/CHANGELOG.md
+++ b/cargo-near-build/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.4](https://github.com/near/cargo-near/compare/cargo-near-build-v0.11.3...cargo-near-build-v0.11.4) - 2026-07-02
+
+### Other
+
+- rename Opts::get_cli_command_for_lib_context to to_argv ([#422](https://github.com/near/cargo-near/pull/422))
+
 ## [0.11.3](https://github.com/near/cargo-near/compare/cargo-near-build-v0.11.2...cargo-near-build-v0.11.3) - 2026-05-29
 
 ### Added

--- a/cargo-near-build/Cargo.toml
+++ b/cargo-near-build/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-near-build"
 edition.workspace = true
 rust-version = "1.86"
-version = "0.11.3"
+version = "0.11.4"
 description = "Library for building Rust smart contracts on NEAR, basis of `cargo-near` crate/CLI"
 repository = "https://github.com/near/cargo-near"
 license = "MIT OR Apache-2.0"

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.21.2"
+version = "0.22.0-rc.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition.workspace = true
 rust-version = "1.93"

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.21.1"
+version = "0.21.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition.workspace = true
 rust-version = "1.93"
@@ -23,7 +23,7 @@ license = false
 eula = false
 
 [dependencies]
-cargo-near-build = { version = "0.11.3", path = "../cargo-near-build", features = [
+cargo-near-build = { version = "0.11.4", path = "../cargo-near-build", features = [
     "build_internal",
     "docker",
 ] }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 const_format = "0.2"
-cargo-near-build = { version = "0.11.3", path = "../cargo-near-build" }
+cargo-near-build = { version = "0.11.4", path = "../cargo-near-build" }
 cargo-near = { path = "../cargo-near", default-features = false }
 tracing = "0.1.40"
 prettyplease = "0.2"
@@ -15,7 +15,7 @@ syn = "2"
 [dev-dependencies]
 borsh = { version = "1.0.0", features = ["derive", "unstable__schema"] }
 camino = "1.1.1"
-cargo-near-build = { version = "0.11.3", path = "../cargo-near-build", features = [
+cargo-near-build = { version = "0.11.4", path = "../cargo-near-build", features = [
     "test_code",
 ] }
 near-api = "0.8"


### PR DESCRIPTION



## 🤖 New release

* `cargo-near-build`: 0.11.3 -> 0.11.4 (✓ API compatible changes)
* `cargo-near`: 0.21.1 -> 0.21.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `cargo-near-build`

<blockquote>

## [0.11.4](https://github.com/near/cargo-near/compare/cargo-near-build-v0.11.3...cargo-near-build-v0.11.4) - 2026-07-02

### Other

- rename Opts::get_cli_command_for_lib_context to to_argv ([#422](https://github.com/near/cargo-near/pull/422))
</blockquote>

## `cargo-near`

<blockquote>

## [0.21.2](https://github.com/near/cargo-near/compare/cargo-near-v0.21.1...cargo-near-v0.21.2) - 2026-07-02

### Added

- support nearcore 2.13 / post-quantum ML-DSA-65 ([#436](https://github.com/near/cargo-near/pull/436))

### Other

- update template to include `cfg(near)` as valid cfg ([#438](https://github.com/near/cargo-near/pull/438))
- update `cargo near new` template `image` and `image_digest` ([#434](https://github.com/near/cargo-near/pull/434))
- rename Opts::get_cli_command_for_lib_context to to_argv ([#422](https://github.com/near/cargo-near/pull/422))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).