### PR TITLE
feat: support nearcore 2.13 / post-quantum ML-DSA-65

### DIFF
--- a/.github/workflows/cargo-near-v-release.yml
+++ b/.github/workflows/cargo-near-v-release.yml
@@ -112,6 +112,11 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
+      # near-crypto (post-quantum ML-DSA-65) pulls in aws-lc-sys, which needs
+      # NASM to assemble its x86_64 Windows code. Use aws-lc-sys's pregenerated
+      # NASM objects so the x86_64-pc-windows-msvc build doesn't require NASM on
+      # the runner. (aarch64 Windows / unix targets ignore this variable.)
+      AWS_LC_SYS_PREBUILT_NASM: "1"
     steps:
       - name: enable windows longpaths
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,7 +454,7 @@ dependencies = [
  "linked-hash-map",
  "names",
  "near-cli-rs",
- "near-primitives 0.37.0-rc.1",
+ "near-primitives 0.37.0-rc.2",
  "reqwest",
  "self_update",
  "semver",
@@ -2965,19 +2965,19 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dd54ba00e601c21619a33d6e127cf0d604ee6c3080d8989492a0faf88cbc5b4"
+checksum = "139112ed78ed5f62ace80e88f4fe2de3edad1a94b90431263b18654d62473e9a"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
  "derive_more",
- "near-config-utils 0.37.0-rc.1",
- "near-crypto 0.37.0-rc.1",
- "near-parameters 0.37.0-rc.1",
- "near-primitives 0.37.0-rc.1",
- "near-time 0.37.0-rc.1",
+ "near-config-utils 0.37.0-rc.2",
+ "near-crypto 0.37.0-rc.2",
+ "near-parameters 0.37.0-rc.2",
+ "near-primitives 0.37.0-rc.2",
+ "near-time 0.37.0-rc.2",
  "num-rational",
  "parking_lot",
  "serde",
@@ -2991,7 +2991,7 @@ dependencies = [
 [[package]]
 name = "near-cli-rs"
 version = "0.27.0"
-source = "git+https://github.com/near/near-cli-rs?rev=f239a8fdc09d15c60c826f04c8544b1a8fba4418#f239a8fdc09d15c60c826f04c8544b1a8fba4418"
+source = "git+https://github.com/near/near-cli-rs?rev=e170e55345c05f57eab0f3527f4c6bcb73a492b9#e170e55345c05f57eab0f3527f4c6bcb73a492b9"
 dependencies = [
  "bip39",
  "borsh",
@@ -3013,13 +3013,13 @@ dependencies = [
  "keyring",
  "linked-hash-map",
  "near-abi",
- "near-crypto 0.37.0-rc.1",
+ "near-crypto 0.37.0-rc.2",
  "near-gas",
  "near-jsonrpc-client 0.21.1",
- "near-jsonrpc-primitives 0.37.0-rc.1",
+ "near-jsonrpc-primitives 0.37.0-rc.2",
  "near-ledger",
- "near-parameters 0.37.0-rc.1",
- "near-primitives 0.37.0-rc.1",
+ "near-parameters 0.37.0-rc.2",
+ "near-primitives 0.37.0-rc.2",
  "near-slip10",
  "near-socialdb-client",
  "near-token",
@@ -3062,9 +3062,9 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdc29612694210b340ff04d94c539e0d65007c97fc4763075a1d6038e58778a1"
+checksum = "a4b30e07d9eb158f1084a36db8963262f75a353b0093a033aa0529faae9db108"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -3100,9 +3100,9 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48363b16b2cfb9776c93c9ca9c470ed6437a2adb997afa0212372b3130cd944a"
+checksum = "9ee338484a9348f3768f4d636a98875f746b9dfeb58f4d7761e70ff74f3ddbb5"
 dependencies = [
  "aws-lc-rs",
  "blake2",
@@ -3113,9 +3113,9 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 0.37.0-rc.1",
- "near-schema-checker-lib 0.37.0-rc.1",
- "near-stdx 0.37.0-rc.1",
+ "near-config-utils 0.37.0-rc.2",
+ "near-schema-checker-lib 0.37.0-rc.2",
+ "near-stdx 0.37.0-rc.2",
  "primitive-types",
  "rand 0.8.6",
  "secp256k1",
@@ -3137,11 +3137,11 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d603b7171fdb5f5200b4d805c9361d54bb2568e5b0636b4f2a3b37e5e3b7549b"
+checksum = "1bf5e92ed9616818b0cbedcc582d2a582194334f9b622276580453624712380b"
 dependencies = [
- "near-primitives-core 0.37.0-rc.1",
+ "near-primitives-core 0.37.0-rc.2",
 ]
 
 [[package]]
@@ -3178,15 +3178,15 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.21.1"
-source = "git+https://github.com/near/near-jsonrpc-client-rs?rev=b1ea63913de39768f4c40affaaf958e79704710d#b1ea63913de39768f4c40affaaf958e79704710d"
+source = "git+https://github.com/near/near-jsonrpc-client-rs?rev=4196c34db5c5e6acfc563d62ab16c68b7c666d7e#4196c34db5c5e6acfc563d62ab16c68b7c666d7e"
 dependencies = [
  "borsh",
  "lazy_static",
  "log",
- "near-chain-configs 0.37.0-rc.1",
- "near-crypto 0.37.0-rc.1",
- "near-jsonrpc-primitives 0.37.0-rc.1",
- "near-primitives 0.37.0-rc.1",
+ "near-chain-configs 0.37.0-rc.2",
+ "near-crypto 0.37.0-rc.2",
+ "near-jsonrpc-primitives 0.37.0-rc.2",
+ "near-primitives 0.37.0-rc.2",
  "reqwest",
  "serde",
  "serde_json",
@@ -3213,16 +3213,16 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2422d73d08d6e3add41e1237443699a27e6150962cbe91aeef14dc2e937a7d26"
+checksum = "79ada6f8e357a6eecba4947cb21e56abc58036fcab2136a438b358a4042b62a6"
 dependencies = [
  "arbitrary",
- "near-chain-configs 0.37.0-rc.1",
- "near-crypto 0.37.0-rc.1",
- "near-primitives 0.37.0-rc.1",
- "near-schema-checker-lib 0.37.0-rc.1",
- "near-time 0.37.0-rc.1",
+ "near-chain-configs 0.37.0-rc.2",
+ "near-crypto 0.37.0-rc.2",
+ "near-primitives 0.37.0-rc.2",
+ "near-schema-checker-lib 0.37.0-rc.2",
+ "near-time 0.37.0-rc.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3300,15 +3300,15 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e376dc8810d6fa5bd295870c767a9418ef5f239e469ca0d7360bed3e89c703"
+checksum = "c9a94eb0bc87f470537646ea6bc5b5b9272bcceb8a798a1bd47e938f8737454a"
 dependencies = [
  "borsh",
  "enum-map",
  "near-account-id",
- "near-primitives-core 0.37.0-rc.1",
- "near-schema-checker-lib 0.37.0-rc.1",
+ "near-primitives-core 0.37.0-rc.2",
+ "near-schema-checker-lib 0.37.0-rc.2",
  "num-rational",
  "serde",
  "serde_repr",
@@ -3361,9 +3361,9 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec7cdd531c3a0cd6c199f183ad6c74755d08344c13f4eab8edd1641fb74a18f"
+checksum = "b5704a32bee9023c61c725ed6403f6bfdd21226e4798d74312b427c5a0f7022c"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -3378,13 +3378,13 @@ dependencies = [
  "enum-map",
  "hex",
  "itertools",
- "near-crypto 0.37.0-rc.1",
- "near-fmt 0.37.0-rc.1",
- "near-parameters 0.37.0-rc.1",
- "near-primitives-core 0.37.0-rc.1",
- "near-schema-checker-lib 0.37.0-rc.1",
- "near-stdx 0.37.0-rc.1",
- "near-time 0.37.0-rc.1",
+ "near-crypto 0.37.0-rc.2",
+ "near-fmt 0.37.0-rc.2",
+ "near-parameters 0.37.0-rc.2",
+ "near-primitives-core 0.37.0-rc.2",
+ "near-schema-checker-lib 0.37.0-rc.2",
+ "near-stdx 0.37.0-rc.2",
+ "near-time 0.37.0-rc.2",
  "num-rational",
  "ordered-float 4.6.0",
  "primitive-types",
@@ -3428,9 +3428,9 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69db87d9459f45873002def58c11b0ff9c55454ca3793ac9cec396aaa0e27d"
+checksum = "f94564d97ca478c94b8a34fdcda0a0077b967fa83e7187c6b8267e9b6e441d47"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -3440,7 +3440,7 @@ dependencies = [
  "enum-map",
  "near-account-id",
  "near-gas",
- "near-schema-checker-lib 0.37.0-rc.1",
+ "near-schema-checker-lib 0.37.0-rc.2",
  "near-token",
  "num-rational",
  "serde",
@@ -3480,9 +3480,9 @@ checksum = "f969a965d1ea04e1f085ee4d6c7273ae1064f578711087f3beaf8d400672cc7e"
 
 [[package]]
 name = "near-schema-checker-core"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f9ab211568bffbc9b76fb87796a28fd4027cbaeccd4bd4743720d4de4fa48fd"
+checksum = "481ec75b745264fa2403643acde2402536ed4273fbf05ea8749a5d1813f683a0"
 
 [[package]]
 name = "near-schema-checker-lib"
@@ -3496,12 +3496,12 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0170e3ee9be1a8f3d0fc5f3f21015fdc00aae2fc5fa9ab2b05e87a8f44e3b3f"
+checksum = "5eb4a7f0e4eb5aaa1032a396ef0b840f6b3cda399dfa74b9d5cfaf0c1b537260"
 dependencies = [
- "near-schema-checker-core 0.37.0-rc.1",
- "near-schema-checker-macro 0.37.0-rc.1",
+ "near-schema-checker-core 0.37.0-rc.2",
+ "near-schema-checker-macro 0.37.0-rc.2",
 ]
 
 [[package]]
@@ -3512,9 +3512,9 @@ checksum = "8a9eb7d4dc413fe39ffa7fe5591ed4c24bc8139b9de8497689178d0101ae5167"
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e271c4d3f240580c96702ee0b40e9529174e651dcb8f1749a6ae7fe1c55751d"
+checksum = "24abafad706a94a56a687618ae7e13b296b0443f54c7b7d92477b3b3c82e336d"
 
 [[package]]
 name = "near-slip10"
@@ -3530,13 +3530,13 @@ dependencies = [
 [[package]]
 name = "near-socialdb-client"
 version = "0.15.1"
-source = "git+https://github.com/near/near-socialdb-client-rs?rev=c6c81d1a17bfd5275aa279b478b299721af108e8#c6c81d1a17bfd5275aa279b478b299721af108e8"
+source = "git+https://github.com/near/near-socialdb-client-rs?rev=66580af4ce6736056e3d6f15e6c93f0127b86aad#66580af4ce6736056e3d6f15e6c93f0127b86aad"
 dependencies = [
  "eyre",
- "near-crypto 0.37.0-rc.1",
+ "near-crypto 0.37.0-rc.2",
  "near-jsonrpc-client 0.21.1",
- "near-jsonrpc-primitives 0.37.0-rc.1",
- "near-primitives 0.37.0-rc.1",
+ "near-jsonrpc-primitives 0.37.0-rc.2",
+ "near-primitives 0.37.0-rc.2",
  "near-token",
  "serde",
  "serde_json",
@@ -3551,9 +3551,9 @@ checksum = "2c5dc0456309fcb256a0609d829971fd99f343e1a7f3b72f85364e64250a4555"
 
 [[package]]
 name = "near-stdx"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49f8c17fb0087367b6dbc6bb76b134329c0929e82f099e4baf65312d55f84d"
+checksum = "f1e1cf6e256646ef9cabf86759582b2e7b06edfde846edaa68fc7d3e69d833f8"
 
 [[package]]
 name = "near-time"
@@ -3568,9 +3568,9 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f410629742ba3e9103b274eb839bd89c7f6aaa3362b26495454d50efc917669"
+checksum = "3014c3edcc10d38313abd8401700b565ab555423eee090a1b1491c700ed711a2"
 dependencies = [
  "parking_lot",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2990,8 +2990,9 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.27.0"
-source = "git+https://github.com/near/near-cli-rs?rev=e170e55345c05f57eab0f3527f4c6bcb73a492b9#e170e55345c05f57eab0f3527f4c6bcb73a492b9"
+version = "0.28.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063f4f39eafea13b6d447fa9d18ae108a9ce0d37061ded96434fdee57fc8434a"
 dependencies = [
  "bip39",
  "borsh",
@@ -3015,7 +3016,7 @@ dependencies = [
  "near-abi",
  "near-crypto 0.37.0-rc.2",
  "near-gas",
- "near-jsonrpc-client 0.21.1",
+ "near-jsonrpc-client 0.22.0-rc.1",
  "near-jsonrpc-primitives 0.37.0-rc.2",
  "near-ledger",
  "near-parameters 0.37.0-rc.2",
@@ -3177,8 +3178,9 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "0.21.1"
-source = "git+https://github.com/near/near-jsonrpc-client-rs?rev=4196c34db5c5e6acfc563d62ab16c68b7c666d7e#4196c34db5c5e6acfc563d62ab16c68b7c666d7e"
+version = "0.22.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249aacedbd175416a3635a83752581225b08a80e34bcba7ff65959c8954cf8e7"
 dependencies = [
  "borsh",
  "lazy_static",
@@ -3529,12 +3531,13 @@ dependencies = [
 
 [[package]]
 name = "near-socialdb-client"
-version = "0.15.1"
-source = "git+https://github.com/near/near-socialdb-client-rs?rev=66580af4ce6736056e3d6f15e6c93f0127b86aad#66580af4ce6736056e3d6f15e6c93f0127b86aad"
+version = "0.16.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf155a85c6b9bd805beff5f7d0cfae6bcd113a952d13d21733d6bc3b9090a89"
 dependencies = [
  "eyre",
  "near-crypto 0.37.0-rc.2",
- "near-jsonrpc-client 0.21.1",
+ "near-jsonrpc-client 0.22.0-rc.1",
  "near-jsonrpc-primitives 0.37.0-rc.2",
  "near-primitives 0.37.0-rc.2",
  "near-token",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,9 +135,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "async-trait"
@@ -147,7 +147,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -161,6 +161,29 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "backtrace"
@@ -216,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.100"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
+checksum = "4ed83caece3afc59919481b33b472e1432d1abc4641ed9100be142ef5110b406"
 dependencies = [
  "hex-conservative",
 ]
@@ -231,15 +254,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -276,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.9.1"
+version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -286,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.9.1"
+version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
  "darling 0.21.3",
  "ident_case",
@@ -296,7 +319,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -320,7 +343,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -393,9 +416,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "bytesize"
@@ -408,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+checksum = "b4ce8d3bd5823c7504d3f579f13e7b2f3da252fcb938c594d5680ee508bf846f"
 dependencies = [
  "serde_core",
 ]
@@ -431,7 +454,7 @@ dependencies = [
  "linked-hash-map",
  "names",
  "near-cli-rs",
- "near-primitives 0.36.0",
+ "near-primitives 0.0.0",
  "reqwest",
  "self_update",
  "semver",
@@ -504,7 +527,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "syn 2.0.117",
+ "syn 2.0.118",
  "tempfile",
  "testresult",
  "tokio",
@@ -578,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -613,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -656,7 +679,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -664,6 +687,15 @@ name = "clap_lex"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "codespan-reporting"
@@ -898,7 +930,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -990,7 +1022,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1020,7 +1052,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1034,7 +1066,7 @@ dependencies = [
  "indexmap 2.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1052,7 +1084,7 @@ dependencies = [
  "indexmap 2.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1086,7 +1118,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1100,7 +1132,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1111,7 +1143,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1122,7 +1154,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1173,7 +1205,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1185,7 +1216,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1206,7 +1237,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1216,7 +1247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1238,7 +1269,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -1312,7 +1343,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1430,7 +1461,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1501,7 +1532,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1624,6 +1655,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "function_name"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,7 +1737,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1780,16 +1817,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1808,7 +1843,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -1843,9 +1878,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1948,9 +1983,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1993,9 +2028,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2176,12 +2211,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2210,9 +2239,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -2301,7 +2330,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6654738b8024300cf062d04a1c13c10c8e2cea598ec1c47dc9b6641159429756"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "crossterm",
  "dyn-clone",
  "fuzzy-matcher",
@@ -2407,13 +2436,12 @@ checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2516,15 +2544,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cc46bac87ef8093eed6f272babb833b6443374399985ac8ed28471ee0918545"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
 
 [[package]]
 name = "ledger-apdu"
@@ -2581,9 +2603,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.4+1.9.3"
+version = "0.18.5+1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b26f66f35e1871b22efcf7191564123d2a446ca0538cde63c23adfefa9b15b7"
+checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
 dependencies = [
  "cc",
  "libc",
@@ -2628,9 +2650,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.28"
+version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "libc",
@@ -2686,9 +2708,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -2713,15 +2735,15 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -2918,6 +2940,30 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+dependencies = [
+ "anyhow",
+ "bytesize",
+ "chrono",
+ "derive_more",
+ "near-config-utils 0.0.0",
+ "near-crypto 0.0.0",
+ "near-parameters 0.0.0",
+ "near-primitives 0.0.0",
+ "near-time 0.0.0",
+ "num-rational",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smart-default",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "near-chain-configs"
 version = "0.34.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b49e9e2d173d526725d4055ac2af4fa18ba0e3cfd4a6c4c6439ac63a63ad9f41"
@@ -2942,35 +2988,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-chain-configs"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad19244d6390aa12020ed3f5971ea452fb54aa8b8f6435d4cf0cbbbc8fbd302"
-dependencies = [
- "anyhow",
- "bytesize",
- "chrono",
- "derive_more",
- "near-config-utils 0.36.0",
- "near-crypto 0.36.0",
- "near-parameters 0.36.0",
- "near-primitives 0.36.0",
- "near-time 0.36.0",
- "num-rational",
- "parking_lot",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "smart-default",
- "time",
- "tracing",
-]
-
-[[package]]
 name = "near-cli-rs"
 version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40cfd499c512b5989a8ac8ab7b7dba2e326d49da330c7d52a44b6f8c9cdbcaca"
+source = "git+https://github.com/near/near-cli-rs?rev=178be1a97e19e354d5ca0e7b6a1531d9577f29fc#178be1a97e19e354d5ca0e7b6a1531d9577f29fc"
 dependencies = [
  "bip39",
  "borsh",
@@ -2992,13 +3012,13 @@ dependencies = [
  "keyring",
  "linked-hash-map",
  "near-abi",
- "near-crypto 0.36.0",
+ "near-crypto 0.0.0",
  "near-gas",
  "near-jsonrpc-client 0.21.1",
- "near-jsonrpc-primitives 0.36.0",
+ "near-jsonrpc-primitives 0.0.0",
  "near-ledger",
- "near-parameters 0.36.0",
- "near-primitives 0.36.0",
+ "near-parameters 0.0.0",
+ "near-primitives 0.0.0",
  "near-slip10",
  "near-socialdb-client",
  "near-token",
@@ -3023,8 +3043,19 @@ dependencies = [
  "tracing-indicatif",
  "tracing-subscriber",
  "url",
- "wasmparser 0.243.0",
+ "wasmparser",
  "zstd",
+]
+
+[[package]]
+name = "near-config-utils"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+dependencies = [
+ "anyhow",
+ "json_comments",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -3040,15 +3071,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-config-utils"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0238af1d79fd3841817e3a5861bb628ba825669f211ca379836ae716da67bb21"
+name = "near-crypto"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 dependencies = [
- "anyhow",
- "json_comments",
+ "aws-lc-rs",
+ "blake2",
+ "borsh",
+ "bs58 0.4.0",
+ "curve25519-dalek",
+ "derive_more",
+ "ed25519-dalek",
+ "hex",
+ "near-account-id",
+ "near-config-utils 0.0.0",
+ "near-schema-checker-lib 0.0.0",
+ "near-stdx 0.0.0",
+ "primitive-types",
+ "rand 0.8.6",
+ "secp256k1",
+ "serde",
+ "serde_json",
+ "sha3",
+ "subtle",
  "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
@@ -3078,29 +3124,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-crypto"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe9390bf0db47f0a34386ef6a30adc1270288874b7eac5cab7fa48d3f89fe03"
+name = "near-fmt"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 dependencies = [
- "blake2",
- "borsh",
- "bs58 0.4.0",
- "curve25519-dalek",
- "derive_more",
- "ed25519-dalek",
- "hex",
- "near-account-id",
- "near-config-utils 0.36.0",
- "near-schema-checker-lib 0.36.0",
- "near-stdx 0.36.0",
- "primitive-types",
- "rand 0.8.6",
- "secp256k1",
- "serde",
- "serde_json",
- "subtle",
- "thiserror 2.0.18",
+ "near-primitives-core 0.0.0",
 ]
 
 [[package]]
@@ -3110,15 +3138,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31b6d8fb4146cf0a7dcadf7816bf7b8efd5c081d6d2ca524bc80815b5f86812"
 dependencies = [
  "near-primitives-core 0.34.7",
-]
-
-[[package]]
-name = "near-fmt"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503fac5d4e533a6d5e2c642cd22bd2400d1159dd5b2db58072dfc183a288c273"
-dependencies = [
- "near-primitives-core 0.36.0",
 ]
 
 [[package]]
@@ -3155,20 +3174,36 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614359c17b9cbf5faf2d82ecfe10d7a79b588c51f5f04517f75eff09f1751cdb"
+source = "git+https://github.com/near/near-jsonrpc-client-rs?rev=5f5d150d47315745945fba7672bf8c90c5bf7f95#5f5d150d47315745945fba7672bf8c90c5bf7f95"
 dependencies = [
  "borsh",
  "lazy_static",
  "log",
- "near-chain-configs 0.36.0",
- "near-crypto 0.36.0",
- "near-jsonrpc-primitives 0.36.0",
- "near-primitives 0.36.0",
+ "near-chain-configs 0.0.0",
+ "near-crypto 0.0.0",
+ "near-jsonrpc-primitives 0.0.0",
+ "near-primitives 0.0.0",
  "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "near-jsonrpc-primitives"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+dependencies = [
+ "arbitrary",
+ "near-chain-configs 0.0.0",
+ "near-crypto 0.0.0",
+ "near-primitives 0.0.0",
+ "near-schema-checker-lib 0.0.0",
+ "near-time 0.0.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]
@@ -3183,24 +3218,6 @@ dependencies = [
  "near-primitives 0.34.7",
  "near-schema-checker-lib 0.34.7",
  "near-time 0.34.7",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "time",
-]
-
-[[package]]
-name = "near-jsonrpc-primitives"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fa313996117ffead7c6f8eb12bb2b83e6ad569c7c2fd58d406c0f53ed06e01"
-dependencies = [
- "arbitrary",
- "near-chain-configs 0.36.0",
- "near-crypto 0.36.0",
- "near-primitives 0.36.0",
- "near-schema-checker-lib 0.36.0",
- "near-time 0.36.0",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3259,6 +3276,24 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+dependencies = [
+ "borsh",
+ "enum-map",
+ "near-account-id",
+ "near-primitives-core 0.0.0",
+ "near-schema-checker-lib 0.0.0",
+ "num-rational",
+ "serde",
+ "serde_repr",
+ "serde_yaml",
+ "strum",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "near-parameters"
 version = "0.34.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7a561606a8beb563bf166c8a9ceb7f97058b376d17ea1a9b4b65ebc9bff29ac"
@@ -3277,22 +3312,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-parameters"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89a9337ab742575d6dc9770ee7d4398de8cec8bbe5eaf25f00349f4e13d0173"
+name = "near-primitives"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 dependencies = [
+ "arbitrary",
+ "base64 0.21.7",
+ "bitvec",
  "borsh",
+ "bytes",
+ "bytesize",
+ "chrono",
+ "derive_builder",
+ "derive_more",
+ "easy-ext 0.2.9",
  "enum-map",
- "near-account-id",
- "near-primitives-core 0.36.0",
- "near-schema-checker-lib 0.36.0",
+ "hex",
+ "itertools",
+ "near-crypto 0.0.0",
+ "near-fmt 0.0.0",
+ "near-parameters 0.0.0",
+ "near-primitives-core 0.0.0",
+ "near-schema-checker-lib 0.0.0",
+ "near-stdx 0.0.0",
+ "near-time 0.0.0",
  "num-rational",
+ "ordered-float 4.6.0",
+ "primitive-types",
+ "rand 0.8.6",
+ "rand_chacha 0.3.1",
  "serde",
- "serde_repr",
- "serde_yaml",
+ "serde_json",
+ "serde_with",
+ "sha3",
+ "smallvec",
+ "smart-default",
  "strum",
  "thiserror 2.0.18",
+ "tracing",
+ "zstd",
 ]
 
 [[package]]
@@ -3338,46 +3396,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-primitives"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381f54f821ecdddfaccba5815a8d72bb4bb7abacac79783ce86841518523c591"
+name = "near-primitives-core"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
- "bitvec",
  "borsh",
- "bytes",
- "bytesize",
- "chrono",
- "derive_builder",
+ "bs58 0.4.0",
  "derive_more",
- "easy-ext 0.2.9",
  "enum-map",
- "hex",
- "itertools",
- "near-crypto 0.36.0",
- "near-fmt 0.36.0",
- "near-parameters 0.36.0",
- "near-primitives-core 0.36.0",
- "near-schema-checker-lib 0.36.0",
- "near-stdx 0.36.0",
- "near-time 0.36.0",
+ "near-account-id",
+ "near-gas",
+ "near-schema-checker-lib 0.0.0",
+ "near-token",
  "num-rational",
- "ordered-float 4.6.0",
- "primitive-types",
- "rand 0.8.6",
- "rand_chacha 0.3.1",
  "serde",
- "serde_json",
+ "serde_repr",
  "serde_with",
- "sha3",
- "smallvec",
- "smart-default",
- "strum",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
- "tracing",
- "zstd",
 ]
 
 [[package]]
@@ -3395,30 +3433,6 @@ dependencies = [
  "near-account-id",
  "near-gas",
  "near-schema-checker-lib 0.34.7",
- "near-token",
- "num-rational",
- "serde",
- "serde_repr",
- "serde_with",
- "sha2 0.10.9",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "near-primitives-core"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5660ac51d24534bc144e7cc04f702921c22a7e2553072663d4b43a56a8bb1ae7"
-dependencies = [
- "arbitrary",
- "base64 0.21.7",
- "borsh",
- "bs58 0.4.0",
- "derive_more",
- "enum-map",
- "near-account-id",
- "near-gas",
- "near-schema-checker-lib 0.36.0",
  "near-token",
  "num-rational",
  "serde",
@@ -3452,15 +3466,23 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-core"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+
+[[package]]
+name = "near-schema-checker-core"
 version = "0.34.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f969a965d1ea04e1f085ee4d6c7273ae1064f578711087f3beaf8d400672cc7e"
 
 [[package]]
-name = "near-schema-checker-core"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ad456b1bd9876772d6c0b557d100d518d60dd13e359daca8e0293828e29a05"
+name = "near-schema-checker-lib"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+dependencies = [
+ "near-schema-checker-core 0.0.0",
+ "near-schema-checker-macro 0.0.0",
+]
 
 [[package]]
 name = "near-schema-checker-lib"
@@ -3473,26 +3495,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-schema-checker-lib"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebdeed0043b2309b306984e4d3eeff6777ba6c66a2f955d34f883fd4ce7f84f2"
-dependencies = [
- "near-schema-checker-core 0.36.0",
- "near-schema-checker-macro 0.36.0",
-]
+name = "near-schema-checker-macro"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 
 [[package]]
 name = "near-schema-checker-macro"
 version = "0.34.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9eb7d4dc413fe39ffa7fe5591ed4c24bc8139b9de8497689178d0101ae5167"
-
-[[package]]
-name = "near-schema-checker-macro"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731a7b9cc155e291f149f2f6f8f88f5cab512b772aaf301f9defb4e4bceb1629"
 
 [[package]]
 name = "near-slip10"
@@ -3508,14 +3519,13 @@ dependencies = [
 [[package]]
 name = "near-socialdb-client"
 version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7cd480aad6faff2ba872e3368cd17b96db3b4244621e59bb8b95df984607a8"
+source = "git+https://github.com/near/near-socialdb-client-rs?rev=2268c29c4e8ad095de2a511521f08411858a1811#2268c29c4e8ad095de2a511521f08411858a1811"
 dependencies = [
  "eyre",
- "near-crypto 0.36.0",
+ "near-crypto 0.0.0",
  "near-jsonrpc-client 0.21.1",
- "near-jsonrpc-primitives 0.36.0",
- "near-primitives 0.36.0",
+ "near-jsonrpc-primitives 0.0.0",
+ "near-primitives 0.0.0",
  "near-token",
  "serde",
  "serde_json",
@@ -3524,21 +3534,19 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+
+[[package]]
+name = "near-stdx"
 version = "0.34.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c5dc0456309fcb256a0609d829971fd99f343e1a7f3b72f85364e64250a4555"
 
 [[package]]
-name = "near-stdx"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f35191f9d7a78d5cdca9788e648dce89ebbb74faef4abfa6992ed7f1fb300369"
-
-[[package]]
 name = "near-time"
-version = "0.34.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de9ae070cbd84d16b948fcc335ea82db35919bf856e349f333143ff2894eeafd"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 dependencies = [
  "parking_lot",
  "serde",
@@ -3547,9 +3555,9 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "0.36.0"
+version = "0.34.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba02806ee8691aaf41717febbe09f8e8b60ff145f09f0fc23438c07a370b3b7"
+checksum = "de9ae070cbd84d16b948fcc335ea82db35919bf856e349f333143ff2894eeafd"
 dependencies = [
  "parking_lot",
  "serde",
@@ -3667,7 +3675,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3805,11 +3813,11 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3825,7 +3833,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3842,18 +3850,18 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-src"
-version = "300.6.0+3.6.2"
+version = "300.6.1+3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -4048,7 +4056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4163,9 +4171,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -4183,9 +4191,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -4218,9 +4226,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -4272,7 +4280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -4338,7 +4346,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4380,14 +4388,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4408,9 +4416,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rend"
@@ -4479,7 +4487,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -4514,9 +4522,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.42.0"
+version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -4556,7 +4564,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4565,9 +4573,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "log",
  "once_cell",
@@ -4596,7 +4604,7 @@ checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -4674,7 +4682,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4712,7 +4720,7 @@ checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4746,7 +4754,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -4759,7 +4767,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4879,7 +4887,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4890,7 +4898,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4914,7 +4922,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4975,7 +4983,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5057,9 +5065,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -5128,9 +5136,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smart-default"
@@ -5140,14 +5148,14 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "smawk"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "snafu"
@@ -5167,7 +5175,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5262,7 +5270,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5311,7 +5319,7 @@ dependencies = [
  "symbolic-common",
  "symbolic-ppdb",
  "thiserror 2.0.18",
- "wasmparser 0.243.0",
+ "wasmparser",
  "zip",
  "zstd",
 ]
@@ -5345,9 +5353,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5371,7 +5379,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5380,7 +5388,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -5419,7 +5427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -5488,7 +5496,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5499,7 +5507,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5513,12 +5521,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -5528,15 +5535,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5592,7 +5599,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5607,9 +5614,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-retry"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40f644c762e9d396831ae2f8935c954b0d758c4532e924bead0f666d0c1c8640"
+checksum = "4a129d95275ebf4c493ec53bf0f8cd95f5ac161bc4f381700809a54f595d4470"
 dependencies = [
  "pin-project-lite",
  "rand 0.10.1",
@@ -5761,7 +5768,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
@@ -5804,7 +5811,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5886,7 +5893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5909,9 +5916,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uint"
@@ -5948,9 +5955,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -5996,6 +6003,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -6083,9 +6096,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6161,23 +6174,14 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen 0.46.0",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6189,9 +6193,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6199,9 +6203,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6209,46 +6213,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -6310,23 +6292,11 @@ version = "0.243.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6d8db401b0528ec316dfbe579e6ab4152d61739cfe076706d2009127970159d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
  "serde",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
 ]
 
 [[package]]
@@ -6342,9 +6312,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6362,9 +6332,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6421,7 +6391,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6432,7 +6402,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6660,94 +6630,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap 2.14.0",
- "prettyplease 0.2.37",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease 0.2.37",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.1",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser 0.244.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.244.0",
-]
-
-[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6774,9 +6656,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6791,28 +6673,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.49"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.49"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6832,28 +6714,28 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6886,7 +6768,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6916,9 +6798,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,7 +454,7 @@ dependencies = [
  "linked-hash-map",
  "names",
  "near-cli-rs",
- "near-primitives 0.0.0",
+ "near-primitives 0.37.0-rc.1",
  "reqwest",
  "self_update",
  "semver",
@@ -2940,30 +2940,6 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
-dependencies = [
- "anyhow",
- "bytesize",
- "chrono",
- "derive_more",
- "near-config-utils 0.0.0",
- "near-crypto 0.0.0",
- "near-parameters 0.0.0",
- "near-primitives 0.0.0",
- "near-time 0.0.0",
- "num-rational",
- "parking_lot",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "smart-default",
- "time",
- "tracing",
-]
-
-[[package]]
-name = "near-chain-configs"
 version = "0.34.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b49e9e2d173d526725d4055ac2af4fa18ba0e3cfd4a6c4c6439ac63a63ad9f41"
@@ -2988,9 +2964,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-chain-configs"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dd54ba00e601c21619a33d6e127cf0d604ee6c3080d8989492a0faf88cbc5b4"
+dependencies = [
+ "anyhow",
+ "bytesize",
+ "chrono",
+ "derive_more",
+ "near-config-utils 0.37.0-rc.1",
+ "near-crypto 0.37.0-rc.1",
+ "near-parameters 0.37.0-rc.1",
+ "near-primitives 0.37.0-rc.1",
+ "near-time 0.37.0-rc.1",
+ "num-rational",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smart-default",
+ "time",
+ "tracing",
+]
+
+[[package]]
 name = "near-cli-rs"
 version = "0.27.0"
-source = "git+https://github.com/near/near-cli-rs?rev=178be1a97e19e354d5ca0e7b6a1531d9577f29fc#178be1a97e19e354d5ca0e7b6a1531d9577f29fc"
+source = "git+https://github.com/near/near-cli-rs?rev=f239a8fdc09d15c60c826f04c8544b1a8fba4418#f239a8fdc09d15c60c826f04c8544b1a8fba4418"
 dependencies = [
  "bip39",
  "borsh",
@@ -3012,13 +3013,13 @@ dependencies = [
  "keyring",
  "linked-hash-map",
  "near-abi",
- "near-crypto 0.0.0",
+ "near-crypto 0.37.0-rc.1",
  "near-gas",
  "near-jsonrpc-client 0.21.1",
- "near-jsonrpc-primitives 0.0.0",
+ "near-jsonrpc-primitives 0.37.0-rc.1",
  "near-ledger",
- "near-parameters 0.0.0",
- "near-primitives 0.0.0",
+ "near-parameters 0.37.0-rc.1",
+ "near-primitives 0.37.0-rc.1",
  "near-slip10",
  "near-socialdb-client",
  "near-token",
@@ -3049,17 +3050,6 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
-dependencies = [
- "anyhow",
- "json_comments",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "near-config-utils"
 version = "0.34.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da2ba8f7129472fc147b867e904e4b8f398aa79f263f54dff6283c4860446ef8"
@@ -3071,30 +3061,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-crypto"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+name = "near-config-utils"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdc29612694210b340ff04d94c539e0d65007c97fc4763075a1d6038e58778a1"
 dependencies = [
- "aws-lc-rs",
- "blake2",
- "borsh",
- "bs58 0.4.0",
- "curve25519-dalek",
- "derive_more",
- "ed25519-dalek",
- "hex",
- "near-account-id",
- "near-config-utils 0.0.0",
- "near-schema-checker-lib 0.0.0",
- "near-stdx 0.0.0",
- "primitive-types",
- "rand 0.8.6",
- "secp256k1",
- "serde",
- "serde_json",
- "sha3",
- "subtle",
+ "anyhow",
+ "json_comments",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -3124,11 +3099,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-fmt"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+name = "near-crypto"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48363b16b2cfb9776c93c9ca9c470ed6437a2adb997afa0212372b3130cd944a"
 dependencies = [
- "near-primitives-core 0.0.0",
+ "aws-lc-rs",
+ "blake2",
+ "borsh",
+ "bs58 0.4.0",
+ "curve25519-dalek",
+ "derive_more",
+ "ed25519-dalek",
+ "hex",
+ "near-account-id",
+ "near-config-utils 0.37.0-rc.1",
+ "near-schema-checker-lib 0.37.0-rc.1",
+ "near-stdx 0.37.0-rc.1",
+ "primitive-types",
+ "rand 0.8.6",
+ "secp256k1",
+ "serde",
+ "serde_json",
+ "sha3",
+ "subtle",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3138,6 +3133,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31b6d8fb4146cf0a7dcadf7816bf7b8efd5c081d6d2ca524bc80815b5f86812"
 dependencies = [
  "near-primitives-core 0.34.7",
+]
+
+[[package]]
+name = "near-fmt"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d603b7171fdb5f5200b4d805c9361d54bb2568e5b0636b4f2a3b37e5e3b7549b"
+dependencies = [
+ "near-primitives-core 0.37.0-rc.1",
 ]
 
 [[package]]
@@ -3174,36 +3178,19 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.21.1"
-source = "git+https://github.com/near/near-jsonrpc-client-rs?rev=5f5d150d47315745945fba7672bf8c90c5bf7f95#5f5d150d47315745945fba7672bf8c90c5bf7f95"
+source = "git+https://github.com/near/near-jsonrpc-client-rs?rev=b1ea63913de39768f4c40affaaf958e79704710d#b1ea63913de39768f4c40affaaf958e79704710d"
 dependencies = [
  "borsh",
  "lazy_static",
  "log",
- "near-chain-configs 0.0.0",
- "near-crypto 0.0.0",
- "near-jsonrpc-primitives 0.0.0",
- "near-primitives 0.0.0",
+ "near-chain-configs 0.37.0-rc.1",
+ "near-crypto 0.37.0-rc.1",
+ "near-jsonrpc-primitives 0.37.0-rc.1",
+ "near-primitives 0.37.0-rc.1",
  "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "near-jsonrpc-primitives"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
-dependencies = [
- "arbitrary",
- "near-chain-configs 0.0.0",
- "near-crypto 0.0.0",
- "near-primitives 0.0.0",
- "near-schema-checker-lib 0.0.0",
- "near-time 0.0.0",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "time",
 ]
 
 [[package]]
@@ -3218,6 +3205,24 @@ dependencies = [
  "near-primitives 0.34.7",
  "near-schema-checker-lib 0.34.7",
  "near-time 0.34.7",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "near-jsonrpc-primitives"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2422d73d08d6e3add41e1237443699a27e6150962cbe91aeef14dc2e937a7d26"
+dependencies = [
+ "arbitrary",
+ "near-chain-configs 0.37.0-rc.1",
+ "near-crypto 0.37.0-rc.1",
+ "near-primitives 0.37.0-rc.1",
+ "near-schema-checker-lib 0.37.0-rc.1",
+ "near-time 0.37.0-rc.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3276,24 +3281,6 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
-dependencies = [
- "borsh",
- "enum-map",
- "near-account-id",
- "near-primitives-core 0.0.0",
- "near-schema-checker-lib 0.0.0",
- "num-rational",
- "serde",
- "serde_repr",
- "serde_yaml",
- "strum",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "near-parameters"
 version = "0.34.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7a561606a8beb563bf166c8a9ceb7f97058b376d17ea1a9b4b65ebc9bff29ac"
@@ -3312,45 +3299,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-primitives"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+name = "near-parameters"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e376dc8810d6fa5bd295870c767a9418ef5f239e469ca0d7360bed3e89c703"
 dependencies = [
- "arbitrary",
- "base64 0.21.7",
- "bitvec",
  "borsh",
- "bytes",
- "bytesize",
- "chrono",
- "derive_builder",
- "derive_more",
- "easy-ext 0.2.9",
  "enum-map",
- "hex",
- "itertools",
- "near-crypto 0.0.0",
- "near-fmt 0.0.0",
- "near-parameters 0.0.0",
- "near-primitives-core 0.0.0",
- "near-schema-checker-lib 0.0.0",
- "near-stdx 0.0.0",
- "near-time 0.0.0",
+ "near-account-id",
+ "near-primitives-core 0.37.0-rc.1",
+ "near-schema-checker-lib 0.37.0-rc.1",
  "num-rational",
- "ordered-float 4.6.0",
- "primitive-types",
- "rand 0.8.6",
- "rand_chacha 0.3.1",
  "serde",
- "serde_json",
- "serde_with",
- "sha3",
- "smallvec",
- "smart-default",
+ "serde_repr",
+ "serde_yaml",
  "strum",
  "thiserror 2.0.18",
- "tracing",
- "zstd",
 ]
 
 [[package]]
@@ -3396,26 +3360,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-primitives-core"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+name = "near-primitives"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ec7cdd531c3a0cd6c199f183ad6c74755d08344c13f4eab8edd1641fb74a18f"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
+ "bitvec",
  "borsh",
- "bs58 0.4.0",
+ "bytes",
+ "bytesize",
+ "chrono",
+ "derive_builder",
  "derive_more",
+ "easy-ext 0.2.9",
  "enum-map",
- "near-account-id",
- "near-gas",
- "near-schema-checker-lib 0.0.0",
- "near-token",
+ "hex",
+ "itertools",
+ "near-crypto 0.37.0-rc.1",
+ "near-fmt 0.37.0-rc.1",
+ "near-parameters 0.37.0-rc.1",
+ "near-primitives-core 0.37.0-rc.1",
+ "near-schema-checker-lib 0.37.0-rc.1",
+ "near-stdx 0.37.0-rc.1",
+ "near-time 0.37.0-rc.1",
  "num-rational",
+ "ordered-float 4.6.0",
+ "primitive-types",
+ "rand 0.8.6",
+ "rand_chacha 0.3.1",
  "serde",
- "serde_repr",
+ "serde_json",
  "serde_with",
- "sha2 0.10.9",
+ "sha3",
+ "smallvec",
+ "smart-default",
+ "strum",
  "thiserror 2.0.18",
+ "tracing",
+ "zstd",
 ]
 
 [[package]]
@@ -3433,6 +3417,30 @@ dependencies = [
  "near-account-id",
  "near-gas",
  "near-schema-checker-lib 0.34.7",
+ "near-token",
+ "num-rational",
+ "serde",
+ "serde_repr",
+ "serde_with",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "near-primitives-core"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69db87d9459f45873002def58c11b0ff9c55454ca3793ac9cec396aaa0e27d"
+dependencies = [
+ "arbitrary",
+ "base64 0.21.7",
+ "borsh",
+ "bs58 0.4.0",
+ "derive_more",
+ "enum-map",
+ "near-account-id",
+ "near-gas",
+ "near-schema-checker-lib 0.37.0-rc.1",
  "near-token",
  "num-rational",
  "serde",
@@ -3466,23 +3474,15 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-core"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
-
-[[package]]
-name = "near-schema-checker-core"
 version = "0.34.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f969a965d1ea04e1f085ee4d6c7273ae1064f578711087f3beaf8d400672cc7e"
 
 [[package]]
-name = "near-schema-checker-lib"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
-dependencies = [
- "near-schema-checker-core 0.0.0",
- "near-schema-checker-macro 0.0.0",
-]
+name = "near-schema-checker-core"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f9ab211568bffbc9b76fb87796a28fd4027cbaeccd4bd4743720d4de4fa48fd"
 
 [[package]]
 name = "near-schema-checker-lib"
@@ -3495,15 +3495,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-schema-checker-macro"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+name = "near-schema-checker-lib"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0170e3ee9be1a8f3d0fc5f3f21015fdc00aae2fc5fa9ab2b05e87a8f44e3b3f"
+dependencies = [
+ "near-schema-checker-core 0.37.0-rc.1",
+ "near-schema-checker-macro 0.37.0-rc.1",
+]
 
 [[package]]
 name = "near-schema-checker-macro"
 version = "0.34.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9eb7d4dc413fe39ffa7fe5591ed4c24bc8139b9de8497689178d0101ae5167"
+
+[[package]]
+name = "near-schema-checker-macro"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e271c4d3f240580c96702ee0b40e9529174e651dcb8f1749a6ae7fe1c55751d"
 
 [[package]]
 name = "near-slip10"
@@ -3519,13 +3530,13 @@ dependencies = [
 [[package]]
 name = "near-socialdb-client"
 version = "0.15.1"
-source = "git+https://github.com/near/near-socialdb-client-rs?rev=2268c29c4e8ad095de2a511521f08411858a1811#2268c29c4e8ad095de2a511521f08411858a1811"
+source = "git+https://github.com/near/near-socialdb-client-rs?rev=c6c81d1a17bfd5275aa279b478b299721af108e8#c6c81d1a17bfd5275aa279b478b299721af108e8"
 dependencies = [
  "eyre",
- "near-crypto 0.0.0",
+ "near-crypto 0.37.0-rc.1",
  "near-jsonrpc-client 0.21.1",
- "near-jsonrpc-primitives 0.0.0",
- "near-primitives 0.0.0",
+ "near-jsonrpc-primitives 0.37.0-rc.1",
+ "near-primitives 0.37.0-rc.1",
  "near-token",
  "serde",
  "serde_json",
@@ -3534,19 +3545,21 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
-
-[[package]]
-name = "near-stdx"
 version = "0.34.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c5dc0456309fcb256a0609d829971fd99f343e1a7f3b72f85364e64250a4555"
 
 [[package]]
+name = "near-stdx"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d49f8c17fb0087367b6dbc6bb76b134329c0929e82f099e4baf65312d55f84d"
+
+[[package]]
 name = "near-time"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.34.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de9ae070cbd84d16b948fcc335ea82db35919bf856e349f333143ff2894eeafd"
 dependencies = [
  "parking_lot",
  "serde",
@@ -3555,9 +3568,9 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "0.34.7"
+version = "0.37.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de9ae070cbd84d16b948fcc335ea82db35919bf856e349f333143ff2894eeafd"
+checksum = "7f410629742ba3e9103b274eb839bd89c7f6aaa3362b26495454d50efc917669"
 dependencies = [
  "parking_lot",
  "serde",

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -39,11 +39,11 @@ names = { version = "0.14.0", default-features = false }
 derive_more = "2"
 shell-words = "1.0.0"
 interactive-clap = "0.3.2"
-# DRAFT(post-quantum): nearcore 2.13 published 2.13 RC 0.37.0-rc.2; bump to
-# 0.37.0 (drop pre-release) once 2.13 ships stable. near-cli-rs stays on its
-# matching 2.13 draft rev until it cuts a crates.io release.
-near-cli-rs = { git = "https://github.com/near/near-cli-rs", rev = "e170e55345c05f57eab0f3527f4c6bcb73a492b9", default-features = false }
-near-primitives = { version = "0.37.0-rc.2", default-features = false }
+# DRAFT(post-quantum): nearcore 2.13 RC crates. Pinned to the published 2.13
+# RCs on crates.io (near-cli-rs 0.28.0-rc.1 pins near-primitives =0.37.0-rc.2).
+# Drop the `-rc` pins for the stable versions once 2.13 ships.
+near-cli-rs = { version = "=0.28.0-rc.1", default-features = false }
+near-primitives = { version = "=0.37.0-rc.2", default-features = false }
 reqwest = "0.12.5"
 indenter = "0.3"
 tracing-core = "0.1.32"

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -39,8 +39,13 @@ names = { version = "0.14.0", default-features = false }
 derive_more = "2"
 shell-words = "1.0.0"
 interactive-clap = "0.3.2"
-near-cli-rs = { version = "0.27", default-features = false }
-near-primitives = { version = "0.36.0", default-features = false }
+# DRAFT(post-quantum): nearcore 2.13 crates are not on crates.io yet, so pin to
+# the same rev the sibling DevEx PRs use (nearcore 2.13-release 46483c8d /
+# near-cli-rs #605 178be1a9) so near-primitives resolves to one version. A bare
+# branch pin can't unify with the siblings' rev pins, hence exact revs here.
+# Swap both back to published crates.io versions once nearcore 2.13 ships.
+near-cli-rs = { git = "https://github.com/near/near-cli-rs", rev = "178be1a97e19e354d5ca0e7b6a1531d9577f29fc", default-features = false }
+near-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10", default-features = false }
 reqwest = "0.12.5"
 indenter = "0.3"
 tracing-core = "0.1.32"

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -39,11 +39,11 @@ names = { version = "0.14.0", default-features = false }
 derive_more = "2"
 shell-words = "1.0.0"
 interactive-clap = "0.3.2"
-# DRAFT(post-quantum): nearcore 2.13 published 2.13 RC 0.37.0-rc.1; bump to
+# DRAFT(post-quantum): nearcore 2.13 published 2.13 RC 0.37.0-rc.2; bump to
 # 0.37.0 (drop pre-release) once 2.13 ships stable. near-cli-rs stays on its
 # matching 2.13 draft rev until it cuts a crates.io release.
-near-cli-rs = { git = "https://github.com/near/near-cli-rs", rev = "f239a8fdc09d15c60c826f04c8544b1a8fba4418", default-features = false }
-near-primitives = { version = "0.37.0-rc.1", default-features = false }
+near-cli-rs = { git = "https://github.com/near/near-cli-rs", rev = "e170e55345c05f57eab0f3527f4c6bcb73a492b9", default-features = false }
+near-primitives = { version = "0.37.0-rc.2", default-features = false }
 reqwest = "0.12.5"
 indenter = "0.3"
 tracing-core = "0.1.32"

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -39,13 +39,11 @@ names = { version = "0.14.0", default-features = false }
 derive_more = "2"
 shell-words = "1.0.0"
 interactive-clap = "0.3.2"
-# DRAFT(post-quantum): nearcore 2.13 crates are not on crates.io yet, so pin to
-# the same rev the sibling DevEx PRs use (nearcore 2.13-release 46483c8d /
-# near-cli-rs #605 178be1a9) so near-primitives resolves to one version. A bare
-# branch pin can't unify with the siblings' rev pins, hence exact revs here.
-# Swap both back to published crates.io versions once nearcore 2.13 ships.
-near-cli-rs = { git = "https://github.com/near/near-cli-rs", rev = "178be1a97e19e354d5ca0e7b6a1531d9577f29fc", default-features = false }
-near-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10", default-features = false }
+# DRAFT(post-quantum): nearcore 2.13 published 2.13 RC 0.37.0-rc.1; bump to
+# 0.37.0 (drop pre-release) once 2.13 ships stable. near-cli-rs stays on its
+# matching 2.13 draft rev until it cuts a crates.io release.
+near-cli-rs = { git = "https://github.com/near/near-cli-rs", rev = "f239a8fdc09d15c60c826f04c8544b1a8fba4418", default-features = false }
+near-primitives = { version = "0.37.0-rc.1", default-features = false }
 reqwest = "0.12.5"
 indenter = "0.3"
 tracing-core = "0.1.32"


### PR DESCRIPTION
## Summary

Bumps `cargo-near`'s `near-*` dependencies to the published nearcore **2.13 RC** crates (protocol v85) so it builds against the same nearcore as the rest of the DevEx 2.13 stack. 2.13's headline chain feature is post-quantum **ML-DSA-65** access keys; for cargo-near this is purely a dependency bump — the CLI-side keygen lives in near-cli-rs.

## Dependency pins (all crates.io, zero git deps)

`cargo-near/Cargo.toml`:
- `near-primitives` → `=0.37.0-rc.2`
- `near-cli-rs` → `=0.28.0-rc.1`

`near-cli-rs 0.28.0-rc.1` itself pins `near-primitives =0.37.0-rc.2`, so the whole tree resolves to a single `near-primitives`/`near-crypto`. `near-jsonrpc-client 0.22.0-rc.1` and `near-socialdb-client 0.16.0-rc.1` come in transitively through near-cli-rs. `Cargo.lock` is updated and in sync.

`near-abi` / `near-verify-rs` are independent DevEx crates and stay on their crates.io ranges. The `integration-tests` harness (`near-api` / `near-workspaces` / `near-sandbox`) stays on published 2.12 nearcore (a disjoint dep subtree) and runs against an existing 2.12 sandbox.

These are `-rc` pins; swap them for the stable crates.io versions once nearcore 2.13 ships.

## Source adaptations

None. cargo-near's own source only touches `Action::DeployContract` / `DeployContractAction`, unchanged in 2.13; it compiles as-is against the RC crates.

## Windows

nearcore 2.13's post-quantum `near-crypto` pulls in `aws-lc-sys`, whose x86_64 Windows build assembles via NASM. The cargo-dist release workflow sets `AWS_LC_SYS_PREBUILT_NASM=1` so the `x86_64-pc-windows-msvc` build uses aws-lc-sys's pregenerated NASM objects instead of requiring NASM on the runner.

## Checks

Local: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo check --workspace --tests`, and `cargo test --lib --bins` all pass.
