### PR TITLE
feat: print built contract size in `cargo near build` output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,6 +455,7 @@ version = "0.11.3"
 dependencies = [
  "bon",
  "bs58 0.5.1",
+ "bytesize",
  "camino",
  "cargo_metadata",
  "colored",

--- a/cargo-near-build/Cargo.toml
+++ b/cargo-near-build/Cargo.toml
@@ -18,6 +18,7 @@ dunce = "1"
 bon = "3"
 cargo_metadata = "0.21"
 colored = "3"
+bytesize = "1"
 tracing = "0.1.40"
 indenter = "0.3"
 pathdiff = { version = "0.2.1", features = ["camino"] }

--- a/cargo-near-build/src/types/near/build/side_effects.rs
+++ b/cargo-near-build/src/types/near/build/side_effects.rs
@@ -10,6 +10,9 @@ impl<'a> ArtifactMessages<'a> {
     pub fn push_binary(&mut self, artifact: &CompilationArtifact) -> eyre::Result<()> {
         self.messages
             .push(("Binary", artifact.path.to_string().bright_yellow().bold()));
+        let size_bytes = std::fs::metadata(&artifact.path)?.len();
+        self.messages
+            .push(("Size", format_size(size_bytes).cyan().dimmed()));
         let checksum = artifact.compute_hash()?;
         self.messages.push((
             "SHA-256 checksum hex ",
@@ -30,5 +33,36 @@ impl<'a> ArtifactMessages<'a> {
         for (header, message) in self.messages {
             eprintln!("     - {header:>max_width$}: {message}");
         }
+    }
+}
+
+/// Formats a byte count as a human-readable size plus the exact byte count,
+/// e.g. `112.8 KB (112824 bytes)`.
+fn format_size(bytes: u64) -> String {
+    format!("{} ({bytes} bytes)", bytesize::ByteSize::b(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_size;
+
+    #[test]
+    fn format_size_keeps_exact_bytes_and_human_units() {
+        let formatted = format_size(112_824);
+        // exact byte count is always preserved for precision
+        assert!(
+            formatted.ends_with("(112824 bytes)"),
+            "missing raw byte count: {formatted}"
+        );
+        // and a human-readable unit is shown alongside it
+        assert!(
+            formatted.contains('B') && formatted.contains("112824 bytes"),
+            "unexpected format: {formatted}"
+        );
+    }
+
+    #[test]
+    fn format_size_handles_small_values() {
+        assert_eq!(format_size(0), "0 B (0 bytes)");
     }
 }

--- a/cargo-near-build/src/types/near/build/side_effects.rs
+++ b/cargo-near-build/src/types/near/build/side_effects.rs
@@ -39,7 +39,8 @@ impl<'a> ArtifactMessages<'a> {
 /// Formats a byte count as a human-readable size plus the exact byte count,
 /// e.g. `112.8 KB (112824 bytes)`.
 fn format_size(bytes: u64) -> String {
-    format!("{} ({bytes} bytes)", bytesize::ByteSize::b(bytes))
+    let unit = if bytes == 1 { "byte" } else { "bytes" };
+    format!("{} ({bytes} {unit})", bytesize::ByteSize::b(bytes))
 }
 
 #[cfg(test)]
@@ -64,5 +65,8 @@ mod tests {
     #[test]
     fn format_size_handles_small_values() {
         assert_eq!(format_size(0), "0 B (0 bytes)");
+        // singular `byte` for a 1-byte artifact, not `1 bytes`
+        assert_eq!(format_size(1), "1 B (1 byte)");
+        assert_eq!(format_size(2), "2 B (2 bytes)");
     }
 }


### PR DESCRIPTION
## Motivation

After a successful build, `cargo near build` prints the binary path and two checksums (SHA-256 hex and bs58), but not the file size. A user asked for the size to be printed too, since contract size matters for deploy limits and gas costs. See #440.

## What changed

`ArtifactMessages::push_binary` in `cargo-near-build/src/types/near/build/side_effects.rs` is the single shared spot that emits the post-build "Binary"/checksum lines for **both** build modes (non-reproducible and reproducible/docker). A new `Size` line is added there, right after the `Binary` path, so it appears in both modes automatically.

The size is read via `std::fs::metadata(&artifact.path)?.len()` and the human-readable part is rendered with the [`bytesize`](https://crates.io/crates/bytesize) crate. `bytesize` is already in the workspace `Cargo.lock` (pulled transitively via the `near-*` deps), so this just wires it as a direct dependency of `cargo-near-build` rather than introducing a new external crate or hand-rolling a formatter. The exact byte count is always shown alongside it for precision:

```
     -                Binary: /path/to/size_test.wasm
     -                  Size: 112.8 KB (112824 bytes)
     - SHA-256 checksum hex : 3a7e1e0beeeac0193691616f1561c57257bdb07d936460217b395ab3da555956
     - SHA-256 checksum bs58: 4wLBkPRuwTR4xu9pYGkLh6X9oXeCLvLLysjGdkVqPhmF
```

(`bytesize` renders decimal/SI units, e.g. `112.8 KB`; the raw byte count disambiguates.)

## Testing

- `cargo build -p cargo-near` — succeeds; built binary prints the `Size` line matching `stat`/`ls -l` exactly (112824 bytes).
- Added unit tests for `format_size` (exact-bytes suffix + small-value `0 B (0 bytes)`), passing under `--features build_internal`.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p cargo-near-build --features build_internal --tests -- -Dclippy::all` — clean (the one `dead_code` warning is pre-existing and unrelated).

Closes #440