### PR TITLE
feat: add `cargo near check` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,24 @@ Once contract is deployed, this will allow you to call a view function `__contra
 ---
 
 ```console
+cargo near check
+```
+
+Type-checks the contract under the **same environment** `cargo near build` uses, without producing a wasm artifact (while in the directory containing contract's Cargo.toml).
+
+This is the fast half of `cargo near build`: it sets `--cfg near` (so `near-sdk >= 5.27` selects the on-chain host-function path), targets `wasm32-unknown-unknown`, and applies the same `--features` / `--no-default-features` / `--profile` (`--release` by default, opt out with `--no-release`) / `--locked` resolution and active/overridden toolchain. It skips ABI generation/embedding, `wasm-opt`, output copying, and the rustc/protocol-version ceiling check — none of which matter when no wasm is emitted.
+
+It runs `cargo check` by default; pass `--clippy` to run `cargo clippy` instead:
+
+```console
+cargo near check --clippy
+```
+
+This is useful as a faster local dev loop than a full build, and for CI lint jobs that previously had to reconstruct the build environment by hand to lint contracts.
+
+---
+
+```console
 cargo near create-dev-account
 ```
 

--- a/cargo-near-build/src/cargo_native/compile.rs
+++ b/cargo-near-build/src/cargo_native/compile.rs
@@ -146,10 +146,11 @@ where
     cmd.arg(command);
     cmd.args(args);
 
-    match color {
-        ColorPreference::Auto => cmd.args(["--color", "auto"]),
+    // `resolved()` maps `Auto` to always/never via our own stderr, since cargo can't detect
+    // the terminal through the stdout/stderr pipes we capture below.
+    match color.resolved() {
         ColorPreference::Always => cmd.args(["--color", "always"]),
-        ColorPreference::Never => cmd.args(["--color", "never"]),
+        _ => cmd.args(["--color", "never"]),
     };
 
     tracing::info!(

--- a/cargo-near-build/src/cargo_native/compile.rs
+++ b/cargo-near-build/src/cargo_native/compile.rs
@@ -80,6 +80,35 @@ where
         ),
     }
 }
+/// Runs a non-artifact-producing cargo subcommand (`check` or `clippy`) with the manifest
+/// located at `manifest_path`.
+///
+/// Unlike [`run`], this does not look up or require any output artifact — `cargo check` and
+/// `cargo clippy` are type-checking passes that don't emit a contract wasm. Diagnostics are
+/// streamed through (same as [`run`]) and the cargo exit status is propagated: an `Err` is
+/// returned if cargo exits non-zero.
+pub fn run_check(
+    command: &str,
+    manifest_path: &ManifestPath,
+    args: &[&str],
+    env: Vec<(&str, &str)>,
+    color: ColorPreference,
+) -> eyre::Result<()> {
+    let final_env: BTreeMap<_, _> = env.into_iter().collect();
+    let removed_env = [crate::env_keys::CARGO_ENCODED_RUSTFLAGS];
+
+    invoke_cargo(
+        command,
+        [&["--message-format=json-render-diagnostics"], args].concat(),
+        manifest_path.directory().ok(),
+        final_env.iter(),
+        &removed_env,
+        color,
+    )?;
+
+    Ok(())
+}
+
 /// Invokes `cargo` with the subcommand `command`, the supplied `args` and set `env` variables.
 ///
 /// If `working_dir` is set, cargo process will be spawned in the specified directory.

--- a/cargo-near-build/src/lib.rs
+++ b/cargo-near-build/src/lib.rs
@@ -52,6 +52,15 @@ pub mod abi {
     pub use crate::types::near::abi::Opts as AbiOpts;
 }
 
+/// `cargo near check` entry point: type-check a contract under the same environment
+/// `cargo near build` uses (`--cfg near`, `wasm32-unknown-unknown` target, same
+/// feature/profile/locked resolution and toolchain), without producing a wasm artifact.
+#[cfg(feature = "build_internal")]
+pub mod check {
+    pub use crate::near::check::run as check;
+    pub use crate::types::near::check::{CheckKind, Opts as CheckOpts};
+}
+
 /// these are exports of types, used for both `internal` and `external` build methods
 mod build_exports {
 

--- a/cargo-near-build/src/near/build/mod.rs
+++ b/cargo-near-build/src/near/build/mod.rs
@@ -277,42 +277,12 @@ pub fn run(args: Opts) -> eyre::Result<CompilationArtifact> {
 
     let abi_path_env = buildtime_env::AbiPath::new(args.no_embed_abi, &min_abi_path);
 
-    // Resolve effective wasm-build rustflags as a token list, in priority order:
-    //   1. default tokens: ["-C", "link-arg=-s"]
-    //   2. user-provided RUSTFLAGS via args.env, parsed as whitespace-split tokens
-    //   3. user-provided CARGO_ENCODED_RUSTFLAGS via args.env, parsed as 0x1f-split tokens
-    //      (ENCODED wins over RUSTFLAGS, matching cargo's own precedence)
-    // Then ["--cfg", "near"] is force-appended so it can't be dropped by user overrides —
-    // it's semantically required to select the on-chain host-function path in near-sdk >= 5.27.
-    //
-    // We carry the result as CARGO_ENCODED_RUSTFLAGS (0x1f-separated) for robustness against
-    // args containing spaces (e.g. paths in `-L`). Cargo prefers ENCODED over RUSTFLAGS when
-    // both are set, so we forward neither RUSTFLAGS nor CARGO_ENCODED_RUSTFLAGS from args.env
-    // afterward to avoid double-setting.
-    let user_encoded =
-        args.env.iter().rev().find_map(|(k, v)| {
-            (k.as_str() == env_keys::CARGO_ENCODED_RUSTFLAGS).then_some(v.as_str())
-        });
-    let user_rustflags = args
-        .env
-        .iter()
-        .rev()
-        .find_map(|(k, v)| (k.as_str() == env_keys::RUSTFLAGS).then_some(v.as_str()));
-
-    let mut rustflag_tokens: Vec<String> = if let Some(encoded) = user_encoded {
-        encoded
-            .split('\x1f')
-            .filter(|s| !s.is_empty())
-            .map(String::from)
-            .collect()
-    } else if let Some(rustflags) = user_rustflags {
-        rustflags.split_whitespace().map(String::from).collect()
-    } else {
-        vec!["-C".into(), "link-arg=-s".into()]
-    };
-    rustflag_tokens.push("--cfg".into());
-    rustflag_tokens.push("near".into());
-    let encoded_rustflags = rustflag_tokens.join("\x1f");
+    // Resolve effective wasm-build rustflags (with `--cfg near` force-appended) as a
+    // CARGO_ENCODED_RUSTFLAGS string. See [`encoded_rustflags_with_cfg_near`] for the full
+    // resolution order and rationale. Because the result is carried as ENCODED, neither
+    // RUSTFLAGS nor CARGO_ENCODED_RUSTFLAGS are forwarded from args.env afterward (see the
+    // filter below) to avoid double-setting.
+    let encoded_rustflags = encoded_rustflags_with_cfg_near(&args.env);
 
     let build_env = {
         let mut build_env: Vec<(&str, &str)> = vec![(
@@ -504,7 +474,7 @@ fn maybe_wasm_opt_step(
 /// This function intentionally returns None rather than an error when rustup is unavailable,
 /// allowing cargo-near to work in environments without rustup by falling back to the default
 /// rustc behavior.
-fn detect_active_toolchain(project_dir: Option<&camino::Utf8Path>) -> Option<String> {
+pub(crate) fn detect_active_toolchain(project_dir: Option<&camino::Utf8Path>) -> Option<String> {
     let mut cmd = std::process::Command::new("rustup");
     cmd.args(["show", "active-toolchain"]);
 
@@ -531,7 +501,9 @@ fn detect_active_toolchain(project_dir: Option<&camino::Utf8Path>) -> Option<Str
 /// Gets the project directory from the manifest path option.
 /// If manifest_path is provided, returns its parent directory.
 /// Otherwise returns None (will use current directory).
-fn get_project_dir(manifest_path: Option<&camino::Utf8PathBuf>) -> Option<&camino::Utf8Path> {
+pub(crate) fn get_project_dir(
+    manifest_path: Option<&camino::Utf8PathBuf>,
+) -> Option<&camino::Utf8Path> {
     manifest_path.and_then(|p| p.parent())
 }
 
@@ -573,9 +545,91 @@ pub fn version_meta_with_override(
     rustc_version::version_meta_for(std::str::from_utf8(&out.stdout)?)
 }
 
+/// Resolves the effective wasm-build rustflags from `env` as a `CARGO_ENCODED_RUSTFLAGS`
+/// (0x1f-separated) string, with `["--cfg", "near"]` force-appended.
+///
+/// Resolution order, in priority:
+///   1. default tokens: `["-C", "link-arg=-s"]`
+///   2. user-provided `RUSTFLAGS` via `env`, parsed as whitespace-split tokens
+///   3. user-provided `CARGO_ENCODED_RUSTFLAGS` via `env`, parsed as 0x1f-split tokens
+///      (ENCODED wins over RUSTFLAGS, matching cargo's own precedence)
+///
+/// `["--cfg", "near"]` is then force-appended so it can't be dropped by user overrides — it's
+/// semantically required to select the on-chain host-function path in near-sdk >= 5.27.
+///
+/// The result is carried as `CARGO_ENCODED_RUSTFLAGS` (0x1f-separated) for robustness against
+/// args containing spaces (e.g. paths in `-L`). Cargo prefers ENCODED over RUSTFLAGS when both
+/// are set, so callers must forward neither `RUSTFLAGS` nor `CARGO_ENCODED_RUSTFLAGS` from
+/// `env` afterward to avoid double-setting.
+///
+/// Shared by [`run`] (wasm build) and the `check`/`clippy` path so the type-check observes the
+/// exact same `--cfg near` configuration the build does.
+pub(crate) fn encoded_rustflags_with_cfg_near(env: &[(String, String)]) -> String {
+    let user_encoded = env
+        .iter()
+        .rev()
+        .find_map(|(k, v)| (k.as_str() == env_keys::CARGO_ENCODED_RUSTFLAGS).then_some(v.as_str()));
+    let user_rustflags = env
+        .iter()
+        .rev()
+        .find_map(|(k, v)| (k.as_str() == env_keys::RUSTFLAGS).then_some(v.as_str()));
+
+    let mut rustflag_tokens: Vec<String> = if let Some(encoded) = user_encoded {
+        encoded
+            .split('\x1f')
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+            .collect()
+    } else if let Some(rustflags) = user_rustflags {
+        rustflags.split_whitespace().map(String::from).collect()
+    } else {
+        vec!["-C".into(), "link-arg=-s".into()]
+    };
+    rustflag_tokens.push("--cfg".into());
+    rustflag_tokens.push("near".into());
+    rustflag_tokens.join("\x1f")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_encoded_rustflags_appends_cfg_near() {
+        const SEP: char = '\x1f';
+
+        // No RUSTFLAGS / CARGO_ENCODED_RUSTFLAGS provided => default tokens + `--cfg near`.
+        let encoded = encoded_rustflags_with_cfg_near(&[]);
+        assert_eq!(
+            encoded.split(SEP).collect::<Vec<_>>(),
+            ["-C", "link-arg=-s", "--cfg", "near"]
+        );
+
+        // RUSTFLAGS provided => whitespace-split tokens + `--cfg near`.
+        let env = vec![(
+            "RUSTFLAGS".to_string(),
+            "-C link-arg=-s --verbose".to_string(),
+        )];
+        let encoded = encoded_rustflags_with_cfg_near(&env);
+        assert_eq!(
+            encoded.split(SEP).collect::<Vec<_>>(),
+            ["-C", "link-arg=-s", "--verbose", "--cfg", "near"]
+        );
+
+        // CARGO_ENCODED_RUSTFLAGS wins over RUSTFLAGS (matching cargo precedence).
+        let env = vec![
+            ("RUSTFLAGS".to_string(), "-C opt-level=3".to_string()),
+            (
+                "CARGO_ENCODED_RUSTFLAGS".to_string(),
+                format!("-C{SEP}link-arg=-s"),
+            ),
+        ];
+        let encoded = encoded_rustflags_with_cfg_near(&env);
+        assert_eq!(
+            encoded.split(SEP).collect::<Vec<_>>(),
+            ["-C", "link-arg=-s", "--cfg", "near"]
+        );
+    }
 
     #[test]
     fn test_get_project_dir() {

--- a/cargo-near-build/src/near/check/mod.rs
+++ b/cargo-near-build/src/near/check/mod.rs
@@ -1,4 +1,6 @@
+use crate::types::near::build::buildtime_env::{Nep330BuildCommand, Nep330Link, Nep330Version};
 use crate::types::near::build::common_buildtime_env;
+use crate::types::near::build::output::version_info::VersionInfo;
 use crate::types::near::check::Opts;
 use crate::{ColorPreference, cargo_native, env_keys};
 use crate::{
@@ -83,6 +85,18 @@ pub fn run(args: Opts) -> eyre::Result<()> {
     // so we must not also forward RUSTFLAGS/CARGO_ENCODED_RUSTFLAGS from args.env below.
     let encoded_rustflags = encoded_rustflags_with_cfg_near(&args.env);
 
+    // Reproduce the same NEP-330 build-time environment `cargo near build` exposes (via
+    // `CommonVariables`), so a contract whose source or `build.rs` reads these variables
+    // type-checks against the same configuration `build` would compile. The output-wasm-path
+    // variable is intentionally omitted — a `check` produces no artifact.
+    let nep330_version = Nep330Version::new(&crate_metadata);
+    let nep330_link = Nep330Link::new(&crate_metadata);
+    let nep330_build_cmd = Nep330BuildCommand::compute_with_fallback_argv(|| {
+        vec!["cargo".to_string(), "near".to_string(), "check".to_string()]
+    })?;
+    let builder_abi_versions =
+        VersionInfo::get_coerced_builder_version()?.compute_env_variables()?;
+
     let check_env = {
         let mut check_env: Vec<(&str, &str)> = vec![(
             env_keys::CARGO_ENCODED_RUSTFLAGS,
@@ -97,6 +111,11 @@ pub fn run(args: Opts) -> eyre::Result<()> {
                 })
                 .map(|(key, value)| (key.as_str(), value.as_str())),
         );
+
+        nep330_version.append_borrowed_to(&mut check_env);
+        nep330_link.append_borrowed_to(&mut check_env);
+        nep330_build_cmd.append_borrowed_to(&mut check_env);
+        builder_abi_versions.append_borrowed_to(&mut check_env);
 
         effective_toolchain.as_ref().inspect(|toolchain| {
             check_env.push((env_keys::RUSTUP_TOOLCHAIN, toolchain));

--- a/cargo-near-build/src/near/check/mod.rs
+++ b/cargo-near-build/src/near/check/mod.rs
@@ -1,0 +1,129 @@
+use crate::types::near::build::common_buildtime_env;
+use crate::types::near::check::Opts;
+use crate::{ColorPreference, cargo_native, env_keys};
+use crate::{
+    cargo_native::target::COMPILATION_TARGET, pretty_print, types::cargo::metadata::CrateMetadata,
+};
+
+use super::build::{detect_active_toolchain, encoded_rustflags_with_cfg_near, get_project_dir};
+
+/// Type-checks a contract under the exact same environment [`build::run`](crate::build) uses,
+/// without producing a wasm artifact.
+///
+/// Runs `cargo check` (default) or `cargo clippy` (when [`Opts::clippy`] is set) with:
+/// - `--cfg near` force-appended to `CARGO_ENCODED_RUSTFLAGS` (identical logic to build, so
+///   near-sdk >= 5.27 selects the on-chain host-function path),
+/// - target `wasm32-unknown-unknown` (verified installed first),
+/// - the same `--features` / `--no-default-features` / `--profile` (`--release` by default
+///   unless `no_release`) / `--locked` resolution as build,
+/// - the active or overridden toolchain.
+///
+/// Deliberately skipped vs. build (all only matter when emitting wasm): ABI generation and
+/// embedding, `wasm-opt`, output-path copying, and the rustc/protocol-version ceiling check.
+///
+/// cargo diagnostics are streamed through; a non-zero cargo exit is propagated as an `Err`.
+pub fn run(args: Opts) -> eyre::Result<()> {
+    let start = std::time::Instant::now();
+
+    let color = args.color.unwrap_or(ColorPreference::Auto);
+    color.apply();
+
+    // Detect the effective toolchain to use: explicit override or active toolchain from rustup,
+    // resolved from the project directory so rust-toolchain.toml is respected. Mirrors build.
+    let project_dir = get_project_dir(args.manifest_path.as_ref());
+    let effective_toolchain = args
+        .override_toolchain
+        .clone()
+        .or_else(|| detect_active_toolchain(project_dir));
+
+    let override_cargo_target_path_env = common_buildtime_env::CargoTargetDir::NoOp;
+
+    let crate_metadata = pretty_print::handle_step("Collecting cargo project metadata...", || {
+        let manifest_path =
+            crate::types::cargo::manifest_path::ManifestPath::from_manifest_path_opt(
+                args.manifest_path.clone(),
+            )?;
+        CrateMetadata::collect(
+            manifest_path,
+            args.no_locked,
+            &override_cargo_target_path_env,
+            effective_toolchain.clone(),
+        )
+    })?;
+
+    pretty_print::handle_step("Checking the host environment...", || {
+        if !cargo_native::target::wasm32_exists(effective_toolchain.clone()) {
+            eyre::bail!("rust target `{}` is not installed", COMPILATION_TARGET);
+        }
+        Ok(())
+    })?;
+
+    let mut cargo_args = vec!["--target", COMPILATION_TARGET];
+
+    if let Some(features) = args.features.as_ref() {
+        cargo_args.extend(&["--features", features.as_str()]);
+    }
+    if args.no_default_features {
+        cargo_args.push("--no-default-features");
+    }
+
+    match (args.no_release, args.profile.as_ref()) {
+        (_, Some(custom_profile_arg)) => {
+            cargo_args.extend(["--profile", custom_profile_arg]);
+        }
+        (false, None) => cargo_args.extend(["--profile", "release"]),
+        (true, None) => {}
+    }
+
+    if !args.no_locked {
+        cargo_args.push("--locked");
+    }
+
+    // Identical `--cfg near` rustflags assembly to build. Carried as CARGO_ENCODED_RUSTFLAGS,
+    // so we must not also forward RUSTFLAGS/CARGO_ENCODED_RUSTFLAGS from args.env below.
+    let encoded_rustflags = encoded_rustflags_with_cfg_near(&args.env);
+
+    let check_env = {
+        let mut check_env: Vec<(&str, &str)> = vec![(
+            env_keys::CARGO_ENCODED_RUSTFLAGS,
+            encoded_rustflags.as_str(),
+        )];
+        check_env.extend(
+            args.env
+                .iter()
+                .filter(|(k, _)| {
+                    k.as_str() != env_keys::RUSTFLAGS
+                        && k.as_str() != env_keys::CARGO_ENCODED_RUSTFLAGS
+                })
+                .map(|(key, value)| (key.as_str(), value.as_str())),
+        );
+
+        effective_toolchain.as_ref().inspect(|toolchain| {
+            check_env.push((env_keys::RUSTUP_TOOLCHAIN, toolchain));
+        });
+
+        check_env
+    };
+
+    let kind = if args.clippy {
+        crate::types::near::check::CheckKind::Clippy
+    } else {
+        crate::types::near::check::CheckKind::Check
+    };
+    let subcommand = kind.cargo_subcommand();
+
+    pretty_print::step(&format!("Checking contract (cargo {subcommand})"));
+    cargo_native::compile::run_check(
+        subcommand,
+        &crate_metadata.manifest_path,
+        &cargo_args,
+        check_env,
+        color,
+    )?;
+
+    pretty_print::success(&format!(
+        "Contract checked successfully! (cargo {subcommand})"
+    ));
+    pretty_print::duration(start, &format!("cargo near check (cargo {subcommand})"));
+    Ok(())
+}

--- a/cargo-near-build/src/near/check/mod.rs
+++ b/cargo-near-build/src/near/check/mod.rs
@@ -1,4 +1,4 @@
-use crate::types::near::build::buildtime_env::{Nep330BuildCommand, Nep330Link, Nep330Version};
+use crate::types::near::build::buildtime_env::Nep330CrateVars;
 use crate::types::near::build::common_buildtime_env;
 use crate::types::near::build::output::version_info::VersionInfo;
 use crate::types::near::check::Opts;
@@ -85,17 +85,16 @@ pub fn run(args: Opts) -> eyre::Result<()> {
     // so we must not also forward RUSTFLAGS/CARGO_ENCODED_RUSTFLAGS from args.env below.
     let encoded_rustflags = encoded_rustflags_with_cfg_near(&args.env);
 
-    // Reproduce the same NEP-330 build-time environment `cargo near build` exposes (via
-    // `CommonVariables`), so a contract whose source or `build.rs` reads these variables
-    // type-checks against the same configuration `build` would compile. The output-wasm-path
-    // variable is intentionally omitted — a `check` produces no artifact.
-    let nep330_version = Nep330Version::new(&crate_metadata);
-    let nep330_link = Nep330Link::new(&crate_metadata);
-    let nep330_build_cmd = Nep330BuildCommand::compute_with_fallback_argv(|| {
-        vec!["cargo".to_string(), "near".to_string(), "check".to_string()]
-    })?;
-    let builder_abi_versions =
-        VersionInfo::get_coerced_builder_version()?.compute_env_variables()?;
+    // Reproduce the same crate-identity NEP-330 build-time env `cargo near build` exposes (via
+    // `CommonVariables`, which shares this exact `Nep330CrateVars` group), so a contract whose
+    // source or `build.rs` reads these variables type-checks against the same configuration
+    // `build` would compile. The artifact/output-tied vars (output wasm path, contract-path and
+    // cargo-target-dir overrides) are intentionally omitted — a `check` produces no artifact.
+    let crate_vars = Nep330CrateVars::new(
+        &crate_metadata,
+        &VersionInfo::get_coerced_builder_version()?,
+        || vec!["cargo".to_string(), "near".to_string(), "check".to_string()],
+    )?;
 
     let check_env = {
         let mut check_env: Vec<(&str, &str)> = vec![(
@@ -112,10 +111,7 @@ pub fn run(args: Opts) -> eyre::Result<()> {
                 .map(|(key, value)| (key.as_str(), value.as_str())),
         );
 
-        nep330_version.append_borrowed_to(&mut check_env);
-        nep330_link.append_borrowed_to(&mut check_env);
-        nep330_build_cmd.append_borrowed_to(&mut check_env);
-        builder_abi_versions.append_borrowed_to(&mut check_env);
+        crate_vars.append_borrowed_to(&mut check_env);
 
         effective_toolchain.as_ref().inspect(|toolchain| {
             check_env.push((env_keys::RUSTUP_TOOLCHAIN, toolchain));

--- a/cargo-near-build/src/near/mod.rs
+++ b/cargo-near-build/src/near/mod.rs
@@ -2,6 +2,8 @@
 pub mod abi;
 #[cfg(feature = "build_internal")]
 pub mod build;
+#[cfg(feature = "build_internal")]
+pub mod check;
 
 #[cfg(feature = "build_external")]
 pub mod build_external;

--- a/cargo-near-build/src/types/near/build/buildtime_env/command.rs
+++ b/cargo-near-build/src/types/near/build/buildtime_env/command.rs
@@ -7,6 +7,17 @@ pub struct Nep330BuildCommand {
 
 impl Nep330BuildCommand {
     pub fn compute(args: &Opts) -> eyre::Result<Self> {
+        Self::compute_with_fallback_argv(|| args.to_argv())
+    }
+
+    /// Computes the `NEP330_BUILD_INFO_BUILD_COMMAND` value.
+    ///
+    /// In cli context (invoked via the `cargo-near` binary) the command is reconstructed from
+    /// `std::env::args()`. Otherwise (lib context) `fallback_argv` supplies the argv: `build`
+    /// passes its `to_argv()`, while non-wasm callers such as `check` pass their own.
+    pub(crate) fn compute_with_fallback_argv(
+        fallback_argv: impl FnOnce() -> Vec<String>,
+    ) -> eyre::Result<Self> {
         tracing::debug!(
             "compute `CARGO_NEAR_BUILD_COMMAND`,  current executable: {:?}",
             std::env::args().collect::<Vec<_>>()
@@ -26,7 +37,7 @@ impl Nep330BuildCommand {
             _ => {
                 // NOTE: order of output of cli flags shouldn't be too important, as the version of
                 // `cargo-near` used as lib will be fixed in `Cargo.lock`
-                args.to_argv()
+                fallback_argv()
             }
         };
 

--- a/cargo-near-build/src/types/near/build/buildtime_env/command.rs
+++ b/cargo-near-build/src/types/near/build/buildtime_env/command.rs
@@ -1,15 +1,10 @@
 use crate::env_keys;
-use crate::types::near::build::input::Opts;
 
 pub struct Nep330BuildCommand {
     value: String,
 }
 
 impl Nep330BuildCommand {
-    pub fn compute(args: &Opts) -> eyre::Result<Self> {
-        Self::compute_with_fallback_argv(|| args.to_argv())
-    }
-
     /// Computes the `NEP330_BUILD_INFO_BUILD_COMMAND` value.
     ///
     /// In cli context (invoked via the `cargo-near` binary) the command is reconstructed from

--- a/cargo-near-build/src/types/near/build/buildtime_env/crate_vars.rs
+++ b/cargo-near-build/src/types/near/build/buildtime_env/crate_vars.rs
@@ -1,0 +1,48 @@
+use crate::types::cargo::metadata::CrateMetadata;
+use crate::types::near::build::output::version_info::VersionInfo;
+
+use super::{BuilderAbiVersions, Nep330BuildCommand, Nep330Link, Nep330Version};
+
+/// NEP-330 build-time env vars describing the crate/build identity, independent of the emitted
+/// wasm artifact. Shared verbatim between `cargo near build` and `cargo near check` so the two
+/// commands can't silently type-check different configurations — add a new crate-level var here
+/// once and both paths pick it up.
+///
+/// The artifact/output-tied vars (`NEP330_BUILD_INFO_OUTPUT_WASM_PATH` and the contract-path /
+/// cargo-target-dir overrides) deliberately live on [`CommonVariables`](super::CommonVariables)
+/// instead, since a `check` emits no artifact and exposes none of them.
+pub struct Nep330CrateVars {
+    pub nep330_version: Nep330Version,
+    pub nep330_link: Nep330Link,
+    pub nep330_build_cmd: Nep330BuildCommand,
+    pub builder_abi_versions: BuilderAbiVersions,
+}
+
+impl Nep330CrateVars {
+    /// `fallback_argv` supplies the `NEP330_BUILD_INFO_BUILD_COMMAND` argv in lib context (in cli
+    /// context it's reconstructed from `std::env::args()` regardless): `build` passes its
+    /// [`Opts::to_argv`](crate::BuildOpts), `check` passes its own `["cargo", "near", "check"]`.
+    pub fn new(
+        crate_metadata: &CrateMetadata,
+        builder_version_info: &VersionInfo,
+        fallback_argv: impl FnOnce() -> Vec<String>,
+    ) -> eyre::Result<Self> {
+        let nep330_version = Nep330Version::new(crate_metadata);
+        let nep330_link = Nep330Link::new(crate_metadata);
+        let nep330_build_cmd = Nep330BuildCommand::compute_with_fallback_argv(fallback_argv)?;
+        let builder_abi_versions = builder_version_info.compute_env_variables()?;
+        Ok(Self {
+            nep330_version,
+            nep330_link,
+            nep330_build_cmd,
+            builder_abi_versions,
+        })
+    }
+
+    pub fn append_borrowed_to<'a>(&'a self, env: &mut Vec<(&str, &'a str)>) {
+        self.nep330_version.append_borrowed_to(env);
+        self.nep330_link.append_borrowed_to(env);
+        self.nep330_build_cmd.append_borrowed_to(env);
+        self.builder_abi_versions.append_borrowed_to(env);
+    }
+}

--- a/cargo-near-build/src/types/near/build/buildtime_env/mod.rs
+++ b/cargo-near-build/src/types/near/build/buildtime_env/mod.rs
@@ -4,6 +4,7 @@ mod link;
 mod version;
 
 mod command;
+mod crate_vars;
 mod output_paths;
 
 mod abi_builder_version;
@@ -16,6 +17,7 @@ pub use link::Nep330Link;
 pub use version::Nep330Version;
 
 pub use command::Nep330BuildCommand;
+pub use crate_vars::Nep330CrateVars;
 pub use output_paths::Nep330OutputWasmPath;
 
 pub use abi_builder_version::BuilderAbiVersions;
@@ -31,11 +33,9 @@ use super::output::version_info::VersionInfo;
 
 /// variables, common for both steps of build, abi-gen and wasm build
 pub struct CommonVariables {
-    pub nep330_version: Nep330Version,
-    pub nep330_link: Nep330Link,
-    pub nep330_build_cmd: Nep330BuildCommand,
+    /// crate-identity NEP-330 vars, shared verbatim with `cargo near check`
+    pub crate_vars: Nep330CrateVars,
     pub nep330_output_wasm_path: Nep330OutputWasmPath,
-    pub builder_abi_versions: BuilderAbiVersions,
     pub override_nep330_contract_path: Nep330ContractPath,
     pub override_cargo_target_path: CargoTargetDir,
 }
@@ -48,33 +48,24 @@ impl CommonVariables {
         override_cargo_target_path: CargoTargetDir,
         output_paths: &OutputPaths,
     ) -> eyre::Result<Self> {
-        let nep330_version = Nep330Version::new(crate_metadata);
-        let nep330_link = Nep330Link::new(crate_metadata);
-
-        let nep330_build_cmd = Nep330BuildCommand::compute(opts)?;
-        let builder_abi_versions = builder_version_info.compute_env_variables()?;
+        let crate_vars =
+            Nep330CrateVars::new(crate_metadata, builder_version_info, || opts.to_argv())?;
         let override_nep330_contract_path =
             Nep330ContractPath::maybe_new(opts.override_nep330_contract_path.clone());
 
         let nep330_output_wasm_path =
             Nep330OutputWasmPath::new(opts.override_nep330_output_wasm_path.clone(), output_paths);
         let result = Self {
-            nep330_version,
-            nep330_link,
-            nep330_build_cmd,
+            crate_vars,
             nep330_output_wasm_path,
-            builder_abi_versions,
             override_nep330_contract_path,
             override_cargo_target_path,
         };
         Ok(result)
     }
     pub fn append_borrowed_to<'a>(&'a self, env: &mut Vec<(&str, &'a str)>) {
-        self.nep330_version.append_borrowed_to(env);
-        self.nep330_link.append_borrowed_to(env);
-        self.nep330_build_cmd.append_borrowed_to(env);
+        self.crate_vars.append_borrowed_to(env);
         self.nep330_output_wasm_path.append_borrowed_to(env);
-        self.builder_abi_versions.append_borrowed_to(env);
         self.override_nep330_contract_path.append_borrowed_to(env);
         self.override_cargo_target_path.append_borrowed_to(env);
     }

--- a/cargo-near-build/src/types/near/build/input/mod.rs
+++ b/cargo-near-build/src/types/near/build/input/mod.rs
@@ -271,6 +271,16 @@ impl ColorPreference {
             ColorPreference::Never => colored::control::set_override(false),
         }
     }
+
+    /// Resolves `Auto` to `Always`/`Never` against cargo-near's own stderr (respecting
+    /// `NO_COLOR`). Used when handing `--color` to a child `cargo` whose output we capture:
+    /// cargo's own `auto` would see the capture pipe and strip colors.
+    pub(crate) fn resolved(self) -> Self {
+        match self {
+            ColorPreference::Auto => default_mode(),
+            already_resolved => already_resolved,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/cargo-near-build/src/types/near/check.rs
+++ b/cargo-near-build/src/types/near/check.rs
@@ -1,0 +1,68 @@
+/// Which cargo subcommand the `check` path drives.
+///
+/// Both run under the exact same environment `cargo near build` uses (`--cfg near`,
+/// `wasm32-unknown-unknown` target, same feature/profile/locked resolution and toolchain),
+/// but neither produces a wasm artifact.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum CheckKind {
+    /// `cargo check` — fast type-check, the default.
+    #[default]
+    Check,
+    /// `cargo clippy` — type-check plus clippy lints.
+    Clippy,
+}
+
+impl CheckKind {
+    /// The cargo subcommand string driven for this kind.
+    pub(crate) fn cargo_subcommand(self) -> &'static str {
+        match self {
+            CheckKind::Check => "check",
+            CheckKind::Clippy => "clippy",
+        }
+    }
+}
+
+/// Argument of [`check`](crate::check).
+///
+/// Mirrors the subset of [`BuildOpts`](crate::BuildOpts) that affects which configuration is
+/// type-checked. Build-only fields (`no_abi`/`no_embed_abi`/`no_doc`/`no_wasmopt`/`out_dir`/
+/// the NEP330 `override_*` outputs/`skip_rust_version_check`) are intentionally absent — a
+/// type-check emits no wasm, so ABI generation, `wasm-opt`, output copying and the
+/// rustc/protocol-version ceiling check don't apply.
+///
+/// [`std::default::Default`] yields a `cargo check` (not clippy) of the current directory's
+/// contract, `--release`, `--locked`.
+#[derive(Debug, Default, Clone, bon::Builder)]
+pub struct Opts {
+    /// Run `cargo clippy` instead of `cargo check`.
+    #[builder(default)]
+    pub clippy: bool,
+    /// disable implicit `--locked` flag for all `cargo` commands, enabled by default
+    #[builder(default)]
+    pub no_locked: bool,
+    /// Type-check in debug mode instead of `--release`
+    #[builder(default)]
+    pub no_release: bool,
+    /// Set build profile
+    pub profile: Option<String>,
+    /// Path to the `Cargo.toml` of the contract to check
+    #[builder(into)]
+    pub manifest_path: Option<camino::Utf8PathBuf>,
+    /// Set compile-time feature flags.
+    #[builder(into)]
+    pub features: Option<String>,
+    /// Disables default feature flags.
+    #[builder(default)]
+    pub no_default_features: bool,
+    /// Coloring: auto, always, never;
+    /// assumed to be auto when `None`
+    pub color: Option<crate::types::near::build::input::ColorPreference>,
+    /// additional environment key-value pairs, that should be passed to the underlying
+    /// `cargo check`/`cargo clippy` command
+    #[builder(default)]
+    pub env: Vec<(String, String)>,
+    /// override value of [`crate::env_keys::RUSTUP_TOOLCHAIN`] environment variable, used for
+    /// all invoked `rustc`, `cargo` and `rustup` commands
+    #[builder(into)]
+    pub override_toolchain: Option<String>,
+}

--- a/cargo-near-build/src/types/near/mod.rs
+++ b/cargo-near-build/src/types/near/mod.rs
@@ -5,6 +5,8 @@ use crate::types::cargo::metadata::CrateMetadata;
 #[cfg(feature = "build_internal")]
 pub mod abi;
 pub mod build;
+#[cfg(feature = "build_internal")]
+pub mod check;
 
 #[cfg(feature = "build_external")]
 pub mod build_extended;

--- a/cargo-near/src/commands/check/mod.rs
+++ b/cargo-near/src/commands/check/mod.rs
@@ -1,0 +1,148 @@
+use cargo_near_build::check::CheckOpts;
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = near_cli_rs::GlobalContext)]
+#[interactive_clap(output_context = CheckCommandlContext)]
+pub struct Command {
+    /// Run `cargo clippy` instead of `cargo check`
+    ///
+    /// By default `cargo near check` runs the equivalent of `cargo check`. With this flag it
+    /// runs `cargo clippy` instead, surfacing clippy lints in addition to type errors.
+    #[interactive_clap(long)]
+    #[interactive_clap(verbatim_doc_comment)]
+    pub clippy: bool,
+    /// Enable `--locked` flag for all `cargo` commands, disabled by default
+    ///
+    /// Running with `--locked` will fail, if
+    /// 1. the contract's crate doesn't have a Cargo.lock file,
+    ///    which locks in place the versions of all of the contract's dependencies
+    ///    (and, recursively, dependencies of dependencies ...), or
+    /// 2. if it has Cargo.lock file, but it needs to be updated (happens if Cargo.toml manifest was updated)
+    ///    This just passes `--locked` to all downstream `cargo` commands being called.
+    #[interactive_clap(long)]
+    #[interactive_clap(verbatim_doc_comment)]
+    pub locked: bool,
+    /// Check the contract in `dev` profile, without optimizations
+    ///
+    /// Without the flag `cargo-near` passes `--release` to the downstream `cargo` command.
+    /// When the flag is specified, `--release` isn't passed and the default `dev` profile is used.
+    #[interactive_clap(verbatim_doc_comment)]
+    #[interactive_clap(long)]
+    pub no_release: bool,
+    /// Check the contract with a custom build profile.
+    ///
+    /// This just passes the argument as `--profile` argument to the downstream `cargo` command.
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_interactive_input)]
+    pub profile: Option<String>,
+    /// Path to the `Cargo.toml` manifest of the contract crate to check
+    ///
+    /// If this argument is not specified, by default the `Cargo.toml` in current directory is assumed
+    /// as the manifest of target crate to check.
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_interactive_input)]
+    #[interactive_clap(verbatim_doc_comment)]
+    pub manifest_path: Option<crate::types::utf8_path_buf::Utf8PathBuf>,
+    /// Space or comma separated list of features to activate
+    ///
+    /// e.g. --features 'feature0 crate3/feature1 feature3'
+    /// This just passes the argument as `--features` argument to downstream `cargo` command.
+    /// Unlike `cargo` argument, this argument doesn't support repetition, at most 1 argument can be specified.
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_interactive_input)]
+    #[interactive_clap(verbatim_doc_comment)]
+    pub features: Option<String>,
+    /// Do not activate the `default` feature of contract's crate
+    ///
+    /// This just passes `--no-default-features` argument to downstream `cargo` command.
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_interactive_input)]
+    #[interactive_clap(verbatim_doc_comment)]
+    pub no_default_features: bool,
+    /// Whether to color output to stdout and stderr by printing ANSI escape sequences: auto, always, never
+    #[interactive_clap(long)]
+    #[interactive_clap(value_enum)]
+    #[interactive_clap(skip_interactive_input)]
+    pub color: Option<crate::types::color_preference_cli::ColorPreferenceCli>,
+    /// Environment overrides in the form of `"KEY=VALUE"` strings. This flag can be repeated.
+    ///
+    /// This makes sense to be used to specify custom `RUSTFLAGS` for the check, e.g.:
+    /// ```bash
+    /// cargo near check --env 'RUSTFLAGS=--verbose'
+    /// ```
+    /// In all cases `--cfg near` is force-appended to the resulting RUSTFLAGS by cargo-near, so
+    /// `near-sdk` selects the on-chain host-function path (identical to `cargo near build`).
+    #[interactive_clap(verbatim_doc_comment)]
+    #[interactive_clap(long_vec_multiple_opt)]
+    pub env: Vec<String>,
+    /// override value of `RUSTUP_TOOLCHAIN` environment variable, used for all invoked `rustc`, `cargo` and `rustup` commands
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_interactive_input)]
+    pub override_toolchain: Option<String>,
+}
+
+impl Command {
+    fn validate_env_opt(&self) -> color_eyre::eyre::Result<()> {
+        for pair in self.env.iter() {
+            pair.split_once('=').ok_or(color_eyre::eyre::eyre!(
+                "invalid \"key=value\" environment argument (must contain '='): {}",
+                pair
+            ))?;
+        }
+        Ok(())
+    }
+}
+
+impl From<Command> for CheckOpts {
+    fn from(value: Command) -> Self {
+        Self {
+            clippy: value.clippy,
+            no_locked: !value.locked,
+            no_release: value.no_release,
+            profile: value.profile,
+            manifest_path: value.manifest_path.map(Into::into),
+            features: value.features,
+            no_default_features: value.no_default_features,
+            color: value.color.map(Into::into),
+            env: get_key_vals(value.env),
+            override_toolchain: value.override_toolchain,
+        }
+    }
+}
+
+fn get_key_vals(input: Vec<String>) -> Vec<(String, String)> {
+    input
+        .iter()
+        .flat_map(|pair_string| {
+            pair_string
+                .split_once('=')
+                .map(|(env_key, value)| (env_key.to_string(), value.to_string()))
+        })
+        .collect()
+}
+
+#[derive(Debug, Clone)]
+pub struct CheckCommandlContext;
+
+impl CheckCommandlContext {
+    pub fn from_previous_context(
+        _previous_context: near_cli_rs::GlobalContext,
+        scope: &<Command as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let args = Command {
+            clippy: scope.clippy,
+            locked: scope.locked,
+            no_release: scope.no_release,
+            profile: scope.profile.clone(),
+            manifest_path: scope.manifest_path.clone(),
+            features: scope.features.clone(),
+            no_default_features: scope.no_default_features,
+            color: scope.color.clone(),
+            env: scope.env.clone(),
+            override_toolchain: scope.override_toolchain.clone(),
+        };
+        args.validate_env_opt()?;
+        cargo_near_build::check::check(args.into())?;
+        Ok(Self)
+    }
+}

--- a/cargo-near/src/commands/check/mod.rs
+++ b/cargo-near/src/commands/check/mod.rs
@@ -111,14 +111,26 @@ impl From<Command> for CheckOpts {
 }
 
 fn get_key_vals(input: Vec<String>) -> Vec<(String, String)> {
-    input
-        .iter()
-        .flat_map(|pair_string| {
-            pair_string
-                .split_once('=')
-                .map(|(env_key, value)| (env_key.to_string(), value.to_string()))
-        })
-        .collect()
+    use std::collections::HashMap;
+
+    let iterator = input.iter().flat_map(|pair_string| {
+        pair_string
+            .split_once('=')
+            .map(|(env_key, value)| (env_key.to_string(), value.to_string()))
+    });
+
+    // Deduplicate repeated `KEY=VALUE` pairs (last value wins), matching `cargo near build`'s
+    // `env_pairs::get_key_vals` so a repeated `--env KEY=...` behaves identically across commands.
+    let dedup_map: HashMap<String, String> = HashMap::from_iter(iterator);
+
+    let result = dedup_map.into_iter().collect();
+    tracing::info!(
+        target: "near_teach_me",
+        parent: &tracing::Span::none(),
+        "Passed additional environment pairs:\n{}",
+        near_cli_rs::common::indent_payload(&format!("{result:#?}"))
+    );
+    result
 }
 
 #[derive(Debug, Clone)]

--- a/cargo-near/src/commands/mod.rs
+++ b/cargo-near/src/commands/mod.rs
@@ -2,6 +2,7 @@ use strum::{EnumDiscriminants, EnumIter, EnumMessage};
 
 pub mod abi;
 pub mod build;
+pub mod check;
 pub mod create_dev_account;
 pub mod deploy;
 pub mod new;
@@ -29,6 +30,11 @@ pub enum NearCommand {
     ))]
     /// Generates ABI for the contract
     Abi(self::abi::Command),
+    #[strum_discriminants(strum(
+        message = "check               -  Type-check a NEAR contract (cargo check/clippy) without building wasm"
+    ))]
+    /// Type-check a NEAR contract (runs `cargo check`, or `cargo clippy` with `--clippy`) under the same environment as `cargo near build`, without producing a wasm artifact
+    Check(self::check::Command),
     #[strum_discriminants(strum(
         message = "create-dev-account  -  Create a development account using a faucet service sponsor and receive some NEAR tokens (testnet only).
 │                            To create an account on mainnet, use NEAR CLI [https://near.cli.rs]"


### PR DESCRIPTION
## Motivation

Closes #439.

`near-sdk >= 5.27` selects the on-chain host-function path via the `--cfg near` cfg flag. `cargo near build` force-appends `--cfg near` to `CARGO_ENCODED_RUSTFLAGS` and targets `wasm32-unknown-unknown`. A plain `cargo check`/`cargo clippy` does **not** set `--cfg near`, doesn't target wasm32, and doesn't pick up the contract's feature/profile selection — so it checks the wrong configuration or fails against near-sdk's guard.

Downstream projects (e.g. near/intents) currently reconstruct the build env by hand in CI just to lint contracts. `cargo near check` gives them the "check" half of `cargo near build` directly, and is a faster local dev loop than a full build.

## What it does

Bare `cargo near check` type-checks the contract under the **same environment** `cargo near build` uses:

- `--cfg near` force-appended to `CARGO_ENCODED_RUSTFLAGS` (identical logic to build — the assembly is now a shared helper, `encoded_rustflags_with_cfg_near`)
- target `wasm32-unknown-unknown`; verifies the target is installed
- same `--features` / `--no-default-features` / `--profile` (`--release` by default, opt out with `--no-release`) / `--locked` resolution
- respects the active/overridden toolchain

…then runs `cargo check` (default), or `cargo clippy` when `--clippy` is passed. Cargo diagnostics stream through and the exit status is propagated.

It **skips** (all only matter when emitting wasm): ABI generation/embedding, `wasm-opt`, output-path copying, and the rustc/protocol-version ceiling check.

```console
cargo near check            # cargo check
cargo near check --clippy   # cargo clippy
```

## Design choices

- **Flat command** (like `cargo near abi`), not the reproducible/non-reproducible action split that `build` has — a reproducible "check" is meaningless (no artifact). Options mirror the `non-reproducible-wasm` `BuildOpts` minus the build-only flags (`--no-abi`/`--no-embed-abi`/`--no-doc`/`--no-wasmopt`/`--out-dir`/`--abi-features`/`--skip-rust-version-check`), plus a `--clippy` bool.
- **`check` vs `clippy`**: single command with a `--clippy` flag rather than two commands; both run the identical environment, only the cargo subcommand differs.
- **Shared env setup**: the `--cfg near` rustflags assembly was extracted from `build::run` into `encoded_rustflags_with_cfg_near` and is called by both paths. `build::run`'s behavior is byte-for-byte unchanged (verified by the existing test suite); a new unit test locks in the helper.
- **New non-artifact cargo path**: `cargo_native::compile::run_check` reuses `invoke_cargo` with the `check`/`clippy` subcommand and skips the artifact-lookup tail (which would otherwise bail since check produces no wasm).
- **Public API parity**: added `cargo_near_build::check(...)` / `CheckOpts` / `CheckKind` mirroring `build()`/`abi()`.
- **`[package.metadata.near.reproducible_build]` auto-pickup**: not applicable — like `build non-reproducible-wasm`, the flat check command does not read that section (it's docker/reproducible-only).

## Files changed

- `cargo-near-build/src/cargo_native/compile.rs` — new `run_check`
- `cargo-near-build/src/near/build/mod.rs` — extracted `encoded_rustflags_with_cfg_near`; `pub(crate)` on `detect_active_toolchain`/`get_project_dir`; unit test
- `cargo-near-build/src/near/check/mod.rs` — new `run`
- `cargo-near-build/src/types/near/check.rs` — new `Opts` (`CheckOpts`) + `CheckKind`
- `cargo-near-build/src/{near,types/near}/mod.rs` — module wiring
- `cargo-near-build/src/lib.rs` — public `check` module
- `cargo-near/src/commands/check/mod.rs` — new CLI command
- `cargo-near/src/commands/mod.rs` — `Check` variant on `NearCommand`
- `README.md` — `cargo near check` docs

## Tested locally

Scaffolded a throwaway contract with the freshly built `cargo near new`, then ran the built binary:

- `cargo near check --manifest-path <fixture>/Cargo.toml` → exit 0; teach-me trace confirms the invocation is `cargo check --target wasm32-unknown-unknown --profile release` with `CARGO_ENCODED_RUSTFLAGS=-C␟link-arg=-s␟--cfg␟near` and the active `RUSTUP_TOOLCHAIN`.
- `cargo near check --clippy …` → runs `cargo clippy`, exit 0.
- Added a `#[cfg(near)]`-gated type error to the contract → check **caught** it (proving `--cfg near` is active) and propagated exit 1; removing it returned to exit 0.
- `--locked --no-release` from the contract dir (no `--manifest-path`) → invocation gains `--locked` and drops `--profile release`, confirming flag/cwd plumbing.
- rustc was 1.93 with no PV metadata, yet check ran fine — confirming the rustc/protocol ceiling check is correctly skipped (a wasm build would reject 1.93 here).

Repo CI checks run locally on the changes (all green): `cargo fmt -- --check`; `cargo clippy --tests -- -Dclippy::all`; `cargo check -p cargo-near-build` for default / `--features build_internal` / `--features docker` / `--all-features`; `RUSTDOCFLAGS="-D warnings" cargo doc -p cargo-near-build` + `cargo test -p cargo-near-build --doc`; `cargo test -p cargo-near-build --features build_internal --lib` (18 tests incl. the new one).

The full `cargo nextest run --workspace` suite (which spins up a NEAR sandbox and compiles contracts under pinned 1.86/1.93 toolchains) was not run end-to-end locally — it's heavy and disk-bound in this environment. No existing tests were modified, and the build front-half is unchanged, so regression risk is low.