### PR TITLE
chore: pin to nearcore 2.13.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0](https://github.com/near/cargo-near/compare/cargo-near-v0.22.0-rc.1...cargo-near-v0.22.0) - 2026-07-13
+
+### Added
+
+- add `cargo near check` subcommand ([#442](https://github.com/near/cargo-near/pull/442))
+- print built contract size in `cargo near build` output ([#441](https://github.com/near/cargo-near/pull/441))
+
+### Fixed
+
+- isolate ABI generation pass into its own CARGO_TARGET_DIR ([#447](https://github.com/near/cargo-near/pull/447))
+- clear cargo-audit failures from new RustSec advisories ([#448](https://github.com/near/cargo-near/pull/448))
+
 ## [0.22.0-rc.1](https://github.com/near/cargo-near/compare/cargo-near-v0.21.1...cargo-near-v0.22.0-rc.1) - 2026-07-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near"
-version = "0.22.0-rc.1"
+version = "0.22.0"
 dependencies = [
  "base64 0.22.1",
  "cargo-near-build",
@@ -474,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-near-build"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "bon",
  "bs58 0.5.1",
@@ -3000,9 +3000,9 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139112ed78ed5f62ace80e88f4fe2de3edad1a94b90431263b18654d62473e9a"
+checksum = "3bf7f65155e58f46a815199e406dc55400a745129ee53c345ed473e07c938dca"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -3025,9 +3025,9 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.28.0-rc.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063f4f39eafea13b6d447fa9d18ae108a9ce0d37061ded96434fdee57fc8434a"
+checksum = "9ccc9f14018da7ca188fdacfc9a3a8b7d3417b7535a924d81682f58167e8ff18"
 dependencies = [
  "bip39",
  "borsh",
@@ -3086,9 +3086,9 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b30e07d9eb158f1084a36db8963262f75a353b0093a033aa0529faae9db108"
+checksum = "e16c9503c54bf8a30614798bd8ed5e9c24f39a2cc24600326c625b58c1192720"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -3098,9 +3098,9 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee338484a9348f3768f4d636a98875f746b9dfeb58f4d7761e70ff74f3ddbb5"
+checksum = "39867e452d80d3dc49dd73bff9532a3c45a979621a4be23a428f19f4764c0295"
 dependencies = [
  "aws-lc-rs",
  "blake2",
@@ -3126,9 +3126,9 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf5e92ed9616818b0cbedcc582d2a582194334f9b622276580453624712380b"
+checksum = "856cfe4ca4c02cbc8173208d0fe5244db8d5c172adac83a40fced1610c18625e"
 dependencies = [
  "near-primitives-core",
 ]
@@ -3147,9 +3147,9 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "0.22.0-rc.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249aacedbd175416a3635a83752581225b08a80e34bcba7ff65959c8954cf8e7"
+checksum = "2d89c387760380551514795ac1d1b9de102fc09d3bc0a6ded75e88ded33d6822"
 dependencies = [
  "borsh",
  "lazy_static",
@@ -3166,9 +3166,9 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ada6f8e357a6eecba4947cb21e56abc58036fcab2136a438b358a4042b62a6"
+checksum = "852ef64fd5e86c5dfa24caae15bc30e3d070770b3c66edb952090d4bba7d6833"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -3234,9 +3234,9 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a94eb0bc87f470537646ea6bc5b5b9272bcceb8a798a1bd47e938f8737454a"
+checksum = "c8a7b0a2a671e8122e0685ba4f164a0d563be8ce1f17e1f3cf8c2f1a82876d38"
 dependencies = [
  "borsh",
  "enum-map",
@@ -3253,9 +3253,9 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5704a32bee9023c61c725ed6403f6bfdd21226e4798d74312b427c5a0f7022c"
+checksum = "9c9d50f756f3090ff71e48ea159c0e849c856f867cbe6043b4faaceda8e819d6"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -3296,9 +3296,9 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f94564d97ca478c94b8a34fdcda0a0077b967fa83e7187c6b8267e9b6e441d47"
+checksum = "fb4ca8694b859cf7c7d894e756bbd46bf09b0bc5f243494ed7698eee1bc799a7"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -3320,9 +3320,9 @@ dependencies = [
 
 [[package]]
 name = "near-sandbox"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbace90e6262f645e638a6540dc08cac42ac2b3088bbb60b13eb630f6759c1c"
+checksum = "a511742b85175d6a233f922eb4770ba7755a34a111ef42aacab1970b5a2a927e"
 dependencies = [
  "flate2",
  "fs4",
@@ -3342,15 +3342,15 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-core"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "481ec75b745264fa2403643acde2402536ed4273fbf05ea8749a5d1813f683a0"
+checksum = "396465c4d441ad832b49f485cda5f5072f13696b1c46c9277d49b4937fb0eeee"
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb4a7f0e4eb5aaa1032a396ef0b840f6b3cda399dfa74b9d5cfaf0c1b537260"
+checksum = "d4dff8ead107faf2f5744d1f126ecc3a3bde129c3e36902ad4020464beac0651"
 dependencies = [
  "near-schema-checker-core",
  "near-schema-checker-macro",
@@ -3358,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24abafad706a94a56a687618ae7e13b296b0443f54c7b7d92477b3b3c82e336d"
+checksum = "732349f01e6f6e47edf921900d6a085b7ed3088464df21b312fec6ade44f8da2"
 
 [[package]]
 name = "near-slip10"
@@ -3375,9 +3375,9 @@ dependencies = [
 
 [[package]]
 name = "near-socialdb-client"
-version = "0.16.0-rc.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf155a85c6b9bd805beff5f7d0cfae6bcd113a952d13d21733d6bc3b9090a89"
+checksum = "7c94b3a6c2271c80d22a118e66bb093dd98d8ae4fab608125352e3f8cd192d1e"
 dependencies = [
  "eyre",
  "near-crypto",
@@ -3392,15 +3392,15 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e1cf6e256646ef9cabf86759582b2e7b06edfde846edaa68fc7d3e69d833f8"
+checksum = "305f4222ee62ff3ec872210f4d3871091d088063d1b51b957a19014d724dacfc"
 
 [[package]]
 name = "near-time"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3014c3edcc10d38313abd8401700b565ab555423eee090a1b1491c700ed711a2"
+checksum = "e9286bbc85a0701cf75cda7ca295f56bda904e6535903e06f8d8d3e494d03ffa"
 dependencies = [
  "parking_lot",
  "serde",
@@ -3446,9 +3446,9 @@ dependencies = [
 
 [[package]]
 name = "near-workspaces"
-version = "0.23.0-rc.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b38b66245c2220cc8d0a2a2324ccd7bba0eb834e4bb4791ba49585c9ce5a9ac"
+checksum = "a0bef8f24e12779aafee45b0549e7dbbfa331699d2cd3dece8fa1056797a3111"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/cargo-near-build/CHANGELOG.md
+++ b/cargo-near-build/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.5](https://github.com/near/cargo-near/compare/cargo-near-build-v0.11.4...cargo-near-build-v0.11.5) - 2026-07-13
+
+### Added
+
+- add `cargo near check` subcommand ([#442](https://github.com/near/cargo-near/pull/442))
+- print built contract size in `cargo near build` output ([#441](https://github.com/near/cargo-near/pull/441))
+
+### Fixed
+
+- isolate ABI generation pass into its own CARGO_TARGET_DIR ([#447](https://github.com/near/cargo-near/pull/447))
+- clear cargo-audit failures from new RustSec advisories ([#448](https://github.com/near/cargo-near/pull/448))
+
 ## [0.11.4](https://github.com/near/cargo-near/compare/cargo-near-build-v0.11.3...cargo-near-build-v0.11.4) - 2026-07-02
 
 ### Other

--- a/cargo-near-build/Cargo.toml
+++ b/cargo-near-build/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-near-build"
 edition.workspace = true
 rust-version = "1.86"
-version = "0.11.4"
+version = "0.11.5"
 description = "Library for building Rust smart contracts on NEAR, basis of `cargo-near` crate/CLI"
 repository = "https://github.com/near/cargo-near"
 license = "MIT OR Apache-2.0"

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -39,7 +39,6 @@ names = { version = "0.14.0", default-features = false }
 derive_more = "2"
 shell-words = "1.0.0"
 interactive-clap = "0.3.2"
-# nearcore 2.13 (post-quantum) crates on crates.io.
 near-cli-rs = { version = "0.28.0", default-features = false }
 near-primitives = { version = "0.37.0", default-features = false }
 reqwest = "0.12.5"

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-near"
-version = "0.22.0-rc.1"
+version = "0.22.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition.workspace = true
 rust-version = "1.93"
@@ -39,11 +39,9 @@ names = { version = "0.14.0", default-features = false }
 derive_more = "2"
 shell-words = "1.0.0"
 interactive-clap = "0.3.2"
-# DRAFT(post-quantum): nearcore 2.13 RC crates. Pinned to the published 2.13
-# RCs on crates.io (near-cli-rs 0.28.0-rc.1 pins near-primitives =0.37.0-rc.2).
-# Drop the `-rc` pins for the stable versions once 2.13 ships.
-near-cli-rs = { version = "=0.28.0-rc.1", default-features = false }
-near-primitives = { version = "=0.37.0-rc.2", default-features = false }
+# nearcore 2.13 (post-quantum) crates on crates.io.
+near-cli-rs = { version = "0.28.0", default-features = false }
+near-primitives = { version = "0.37.0", default-features = false }
 reqwest = "0.12.5"
 indenter = "0.3"
 tracing-core = "0.1.32"

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -23,7 +23,7 @@ license = false
 eula = false
 
 [dependencies]
-cargo-near-build = { version = "0.11.4", path = "../cargo-near-build", features = [
+cargo-near-build = { version = "0.11.5", path = "../cargo-near-build", features = [
     "build_internal",
     "docker",
 ] }

--- a/cargo-near/src/commands/new/new-project-template/Cargo.template.toml
+++ b/cargo-near/src/commands/new/new-project-template/Cargo.template.toml
@@ -38,11 +38,11 @@ container_build_command = [
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-near-sdk = "5.28"
+near-sdk = "5.29"
 
 [dev-dependencies]
-near-sdk = { version = "5.28", features = ["unit-testing"] }
-near-sandbox = "0.3.11"
+near-sdk = { version = "5.29", features = ["unit-testing"] }
+near-sandbox = "0.3.12"
 near-api = "0.8"
 cargo-near-build = "0.11.0"
 tokio = { version = "1.12.0", features = ["full"] }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 const_format = "0.2"
-cargo-near-build = { version = "0.11.4", path = "../cargo-near-build" }
+cargo-near-build = { version = "0.11.5", path = "../cargo-near-build" }
 cargo-near = { path = "../cargo-near", default-features = false }
 tracing = "0.1.40"
 prettyplease = "0.2"
@@ -15,7 +15,7 @@ syn = "2"
 [dev-dependencies]
 borsh = { version = "1.0.0", features = ["derive", "unstable__schema"] }
 camino = "1.1.1"
-cargo-near-build = { version = "0.11.4", path = "../cargo-near-build", features = [
+cargo-near-build = { version = "0.11.5", path = "../cargo-near-build", features = [
     "test_code",
 ] }
 near-api = "0.8"

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -20,7 +20,7 @@ cargo-near-build = { version = "0.11.4", path = "../cargo-near-build", features 
 ] }
 near-api = "0.8"
 near-sandbox = "0.3"
-near-workspaces = "=0.23.0-rc.1"
+near-workspaces = "0.23.0"
 function_name = "0.3"
 git2 = "0.20"
 minifier = "0.3"

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -14,11 +14,10 @@ pub fn setup_tracing() {
     let _ = cargo_near::setup_tracing(true, false);
 }
 
-/// nearcore version the suite spins its sandbox node on. Pinned to the 2.13 RC
+/// nearcore version the suite spins its sandbox node on. Pinned to 2.13
 /// (protocol v85) so tests exercise cargo-near against 2.13 rather than the
-/// `near-sandbox` crate's 2.12 default (`DEFAULT_NEAR_SANDBOX_VERSION`). Bump to
-/// the stable 2.13 tag once it ships.
-pub const NEAR_SANDBOX_VERSION: &str = "2.13.0-rc.2";
+/// `near-sandbox` crate's 2.12 default (`DEFAULT_NEAR_SANDBOX_VERSION`).
+pub const NEAR_SANDBOX_VERSION: &str = "2.13.0";
 
 /// NOTE: this version is version of near-sdk in arbitrary revision from N.x.x development cycle
 pub mod from_git {

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -14,11 +14,6 @@ pub fn setup_tracing() {
     let _ = cargo_near::setup_tracing(true, false);
 }
 
-/// nearcore version the suite spins its sandbox node on. Pinned to 2.13
-/// (protocol v85) so tests exercise cargo-near against 2.13 rather than the
-/// `near-sandbox` crate's 2.12 default (`DEFAULT_NEAR_SANDBOX_VERSION`).
-pub const NEAR_SANDBOX_VERSION: &str = "2.13.0";
-
 /// NOTE: this version is version of near-sdk in arbitrary revision from N.x.x development cycle
 pub mod from_git {
     use const_format::formatcp;

--- a/integration-tests/tests/build/opts.rs
+++ b/integration-tests/tests/build/opts.rs
@@ -1,5 +1,5 @@
 use crate::util;
-use cargo_near_integration_tests::{NEAR_SANDBOX_VERSION, build_fn_with, setup_tracing};
+use cargo_near_integration_tests::{build_fn_with, setup_tracing};
 use function_name::named;
 use std::fs;
 
@@ -30,7 +30,7 @@ async fn test_build_no_embed_abi() -> testresult::TestResult {
         }
     };
 
-    let worker = near_workspaces::sandbox_with_version(NEAR_SANDBOX_VERSION).await?;
+    let worker = near_workspaces::sandbox().await?;
     let contract = worker.dev_deploy(&build_result.wasm).await?;
     let outcome = contract.call("__contract_abi").view().await;
     outcome.unwrap_err();
@@ -155,7 +155,7 @@ async fn test_build_abi_features_separate_from_wasm_features() -> testresult::Te
     );
 
     // WASM should NOT have gated_only (features does not have "gated")
-    let worker = near_workspaces::sandbox_with_version(NEAR_SANDBOX_VERSION).await?;
+    let worker = near_workspaces::sandbox().await?;
     let contract = worker.dev_deploy(&build_result.wasm).await?;
     let outcome = contract.call("gated_only").view().await;
     assert!(
@@ -202,7 +202,7 @@ async fn test_build_both_features_and_abi_features_for_different_targets() -> te
     );
 
     // WASM should also have gated_only (--features gated)
-    let worker = near_workspaces::sandbox_with_version(NEAR_SANDBOX_VERSION).await?;
+    let worker = near_workspaces::sandbox().await?;
     let contract = worker.dev_deploy(&build_result.wasm).await?;
     let outcome = contract.call("gated_only").view().await?;
     assert!(outcome.json::<bool>()?);

--- a/integration-tests/tests/util/mod.rs
+++ b/integration-tests/tests/util/mod.rs
@@ -4,9 +4,7 @@ use serde_json::json;
 
 /// Utility method to test that the `add` function is available and works as intended
 pub async fn test_add(wasm: &[u8]) -> cargo_near::CliResult {
-    let worker =
-        near_workspaces::sandbox_with_version(cargo_near_integration_tests::NEAR_SANDBOX_VERSION)
-            .await?;
+    let worker = near_workspaces::sandbox().await?;
     let contract = worker.dev_deploy(wasm).await?;
     let outcome = contract
         .call("add")
@@ -21,9 +19,7 @@ pub async fn test_add(wasm: &[u8]) -> cargo_near::CliResult {
 }
 
 pub async fn fetch_contract_abi(wasm: &[u8]) -> testresult::TestResult<AbiRoot> {
-    let worker =
-        near_workspaces::sandbox_with_version(cargo_near_integration_tests::NEAR_SANDBOX_VERSION)
-            .await?;
+    let worker = near_workspaces::sandbox().await?;
     let contract = worker.dev_deploy(wasm).await?;
     let outcome = contract.call("__contract_abi").view().await?;
     let outcome_json = zstd::decode_all(outcome.result.as_slice())?;


### PR DESCRIPTION
nearcore 2.13.0 is on crates.io and the rest of the 2.13 cascade is published (`near-cli-rs` 0.28.0, `near-workspaces` 0.23.0), so this builds against the live stable crates.

- Swaps the RC pins for stable: `near-primitives` `=0.37.0-rc.2` → `0.37.0`, `near-cli-rs` `=0.28.0-rc.1` → `0.28.0`, `near-workspaces` (integration-tests dev-dep) `=0.23.0-rc.1` → `0.23.0`, integration-tests sandbox pin `2.13.0-rc.2` → `2.13.0`.
- Releases `cargo-near` 0.22.0 and `cargo-near-build` 0.11.5 — the latter picks up the `cargo near check` and build-size output work (#442, #441) that merged since rc.1, so it can no longer stay on the published 0.11.4.
