### PR TITLE
fix: isolate ABI generation pass into its own CARGO_TARGET_DIR

### DIFF
--- a/cargo-near-build/src/near/abi/generate/mod.rs
+++ b/cargo-near-build/src/near/abi/generate/mod.rs
@@ -69,6 +69,21 @@ pub fn procedure(
 
     pretty_print::step("Generating ABI");
 
+    // The ABI dylib is compiled with its own feature set (`near-sdk/__abi-generate`) and
+    // forced `dev`-profile overrides below, distinct from both the subsequent wasm pass
+    // (different features, `--cfg near` rustflags) and any of the user's own native builds
+    // (`cargo test`, rust-analyzer's `cargo check`) of the same crate graph. Sharing a target
+    // directory with either of those means the alternating profiles/features on the same
+    // dependency units (near-sdk, near-sdk-macros, ...) invalidate each other's fingerprints
+    // back and forth on every switch. Building into a dedicated subdirectory of the resolved
+    // target directory keeps this pass' cache from ever being disturbed by, or disturbing,
+    // anyone else's.
+    let abi_target_dir = crate_metadata
+        .raw_metadata
+        .target_directory
+        .join("cargo-near-abi");
+    let abi_target_dir = abi_target_dir.as_str();
+
     let compile_env = {
         let compile_env = vec![
             ("CARGO_PROFILE_DEV_OPT_LEVEL", "0"),
@@ -76,7 +91,14 @@ pub fn procedure(
             ("CARGO_PROFILE_DEV_LTO", "off"),
             (env_keys::BUILD_RS_ABI_STEP_HINT, "true"),
         ];
-        [&compile_env, env].concat()
+        // appended last, so it wins over any `CARGO_TARGET_DIR` the caller may have
+        // already folded into `env` (e.g. a user-supplied `--target-dir` override)
+        [
+            &compile_env,
+            env,
+            &[(env_keys::CARGO_TARGET_DIR, abi_target_dir)],
+        ]
+        .concat()
     };
     let dylib_artifact = cargo_native::compile::run::<Dylib>(
         &crate_metadata.manifest_path,


### PR DESCRIPTION
## Problem

Every `cargo near build` recompiles `near-sdk` and `near-sdk-macros` instead of reusing the cache.

## Cause

The ABI generation pass (`cargo-near-build/src/near/abi/generate/mod.rs`) compiles the contract as a host dylib with `--features near-sdk/__abi-generate` plus forced profile overrides (`CARGO_PROFILE_DEV_OPT_LEVEL=0`, `CARGO_PROFILE_DEV_DEBUG=0`, `CARGO_PROFILE_DEV_LTO=off`), sharing one `target/` directory with the wasm pass and with any other dev-profile build of the same crate graph (`cargo build`, `cargo test`, rust-analyzer's `cargo check`). Those forced overrides diverge from cargo's own dev-profile defaults (`debug` defaults on), so alternating between the ABI pass and any ordinary dev build of the project flips the fingerprint of shared dependency units back and forth.

Confirmed with `CARGO_LOG=cargo::core::compiler::fingerprint=info`: running a plain `cargo build` right after `cargo near build` shows

```
fingerprint dirty for repro446 v0.1.0 (...)/Build/...
    dirty: ProfileConfigurationChanged
fingerprint error for near-sdk v5.28.3/Build/...
    err: failed to read `.../target/debug/.fingerprint/near-sdk-b155b17a96a380ed/lib-near_sdk`
   Compiling near-sdk v5.28.3
```

i.e. a brand new, never-before-seen fingerprint hash for `near-sdk`, forcing a full recompile — purely from the profile mismatch, independent of the feature-set difference. Two bare `cargo near build` invocations back-to-back with nothing in between don't reproduce it in isolation (each pass reuses its own prior fingerprint fine); it's the interleaving with any other dev-profile build of the project — an everyday occurrence with `cargo test` or rust-analyzer running in the background — that thrashes the shared cache.

## Fix

Build the ABI dylib into its own `<target-dir>/cargo-near-abi` subdirectory (`CARGO_TARGET_DIR` set just for that invocation) instead of the shared default, so its forced profile overrides and feature set can never collide with the wasm pass or with any other build of the same project.

## Repro

```
cargo near new <dir>
cd <dir>
cargo near build non-reproducible-wasm   # populates caches
cargo build                              # simulates a native dev build / rust-analyzer
cargo near build non-reproducible-wasm   # before fix: recompiles near-sdk/near-sdk-macros in the ABI step
                                          # after fix: fully cached, ABI dylib mtime unchanged, same wasm output
```

Fixes #446
