### PR TITLE
feat: `cargo near build list` to enumerate workspace contracts and variants

### DIFF
--- a/cargo-near-build/src/lib.rs
+++ b/cargo-near-build/src/lib.rs
@@ -62,6 +62,15 @@ mod build_exports {
 
 pub use build_exports::*;
 
+/// Enumerate the contracts in a Cargo workspace and their reproducible-build variants.
+///
+/// The discovery primitive behind `cargo near build list`. Available regardless of enabled
+/// features, so build scripts and test harnesses (e.g. `near-workspaces`) can reuse it to drive
+/// multi-contract builds, such as one CI matrix job per (contract, variant) pair.
+pub mod list {
+    pub use crate::near::list::{BuildUnit, WorkspaceContract, list_contracts};
+}
+
 #[cfg(feature = "build_internal")]
 pub use crate::near::build::run as build;
 

--- a/cargo-near-build/src/lib.rs
+++ b/cargo-near-build/src/lib.rs
@@ -68,7 +68,7 @@ pub use build_exports::*;
 /// features, so build scripts and test harnesses (e.g. `near-workspaces`) can reuse it to drive
 /// multi-contract builds, such as one CI matrix job per (contract, variant) pair.
 pub mod list {
-    pub use crate::near::list::{BuildUnit, WorkspaceContract, list_contracts};
+    pub use crate::near::list::{BuildUnit, Workspace, WorkspaceContract, list_contracts};
 }
 
 #[cfg(feature = "build_internal")]

--- a/cargo-near-build/src/near/list.rs
+++ b/cargo-near-build/src/near/list.rs
@@ -14,7 +14,9 @@ use eyre::WrapErr;
 pub struct WorkspaceContract {
     /// Cargo package name, e.g. `defuse-poa-factory`.
     pub name: String,
-    /// Absolute path to the crate's `Cargo.toml`.
+    /// Path to the crate's `Cargo.toml`, relative to the workspace root ([`Workspace::root`]),
+    /// e.g. `contracts/defuse/Cargo.toml`. Relative so it is portable across machines and CI
+    /// runners; join it onto [`Workspace::root`] for an absolute path.
     pub manifest_path: Utf8PathBuf,
     /// Build variants, default first.
     ///
@@ -65,8 +67,19 @@ pub struct BuildUnit {
     /// The wasm filename `cargo near build` writes to the out-dir, e.g. `defuse_poa_token.wasm`.
     /// Variant-independent (see [`WorkspaceContract::wasm_filename`]).
     pub output: String,
-    /// Absolute path to the contract crate's `Cargo.toml`.
+    /// Path to the contract crate's `Cargo.toml`, relative to the workspace root
+    /// (see [`WorkspaceContract::manifest_path`]).
     pub manifest_path: Utf8PathBuf,
+}
+
+/// A Cargo workspace and the contracts in it that opt into reproducible builds.
+#[derive(Debug, Clone)]
+pub struct Workspace {
+    /// Absolute path to the workspace root (the directory containing the workspace `Cargo.toml`).
+    /// Each contract's [`WorkspaceContract::manifest_path`] is relative to this.
+    pub root: Utf8PathBuf,
+    /// Discovered contracts, sorted by package name.
+    pub contracts: Vec<WorkspaceContract>,
 }
 
 /// Discover every workspace member that opts into reproducible builds, with its variants.
@@ -76,11 +89,14 @@ pub struct BuildUnit {
 /// `[package.metadata.near.reproducible_build]` section are skipped. Results are sorted by package
 /// name, and each contract's variants are sorted, so the output is deterministic.
 ///
+/// Each [`WorkspaceContract::manifest_path`] is returned relative to [`Workspace::root`], which is
+/// itself absolute, so the paths are portable while staying resolvable via `root.join(...)`.
+///
 /// Runs `cargo metadata --no-deps`: the dependency graph is not resolved, which keeps this fast
 /// and avoids requiring an up-to-date `Cargo.lock`. Presence of the `reproducible_build` section
 /// is the only requirement; its contents (image, digest, ...) are not validated here, so a
 /// half-filled section still shows up rather than being silently dropped.
-pub fn list_contracts(manifest_path: Option<&Utf8Path>) -> eyre::Result<Vec<WorkspaceContract>> {
+pub fn list_contracts(manifest_path: Option<&Utf8Path>) -> eyre::Result<Workspace> {
     let mut command = cargo_metadata::MetadataCommand::new();
     command.no_deps();
     if let Some(manifest_path) = manifest_path {
@@ -89,6 +105,7 @@ pub fn list_contracts(manifest_path: Option<&Utf8Path>) -> eyre::Result<Vec<Work
     let metadata = command
         .exec()
         .wrap_err("Failed to run `cargo metadata` to enumerate workspace contracts")?;
+    let root = metadata.workspace_root.clone();
 
     let mut contracts: Vec<WorkspaceContract> = metadata
         .workspace_packages()
@@ -109,16 +126,21 @@ pub fn list_contracts(manifest_path: Option<&Utf8Path>) -> eyre::Result<Vec<Work
                 variants.extend(names.into_iter().map(Some));
             }
 
+            // Relative to the workspace root; fall back to the absolute path on the rare chance a
+            // member lives outside the root (e.g. a `../` path member) and can't be made relative.
+            let manifest_path = pathdiff::diff_utf8_paths(&package.manifest_path, &root)
+                .unwrap_or_else(|| package.manifest_path.clone());
+
             Some(WorkspaceContract {
                 name: package.name.as_str().to_string(),
-                manifest_path: package.manifest_path.clone(),
+                manifest_path,
                 variants,
             })
         })
         .collect();
 
     contracts.sort_by(|a, b| a.name.cmp(&b.name));
-    Ok(contracts)
+    Ok(Workspace { root, contracts })
 }
 
 #[cfg(test)]
@@ -128,7 +150,7 @@ mod tests {
     fn contract(name: &str, variants: Vec<Option<String>>) -> WorkspaceContract {
         WorkspaceContract {
             name: name.to_string(),
-            manifest_path: Utf8PathBuf::from(format!("/ws/{name}/Cargo.toml")),
+            manifest_path: Utf8PathBuf::from(format!("{name}/Cargo.toml")),
             variants,
         }
     }

--- a/cargo-near-build/src/near/list.rs
+++ b/cargo-near-build/src/near/list.rs
@@ -16,7 +16,8 @@ pub struct WorkspaceContract {
     pub name: String,
     /// Path to the crate's `Cargo.toml`, relative to the workspace root ([`Workspace::root`]),
     /// e.g. `contracts/defuse/Cargo.toml`. Relative so it is portable across machines and CI
-    /// runners; join it onto [`Workspace::root`] for an absolute path.
+    /// runners; join it onto [`Workspace::root`] for an absolute path. In the rare case a relative
+    /// path can't be computed (a member on a different filesystem root), it is left absolute.
     pub manifest_path: Utf8PathBuf,
     /// Build variants, default first.
     ///
@@ -95,8 +96,10 @@ pub struct Workspace {
 /// [`Workspace::contracts`] and recorded in [`Workspace::skipped`] instead. Results are sorted by
 /// package name, and each contract's variants are sorted, so the output is deterministic.
 ///
-/// Each [`WorkspaceContract::manifest_path`] is returned relative to [`Workspace::root`], which is
-/// itself absolute, so the paths are portable while staying resolvable via `root.join(...)`.
+/// Each [`WorkspaceContract::manifest_path`] is returned relative to [`Workspace::root`] (which is
+/// itself absolute), so the paths are portable while staying resolvable via `root.join(...)`. If a
+/// relative path can't be computed (a member on a different filesystem root), that member's
+/// `manifest_path` is left absolute.
 ///
 /// Runs `cargo metadata --no-deps`: the dependency graph is not resolved, which keeps this fast
 /// and avoids requiring an up-to-date `Cargo.lock`. Presence of the `reproducible_build` section
@@ -137,8 +140,9 @@ pub fn list_contracts(manifest_path: Option<&Utf8Path>) -> eyre::Result<Workspac
             variants.extend(names.into_iter().map(Some));
         }
 
-        // Relative to the workspace root; fall back to the absolute path on the rare chance a
-        // member lives outside the root (e.g. a `../` path member) and can't be made relative.
+        // Relative to the workspace root. `diff_utf8_paths` can express `../` for members above the
+        // root, and only returns `None` when the two paths share no common base (e.g. different
+        // filesystem roots / Windows drive prefixes); fall back to the absolute path there.
         let manifest_path = pathdiff::diff_utf8_paths(&package.manifest_path, &root)
             .unwrap_or_else(|| package.manifest_path.clone());
 

--- a/cargo-near-build/src/near/list.rs
+++ b/cargo-near-build/src/near/list.rs
@@ -80,14 +80,20 @@ pub struct Workspace {
     pub root: Utf8PathBuf,
     /// Discovered contracts, sorted by package name.
     pub contracts: Vec<WorkspaceContract>,
+    /// Workspace members that do **not** opt into reproducible builds (no
+    /// `[package.metadata.near.reproducible_build]` section), by package name, sorted. These are
+    /// the members left out of [`contracts`](Self::contracts); surfaced so callers can report what
+    /// was skipped rather than silently dropping it.
+    pub skipped: Vec<String>,
 }
 
 /// Discover every workspace member that opts into reproducible builds, with its variants.
 ///
 /// `manifest_path` may point at the workspace root or at any member's `Cargo.toml`; `None` uses
 /// the `Cargo.toml` in the current directory to locate the enclosing workspace. Members without a
-/// `[package.metadata.near.reproducible_build]` section are skipped. Results are sorted by package
-/// name, and each contract's variants are sorted, so the output is deterministic.
+/// `[package.metadata.near.reproducible_build]` section are left out of
+/// [`Workspace::contracts`] and recorded in [`Workspace::skipped`] instead. Results are sorted by
+/// package name, and each contract's variants are sorted, so the output is deterministic.
 ///
 /// Each [`WorkspaceContract::manifest_path`] is returned relative to [`Workspace::root`], which is
 /// itself absolute, so the paths are portable while staying resolvable via `root.join(...)`.
@@ -107,40 +113,49 @@ pub fn list_contracts(manifest_path: Option<&Utf8Path>) -> eyre::Result<Workspac
         .wrap_err("Failed to run `cargo metadata` to enumerate workspace contracts")?;
     let root = metadata.workspace_root.clone();
 
-    let mut contracts: Vec<WorkspaceContract> = metadata
-        .workspace_packages()
-        .into_iter()
-        .filter_map(|package| {
-            let reproducible_build = package
-                .metadata
-                .get("near")
-                .and_then(|near| near.get("reproducible_build"))?;
+    // One pass over the members: each is either a contract (has a `reproducible_build` section) or
+    // is recorded as skipped, so nothing is silently dropped.
+    let mut contracts: Vec<WorkspaceContract> = Vec::new();
+    let mut skipped: Vec<String> = Vec::new();
+    for package in metadata.workspace_packages() {
+        let Some(reproducible_build) = package
+            .metadata
+            .get("near")
+            .and_then(|near| near.get("reproducible_build"))
+        else {
+            skipped.push(package.name.as_str().to_string());
+            continue;
+        };
 
-            let mut variants = vec![None];
-            if let Some(variant_table) = reproducible_build
-                .get("variant")
-                .and_then(|v| v.as_object())
-            {
-                let mut names: Vec<String> = variant_table.keys().cloned().collect();
-                names.sort();
-                variants.extend(names.into_iter().map(Some));
-            }
+        let mut variants = vec![None];
+        if let Some(variant_table) = reproducible_build
+            .get("variant")
+            .and_then(|v| v.as_object())
+        {
+            let mut names: Vec<String> = variant_table.keys().cloned().collect();
+            names.sort();
+            variants.extend(names.into_iter().map(Some));
+        }
 
-            // Relative to the workspace root; fall back to the absolute path on the rare chance a
-            // member lives outside the root (e.g. a `../` path member) and can't be made relative.
-            let manifest_path = pathdiff::diff_utf8_paths(&package.manifest_path, &root)
-                .unwrap_or_else(|| package.manifest_path.clone());
+        // Relative to the workspace root; fall back to the absolute path on the rare chance a
+        // member lives outside the root (e.g. a `../` path member) and can't be made relative.
+        let manifest_path = pathdiff::diff_utf8_paths(&package.manifest_path, &root)
+            .unwrap_or_else(|| package.manifest_path.clone());
 
-            Some(WorkspaceContract {
-                name: package.name.as_str().to_string(),
-                manifest_path,
-                variants,
-            })
-        })
-        .collect();
+        contracts.push(WorkspaceContract {
+            name: package.name.as_str().to_string(),
+            manifest_path,
+            variants,
+        });
+    }
 
     contracts.sort_by(|a, b| a.name.cmp(&b.name));
-    Ok(Workspace { root, contracts })
+    skipped.sort();
+    Ok(Workspace {
+        root,
+        contracts,
+        skipped,
+    })
 }
 
 #[cfg(test)]

--- a/cargo-near-build/src/near/list.rs
+++ b/cargo-near-build/src/near/list.rs
@@ -1,0 +1,160 @@
+//! Enumerate the NEAR contracts in a Cargo workspace and their reproducible-build variants.
+//!
+//! This is the discovery primitive behind `cargo near build list`. It is deliberately
+//! dependency-light (just `cargo metadata --no-deps`), so build scripts and test harnesses
+//! such as `near-workspaces` can reuse it to drive multi-contract builds, e.g. one CI matrix
+//! job per (contract, variant) pair.
+
+use camino::{Utf8Path, Utf8PathBuf};
+use eyre::WrapErr;
+
+/// A workspace member that opts into reproducible builds via
+/// `[package.metadata.near.reproducible_build]`, together with its build variants.
+#[derive(Debug, Clone)]
+pub struct WorkspaceContract {
+    /// Cargo package name, e.g. `defuse-poa-factory`.
+    pub name: String,
+    /// Absolute path to the crate's `Cargo.toml`.
+    pub manifest_path: Utf8PathBuf,
+    /// Build variants, default first.
+    ///
+    /// `None` is the default (unnamed) variant, i.e. the top-level
+    /// `[package.metadata.near.reproducible_build]` table. Each `Some(name)` is a
+    /// `[package.metadata.near.reproducible_build.variant.<name>]` sub-table. Named variants
+    /// are sorted for deterministic output.
+    pub variants: Vec<Option<String>>,
+}
+
+impl WorkspaceContract {
+    /// Collision-free wasm filename for one of this contract's variants.
+    ///
+    /// The default variant is `{name}.wasm`; a named variant is `{name}.{variant}.wasm`, so two
+    /// variants of the same crate don't clobber each other when collected into a single out-dir.
+    pub fn output_filename(&self, variant: Option<&str>) -> String {
+        match variant {
+            None => format!("{}.wasm", self.name),
+            Some(variant) => format!("{}.{variant}.wasm", self.name),
+        }
+    }
+
+    /// One [`BuildUnit`] per variant, i.e. one per build that has to run.
+    pub fn build_units(&self) -> impl Iterator<Item = BuildUnit> + '_ {
+        self.variants.iter().map(move |variant| BuildUnit {
+            package: self.name.clone(),
+            variant: variant.clone(),
+            output: self.output_filename(variant.as_deref()),
+            manifest_path: self.manifest_path.clone(),
+        })
+    }
+}
+
+/// A single build to run: one (contract, variant) pair. This is the row a CI matrix consumes,
+/// each job building exactly one wasm.
+#[derive(Debug, Clone)]
+pub struct BuildUnit {
+    /// Cargo package name of the contract crate.
+    pub package: String,
+    /// The named `reproducible_build` variant to build, or `None` for the default one.
+    pub variant: Option<String>,
+    /// Collision-free output filename in the out-dir, e.g. `defuse.far.wasm`.
+    pub output: String,
+    /// Absolute path to the contract crate's `Cargo.toml`.
+    pub manifest_path: Utf8PathBuf,
+}
+
+/// Discover every workspace member that opts into reproducible builds, with its variants.
+///
+/// `manifest_path` may point at the workspace root or at any member's `Cargo.toml`; `None` uses
+/// the `Cargo.toml` in the current directory to locate the enclosing workspace. Members without a
+/// `[package.metadata.near.reproducible_build]` section are skipped. Results are sorted by package
+/// name, and each contract's variants are sorted, so the output is deterministic.
+///
+/// Runs `cargo metadata --no-deps`: the dependency graph is not resolved, which keeps this fast
+/// and avoids requiring an up-to-date `Cargo.lock`. Presence of the `reproducible_build` section
+/// is the only requirement; its contents (image, digest, ...) are not validated here, so a
+/// half-filled section still shows up rather than being silently dropped.
+pub fn list_contracts(manifest_path: Option<&Utf8Path>) -> eyre::Result<Vec<WorkspaceContract>> {
+    let mut command = cargo_metadata::MetadataCommand::new();
+    command.no_deps();
+    if let Some(manifest_path) = manifest_path {
+        command.manifest_path(manifest_path.as_std_path().to_path_buf());
+    }
+    let metadata = command
+        .exec()
+        .wrap_err("Failed to run `cargo metadata` to enumerate workspace contracts")?;
+
+    let mut contracts: Vec<WorkspaceContract> = metadata
+        .workspace_packages()
+        .into_iter()
+        .filter_map(|package| {
+            let reproducible_build = package
+                .metadata
+                .get("near")
+                .and_then(|near| near.get("reproducible_build"))?;
+
+            let mut variants = vec![None];
+            if let Some(variant_table) = reproducible_build
+                .get("variant")
+                .and_then(|v| v.as_object())
+            {
+                let mut names: Vec<String> = variant_table.keys().cloned().collect();
+                names.sort();
+                variants.extend(names.into_iter().map(Some));
+            }
+
+            Some(WorkspaceContract {
+                name: package.name.as_str().to_string(),
+                manifest_path: package.manifest_path.clone(),
+                variants,
+            })
+        })
+        .collect();
+
+    contracts.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(contracts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn contract(name: &str, variants: Vec<Option<String>>) -> WorkspaceContract {
+        WorkspaceContract {
+            name: name.to_string(),
+            manifest_path: Utf8PathBuf::from(format!("/ws/{name}/Cargo.toml")),
+            variants,
+        }
+    }
+
+    #[test]
+    fn output_filename_default_and_named() {
+        let contract = contract("defuse", vec![None, Some("far".to_string())]);
+        assert_eq!(contract.output_filename(None), "defuse.wasm");
+        assert_eq!(contract.output_filename(Some("far")), "defuse.far.wasm");
+    }
+
+    #[test]
+    fn build_units_cover_every_variant_default_first() {
+        let contract = contract(
+            "wallet",
+            vec![
+                None,
+                Some("no-auth".to_string()),
+                Some("webauthn".to_string()),
+            ],
+        );
+        let units: Vec<_> = contract.build_units().collect();
+        assert_eq!(units.len(), 3);
+
+        assert_eq!(units[0].variant, None);
+        assert_eq!(units[0].output, "wallet.wasm");
+        assert_eq!(units[0].package, "wallet");
+        assert_eq!(units[0].manifest_path, contract.manifest_path);
+
+        assert_eq!(units[1].variant.as_deref(), Some("no-auth"));
+        assert_eq!(units[1].output, "wallet.no-auth.wasm");
+
+        assert_eq!(units[2].variant.as_deref(), Some("webauthn"));
+        assert_eq!(units[2].output, "wallet.webauthn.wasm");
+    }
+}

--- a/cargo-near-build/src/near/list.rs
+++ b/cargo-near-build/src/near/list.rs
@@ -26,23 +26,29 @@ pub struct WorkspaceContract {
 }
 
 impl WorkspaceContract {
-    /// Collision-free wasm filename for one of this contract's variants.
+    /// The wasm filename `cargo near build` writes to its out-dir for this contract.
     ///
-    /// The default variant is `{name}.wasm`; a named variant is `{name}.{variant}.wasm`, so two
-    /// variants of the same crate don't clobber each other when collected into a single out-dir.
-    pub fn output_filename(&self, variant: Option<&str>) -> String {
-        match variant {
-            None => format!("{}.wasm", self.name),
-            Some(variant) => format!("{}.{variant}.wasm", self.name),
-        }
+    /// This matches the artifact-naming rule the build pipeline already uses
+    /// (`CrateMetadata::formatted_package_name`): the package name with `-` replaced by `_`, plus
+    /// a `.wasm` extension. It does **not** depend on the variant, since `--variant` changes the
+    /// build inputs but not the output path, so every variant of a package writes the same
+    /// filename. In a CI matrix that's harmless (each job has its own out-dir); collecting several
+    /// variants into one directory would require renaming per job.
+    pub fn wasm_filename(&self) -> String {
+        format!(
+            "{}.{}",
+            self.name.replace('-', "_"),
+            crate::types::near::EXPECTED_WASM_EXTENSION
+        )
     }
 
     /// One [`BuildUnit`] per variant, i.e. one per build that has to run.
     pub fn build_units(&self) -> impl Iterator<Item = BuildUnit> + '_ {
+        let output = self.wasm_filename();
         self.variants.iter().map(move |variant| BuildUnit {
             package: self.name.clone(),
             variant: variant.clone(),
-            output: self.output_filename(variant.as_deref()),
+            output: output.clone(),
             manifest_path: self.manifest_path.clone(),
         })
     }
@@ -56,7 +62,8 @@ pub struct BuildUnit {
     pub package: String,
     /// The named `reproducible_build` variant to build, or `None` for the default one.
     pub variant: Option<String>,
-    /// Collision-free output filename in the out-dir, e.g. `defuse.far.wasm`.
+    /// The wasm filename `cargo near build` writes to the out-dir, e.g. `defuse_poa_token.wasm`.
+    /// Variant-independent (see [`WorkspaceContract::wasm_filename`]).
     pub output: String,
     /// Absolute path to the contract crate's `Cargo.toml`.
     pub manifest_path: Utf8PathBuf,
@@ -127,16 +134,22 @@ mod tests {
     }
 
     #[test]
-    fn output_filename_default_and_named() {
-        let contract = contract("defuse", vec![None, Some("far".to_string())]);
-        assert_eq!(contract.output_filename(None), "defuse.wasm");
-        assert_eq!(contract.output_filename(Some("far")), "defuse.far.wasm");
+    fn wasm_filename_normalizes_hyphens_to_underscores() {
+        // Matches `CrateMetadata::formatted_package_name` / the actual cargo-near artifact name.
+        assert_eq!(
+            contract("defuse", vec![None]).wasm_filename(),
+            "defuse.wasm"
+        );
+        assert_eq!(
+            contract("defuse-poa-token", vec![None]).wasm_filename(),
+            "defuse_poa_token.wasm"
+        );
     }
 
     #[test]
-    fn build_units_cover_every_variant_default_first() {
+    fn build_units_cover_every_variant_default_first_sharing_one_output() {
         let contract = contract(
-            "wallet",
+            "defuse-wallet",
             vec![
                 None,
                 Some("no-auth".to_string()),
@@ -146,15 +159,15 @@ mod tests {
         let units: Vec<_> = contract.build_units().collect();
         assert_eq!(units.len(), 3);
 
-        assert_eq!(units[0].variant, None);
-        assert_eq!(units[0].output, "wallet.wasm");
-        assert_eq!(units[0].package, "wallet");
-        assert_eq!(units[0].manifest_path, contract.manifest_path);
+        // Default first, then the variants in the order given.
+        let variants: Vec<Option<&str>> = units.iter().map(|u| u.variant.as_deref()).collect();
+        assert_eq!(variants, [None, Some("no-auth"), Some("webauthn")]);
 
-        assert_eq!(units[1].variant.as_deref(), Some("no-auth"));
-        assert_eq!(units[1].output, "wallet.no-auth.wasm");
-
-        assert_eq!(units[2].variant.as_deref(), Some("webauthn"));
-        assert_eq!(units[2].output, "wallet.webauthn.wasm");
+        // `--variant` doesn't change the output path, so every unit writes the same file.
+        for unit in &units {
+            assert_eq!(unit.package, "defuse-wallet");
+            assert_eq!(unit.output, "defuse_wallet.wasm");
+            assert_eq!(unit.manifest_path, contract.manifest_path);
+        }
     }
 }

--- a/cargo-near-build/src/near/mod.rs
+++ b/cargo-near-build/src/near/mod.rs
@@ -11,3 +11,5 @@ pub mod build_rs_build_external;
 
 #[cfg(feature = "docker")]
 pub mod docker_build;
+
+pub mod list;

--- a/cargo-near/Cargo.toml
+++ b/cargo-near/Cargo.toml
@@ -29,7 +29,7 @@ cargo-near-build = { version = "0.11.4", path = "../cargo-near-build", features 
 ] }
 clap = { version = "4.0.18", features = ["derive", "env"] }
 colored = "3"
-serde = "1.0.197"
+serde = { version = "1.0.197", features = ["derive"] }
 color-eyre = "0.6"
 inquire = "0.9.3"
 strum = { version = "0.24", features = ["derive"] }

--- a/cargo-near/src/commands/build/actions/list.rs
+++ b/cargo-near/src/commands/build/actions/list.rs
@@ -51,7 +51,7 @@ mod context {
 
 /// A single unit of work: build `package` (optionally with `variant`) and write it to `output`.
 ///
-/// This is the JSON row shape a CI matrix consumes — each job builds exactly one wasm. It mirrors
+/// This is the JSON row shape a CI matrix consumes; each job builds exactly one wasm. It mirrors
 /// [`cargo_near_build::list::BuildUnit`], with `manifest_path` stringified for the wire.
 #[derive(Debug, serde::Serialize)]
 pub struct BuildJob {
@@ -59,7 +59,8 @@ pub struct BuildJob {
     pub package: String,
     /// The named `reproducible_build` variant to build, or `null` for the default one.
     pub variant: Option<String>,
-    /// Intended, collision-free output filename in the out-dir, e.g. `defuse.far.wasm`.
+    /// Wasm filename `cargo near build` writes to the out-dir, e.g. `defuse_poa_token.wasm`.
+    /// Variant-independent, so a package's variants share this name.
     pub output: String,
     /// Absolute path to the contract crate's `Cargo.toml`.
     pub manifest_path: String,
@@ -79,21 +80,17 @@ impl From<cargo_near_build::list::BuildUnit> for BuildJob {
 fn print_human_readable(contracts: &[cargo_near_build::list::WorkspaceContract]) {
     for contract in contracts {
         println!(
-            "{} ({})",
+            "{} ({})  →  {}",
             contract.name.bold(),
-            contract.manifest_path.as_str().dimmed()
+            contract.manifest_path.as_str().dimmed(),
+            contract.wasm_filename()
         );
         for variant in &contract.variants {
             let label = match variant {
-                None => "<default>".to_string(),
-                Some(name) => name.clone(),
+                None => "<default>",
+                Some(name) => name,
             };
-            println!(
-                "  {} {}  →  {}",
-                "•".cyan(),
-                label,
-                contract.output_filename(variant.as_deref())
-            );
+            println!("  {} {}", "•".cyan(), label);
         }
     }
 }

--- a/cargo-near/src/commands/build/actions/list.rs
+++ b/cargo-near/src/commands/build/actions/list.rs
@@ -62,7 +62,7 @@ pub struct BuildJob {
     /// Wasm filename `cargo near build` writes to the out-dir, e.g. `defuse_poa_token.wasm`.
     /// Variant-independent, so a package's variants share this name.
     pub output: String,
-    /// Absolute path to the contract crate's `Cargo.toml`.
+    /// Path to the contract crate's `Cargo.toml`, relative to the workspace root.
     pub manifest_path: String,
 }
 
@@ -77,8 +77,13 @@ impl From<cargo_near_build::list::BuildUnit> for BuildJob {
     }
 }
 
-fn print_human_readable(contracts: &[cargo_near_build::list::WorkspaceContract]) {
-    for contract in contracts {
+fn print_human_readable(workspace: &cargo_near_build::list::Workspace) {
+    println!(
+        "{} {}",
+        "workspace:".dimmed(),
+        workspace.root.as_str().dimmed()
+    );
+    for contract in &workspace.contracts {
         println!(
             "{} ({})  →  {}",
             contract.name.bold(),
@@ -96,17 +101,18 @@ fn print_human_readable(contracts: &[cargo_near_build::list::WorkspaceContract])
 }
 
 pub fn run(opts: ListOpts) -> color_eyre::eyre::Result<()> {
-    let contracts =
+    let workspace =
         cargo_near_build::list::list_contracts(opts.manifest_path.as_ref().map(|p| p.as_path()))?;
 
     if opts.json {
-        let jobs: Vec<BuildJob> = contracts
+        let jobs: Vec<BuildJob> = workspace
+            .contracts
             .iter()
             .flat_map(|contract| contract.build_units())
             .map(BuildJob::from)
             .collect();
         println!("{}", serde_json::to_string_pretty(&jobs)?);
-    } else if contracts.is_empty() {
+    } else if workspace.contracts.is_empty() {
         eprintln!(
             "{}",
             "No contracts with `[package.metadata.near.reproducible_build]` \
@@ -114,7 +120,7 @@ pub fn run(opts: ListOpts) -> color_eyre::eyre::Result<()> {
                 .yellow()
         );
     } else {
-        print_human_readable(&contracts);
+        print_human_readable(&workspace);
     }
 
     Ok(())

--- a/cargo-near/src/commands/build/actions/list.rs
+++ b/cargo-near/src/commands/build/actions/list.rs
@@ -73,7 +73,8 @@ pub struct BuildJob {
     /// Wasm filename `cargo near build` writes to the out-dir, e.g. `defuse_poa_token.wasm`.
     /// Variant-independent, so a package's variants share this name.
     pub output: String,
-    /// Path to the contract crate's `Cargo.toml`, relative to the workspace root.
+    /// Path to the contract crate's `Cargo.toml`, relative to `workspace_root` (absolute only in
+    /// the rare case a relative path can't be computed, e.g. a different filesystem root).
     pub manifest_path: String,
 }
 
@@ -96,7 +97,8 @@ impl From<cargo_near_build::list::BuildUnit> for BuildJob {
 struct ListOutput {
     /// Envelope schema version. Bumped only on a breaking change to this shape.
     version: u32,
-    /// Absolute path to the workspace root; each job's `manifest_path` is relative to it.
+    /// Absolute path to the workspace root; each job's `manifest_path` is relative to it (absolute
+    /// only in the rare case a relative path can't be computed).
     workspace_root: String,
     /// The build jobs, one per emitted (contract, variant) pair.
     jobs: Vec<BuildJob>,

--- a/cargo-near/src/commands/build/actions/list.rs
+++ b/cargo-near/src/commands/build/actions/list.rs
@@ -159,15 +159,20 @@ pub fn run(opts: ListOpts) -> color_eyre::eyre::Result<()> {
         print_human_readable(&workspace, opts.variants);
     }
 
-    // Report skipped members on stderr (both modes), so stdout/jq stays clean.
+    // Report skipped members on stderr (both modes), so stdout/jq stays clean. Cap the listed
+    // names so large workspaces (many library crates) don't dump a wall of text.
     if !workspace.skipped.is_empty() {
+        const MAX_LISTED: usize = 10;
+        let total = workspace.skipped.len();
+        let mut names = workspace.skipped[..total.min(MAX_LISTED)].join(", ");
+        if total > MAX_LISTED {
+            names.push_str(&format!(" (+{} more)", total - MAX_LISTED));
+        }
         eprintln!(
             "{}",
             format!(
-                "Skipped {} workspace member(s) without a \
-                 [package.metadata.near.reproducible_build] section: {}",
-                workspace.skipped.len(),
-                workspace.skipped.join(", ")
+                "Skipped {total} workspace member(s) without a \
+                 [package.metadata.near.reproducible_build] section: {names}"
             )
             .yellow()
         );

--- a/cargo-near/src/commands/build/actions/list.rs
+++ b/cargo-near/src/commands/build/actions/list.rs
@@ -161,24 +161,8 @@ pub fn run(opts: ListOpts) -> color_eyre::eyre::Result<()> {
         print_human_readable(&workspace, opts.variants);
     }
 
-    // Report skipped members on stderr (both modes), so stdout/jq stays clean. Cap the listed
-    // names so large workspaces (many library crates) don't dump a wall of text.
-    if !workspace.skipped.is_empty() {
-        const MAX_LISTED: usize = 10;
-        let total = workspace.skipped.len();
-        let mut names = workspace.skipped[..total.min(MAX_LISTED)].join(", ");
-        if total > MAX_LISTED {
-            names.push_str(&format!(" (+{} more)", total - MAX_LISTED));
-        }
-        eprintln!(
-            "{}",
-            format!(
-                "Skipped {total} workspace member(s) without a \
-                 [package.metadata.near.reproducible_build] section: {names}"
-            )
-            .yellow()
-        );
-    }
+    // Report skipped members on stderr (both modes) so stdout/jq stays clean.
+    super::warn_skipped_members(&workspace);
 
     Ok(())
 }

--- a/cargo-near/src/commands/build/actions/list.rs
+++ b/cargo-near/src/commands/build/actions/list.rs
@@ -12,13 +12,22 @@ pub struct ListOpts {
     #[interactive_clap(skip_interactive_input)]
     #[interactive_clap(verbatim_doc_comment)]
     pub manifest_path: Option<crate::types::utf8_path_buf::Utf8PathBuf>,
-    /// Emit a machine-readable JSON array of build jobs (suitable for a CI build matrix)
+    /// Emit a machine-readable JSON object of build jobs (suitable for a CI build matrix)
     ///
-    /// One entry is emitted per (contract, variant) pair, so the array can be fed
-    /// straight into a GitHub Actions `matrix` via `fromJSON(...)`.
+    /// The `jobs` array can be fed straight into a GitHub Actions `matrix` via
+    /// `fromJSON(...)`.
     #[interactive_clap(long)]
+    #[interactive_clap(skip_interactive_input)]
     #[interactive_clap(verbatim_doc_comment)]
     pub json: bool,
+    /// Include every reproducible-build variant, not just each contract's default one
+    ///
+    /// Without this flag, one job per contract is emitted (the default variant). With it,
+    /// one job per (contract, variant) pair is emitted.
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_interactive_input)]
+    #[interactive_clap(verbatim_doc_comment)]
+    pub variants: bool,
 }
 
 impl From<CliListOpts> for ListOpts {
@@ -26,6 +35,7 @@ impl From<CliListOpts> for ListOpts {
         Self {
             manifest_path: value.manifest_path,
             json: value.json,
+            variants: value.variants,
         }
     }
 }
@@ -42,6 +52,7 @@ mod context {
             let opts = super::ListOpts {
                 manifest_path: scope.manifest_path.clone(),
                 json: scope.json,
+                variants: scope.variants,
             };
             super::run(opts)?;
             Ok(Self)
@@ -77,7 +88,21 @@ impl From<cargo_near_build::list::BuildUnit> for BuildJob {
     }
 }
 
-fn print_human_readable(workspace: &cargo_near_build::list::Workspace) {
+/// The `--json` output: a versioned envelope around the [`BuildJob`] rows.
+///
+/// Wrapping the jobs (rather than emitting a bare array) leaves room to add fields without a
+/// breaking change; consumers can gate on `version`.
+#[derive(Debug, serde::Serialize)]
+struct ListOutput {
+    /// Envelope schema version. Bumped only on a breaking change to this shape.
+    version: u32,
+    /// Absolute path to the workspace root; each job's `manifest_path` is relative to it.
+    workspace_root: String,
+    /// The build jobs, one per emitted (contract, variant) pair.
+    jobs: Vec<BuildJob>,
+}
+
+fn print_human_readable(workspace: &cargo_near_build::list::Workspace, variants: bool) {
     println!(
         "{} {}",
         "workspace:".dimmed(),
@@ -91,6 +116,10 @@ fn print_human_readable(workspace: &cargo_near_build::list::Workspace) {
             contract.wasm_filename()
         );
         for variant in &contract.variants {
+            // Without `--variants`, show only each contract's default variant.
+            if !variants && variant.is_some() {
+                continue;
+            }
             let label = match variant {
                 None => "<default>",
                 Some(name) => name,
@@ -105,13 +134,20 @@ pub fn run(opts: ListOpts) -> color_eyre::eyre::Result<()> {
         cargo_near_build::list::list_contracts(opts.manifest_path.as_ref().map(|p| p.as_path()))?;
 
     if opts.json {
+        // Without `--variants`, emit one job per contract (the default variant only).
         let jobs: Vec<BuildJob> = workspace
             .contracts
             .iter()
             .flat_map(|contract| contract.build_units())
+            .filter(|unit| opts.variants || unit.variant.is_none())
             .map(BuildJob::from)
             .collect();
-        println!("{}", serde_json::to_string_pretty(&jobs)?);
+        let output = ListOutput {
+            version: 1,
+            workspace_root: workspace.root.to_string(),
+            jobs,
+        };
+        println!("{}", serde_json::to_string_pretty(&output)?);
     } else if workspace.contracts.is_empty() {
         eprintln!(
             "{}",
@@ -120,7 +156,21 @@ pub fn run(opts: ListOpts) -> color_eyre::eyre::Result<()> {
                 .yellow()
         );
     } else {
-        print_human_readable(&workspace);
+        print_human_readable(&workspace, opts.variants);
+    }
+
+    // Report skipped members on stderr (both modes), so stdout/jq stays clean.
+    if !workspace.skipped.is_empty() {
+        eprintln!(
+            "{}",
+            format!(
+                "Skipped {} workspace member(s) without a \
+                 [package.metadata.near.reproducible_build] section: {}",
+                workspace.skipped.len(),
+                workspace.skipped.join(", ")
+            )
+            .yellow()
+        );
     }
 
     Ok(())

--- a/cargo-near/src/commands/build/actions/list.rs
+++ b/cargo-near/src/commands/build/actions/list.rs
@@ -1,0 +1,124 @@
+use colored::Colorize;
+
+#[derive(Debug, Default, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = cargo_near_build::docker::BuildContext)]
+#[interactive_clap(output_context = context::Context)]
+pub struct ListOpts {
+    /// Path to the `Cargo.toml` of the workspace (or of any member of it)
+    ///
+    /// If this argument is not specified, the `Cargo.toml` in the current directory is used
+    /// to locate the enclosing workspace.
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_interactive_input)]
+    #[interactive_clap(verbatim_doc_comment)]
+    pub manifest_path: Option<crate::types::utf8_path_buf::Utf8PathBuf>,
+    /// Emit a machine-readable JSON array of build jobs (suitable for a CI build matrix)
+    ///
+    /// One entry is emitted per (contract, variant) pair, so the array can be fed
+    /// straight into a GitHub Actions `matrix` via `fromJSON(...)`.
+    #[interactive_clap(long)]
+    #[interactive_clap(verbatim_doc_comment)]
+    pub json: bool,
+}
+
+impl From<CliListOpts> for ListOpts {
+    fn from(value: CliListOpts) -> Self {
+        Self {
+            manifest_path: value.manifest_path,
+            json: value.json,
+        }
+    }
+}
+
+mod context {
+    #[derive(Debug)]
+    pub struct Context;
+
+    impl Context {
+        pub fn from_previous_context(
+            _previous_context: cargo_near_build::docker::BuildContext,
+            scope: &<super::ListOpts as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+        ) -> color_eyre::eyre::Result<Self> {
+            let opts = super::ListOpts {
+                manifest_path: scope.manifest_path.clone(),
+                json: scope.json,
+            };
+            super::run(opts)?;
+            Ok(Self)
+        }
+    }
+}
+
+/// A single unit of work: build `package` (optionally with `variant`) and write it to `output`.
+///
+/// This is the JSON row shape a CI matrix consumes — each job builds exactly one wasm. It mirrors
+/// [`cargo_near_build::list::BuildUnit`], with `manifest_path` stringified for the wire.
+#[derive(Debug, serde::Serialize)]
+pub struct BuildJob {
+    /// Cargo package name of the contract crate, e.g. `defuse-poa-factory`.
+    pub package: String,
+    /// The named `reproducible_build` variant to build, or `null` for the default one.
+    pub variant: Option<String>,
+    /// Intended, collision-free output filename in the out-dir, e.g. `defuse.far.wasm`.
+    pub output: String,
+    /// Absolute path to the contract crate's `Cargo.toml`.
+    pub manifest_path: String,
+}
+
+impl From<cargo_near_build::list::BuildUnit> for BuildJob {
+    fn from(unit: cargo_near_build::list::BuildUnit) -> Self {
+        Self {
+            package: unit.package,
+            variant: unit.variant,
+            output: unit.output,
+            manifest_path: unit.manifest_path.to_string(),
+        }
+    }
+}
+
+fn print_human_readable(contracts: &[cargo_near_build::list::WorkspaceContract]) {
+    for contract in contracts {
+        println!(
+            "{} ({})",
+            contract.name.bold(),
+            contract.manifest_path.as_str().dimmed()
+        );
+        for variant in &contract.variants {
+            let label = match variant {
+                None => "<default>".to_string(),
+                Some(name) => name.clone(),
+            };
+            println!(
+                "  {} {}  →  {}",
+                "•".cyan(),
+                label,
+                contract.output_filename(variant.as_deref())
+            );
+        }
+    }
+}
+
+pub fn run(opts: ListOpts) -> color_eyre::eyre::Result<()> {
+    let contracts =
+        cargo_near_build::list::list_contracts(opts.manifest_path.as_ref().map(|p| p.as_path()))?;
+
+    if opts.json {
+        let jobs: Vec<BuildJob> = contracts
+            .iter()
+            .flat_map(|contract| contract.build_units())
+            .map(BuildJob::from)
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&jobs)?);
+    } else if contracts.is_empty() {
+        eprintln!(
+            "{}",
+            "No contracts with `[package.metadata.near.reproducible_build]` \
+             were found in this workspace."
+                .yellow()
+        );
+    } else {
+        print_human_readable(&contracts);
+    }
+
+    Ok(())
+}

--- a/cargo-near/src/commands/build/mod.rs
+++ b/cargo-near/src/commands/build/mod.rs
@@ -19,6 +19,7 @@ pub mod context {
 }
 
 pub mod actions {
+    pub mod list;
     pub mod non_reproducible_wasm;
     pub mod reproducible_wasm;
 
@@ -39,6 +40,11 @@ pub mod actions {
         ))]
         /// Requires `[reproducible_build]` section in Cargo.toml, and all changes committed to git (recommended for the production release)
         ReproducibleWasm(self::reproducible_wasm::BuildOpts),
+        #[strum_discriminants(strum(
+            message = "list                   - List workspace contracts and their reproducible-build variants (supports --json for a CI build matrix)"
+        ))]
+        /// List workspace contracts and their reproducible-build variants (supports `--json` for a CI build matrix)
+        List(self::list::ListOpts),
     }
 }
 

--- a/cargo-near/src/commands/build/mod.rs
+++ b/cargo-near/src/commands/build/mod.rs
@@ -25,6 +25,31 @@ pub mod actions {
 
     use strum::{EnumDiscriminants, EnumIter, EnumMessage};
 
+    /// Warn (on stderr) about workspace members that were skipped because they lack a
+    /// `[package.metadata.near.reproducible_build]` section, so a skipped member (e.g. a
+    /// contract that hasn't added the section yet) is visible rather than dropped silently.
+    /// Caps the listed names for large workspaces. Shared by `build list` and `--workspace`.
+    pub(crate) fn warn_skipped_members(workspace: &cargo_near_build::list::Workspace) {
+        use colored::Colorize;
+        if workspace.skipped.is_empty() {
+            return;
+        }
+        const MAX_LISTED: usize = 10;
+        let total = workspace.skipped.len();
+        let mut names = workspace.skipped[..total.min(MAX_LISTED)].join(", ");
+        if total > MAX_LISTED {
+            names.push_str(&format!(" (+{} more)", total - MAX_LISTED));
+        }
+        eprintln!(
+            "{}",
+            format!(
+                "Skipped {total} workspace member(s) without a \
+                 [package.metadata.near.reproducible_build] section: {names}"
+            )
+            .yellow()
+        );
+    }
+
     #[derive(Debug, Clone, EnumDiscriminants, interactive_clap::InteractiveClap)]
     #[strum_discriminants(derive(EnumMessage, EnumIter))]
     #[interactive_clap(input_context = near_cli_rs::GlobalContext)]

--- a/integration-tests/tests/build_list.rs
+++ b/integration-tests/tests/build_list.rs
@@ -101,6 +101,9 @@ fn list_contracts_discovers_variants_and_filters_non_contracts() -> testresult::
     let names: Vec<&str> = contracts.iter().map(|c| c.name.as_str()).collect();
     assert_eq!(names, ["contract-a", "contract-b"]);
 
+    // plain-lib opts out of reproducible builds, so it lands in `skipped` rather than `contracts`.
+    assert_eq!(workspace.skipped, ["plain-lib"]);
+
     // Manifest paths are relative to the workspace root, and resolve back to real files.
     assert_eq!(contracts[0].manifest_path, "contract-a/Cargo.toml");
     assert_eq!(contracts[1].manifest_path, "contract-b/Cargo.toml");

--- a/integration-tests/tests/build_list.rs
+++ b/integration-tests/tests/build_list.rs
@@ -94,11 +94,17 @@ fn list_contracts_discovers_variants_and_filters_non_contracts() -> testresult::
     let manifest = Utf8PathBuf::from_path_buf(tmp.path().join("Cargo.toml"))
         .expect("temp path is valid UTF-8");
 
-    let contracts = cargo_near_build::list::list_contracts(Some(manifest.as_path()))?;
+    let workspace = cargo_near_build::list::list_contracts(Some(manifest.as_path()))?;
+    let contracts = &workspace.contracts;
 
     // plain-lib is excluded; the two contracts come back sorted by package name.
     let names: Vec<&str> = contracts.iter().map(|c| c.name.as_str()).collect();
     assert_eq!(names, ["contract-a", "contract-b"]);
+
+    // Manifest paths are relative to the workspace root, and resolve back to real files.
+    assert_eq!(contracts[0].manifest_path, "contract-a/Cargo.toml");
+    assert_eq!(contracts[1].manifest_path, "contract-b/Cargo.toml");
+    assert!(workspace.root.join(&contracts[0].manifest_path).is_file());
 
     // contract-a: default variant only.
     assert_eq!(contracts[0].variants, vec![None]);

--- a/integration-tests/tests/build_list.rs
+++ b/integration-tests/tests/build_list.rs
@@ -1,0 +1,129 @@
+//! Exercises `cargo_near_build::list::list_contracts` — the discovery primitive behind
+//! `cargo near build list` — against a synthesized multi-crate workspace. Only `cargo metadata`
+//! runs here; nothing is compiled, so the test is fast and offline.
+
+use camino::Utf8PathBuf;
+use std::fs;
+use std::path::Path;
+
+fn write(path: &Path, contents: &str) -> testresult::TestResult {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, contents)?;
+    Ok(())
+}
+
+/// Lays out a workspace with two contracts (one with named variants, one without) plus a plain
+/// library crate that opts out of reproducible builds. Members are listed out of alphabetical
+/// order on purpose, to check that discovery sorts them.
+fn scaffold_workspace(root: &Path) -> testresult::TestResult {
+    write(
+        &root.join("Cargo.toml"),
+        r#"[workspace]
+resolver = "2"
+members = ["contract-b", "contract-a", "plain-lib"]
+"#,
+    )?;
+
+    // contract-a: reproducible build, default variant only.
+    write(
+        &root.join("contract-a/Cargo.toml"),
+        r#"[package]
+name = "contract-a"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[package.metadata.near.reproducible_build]
+image = "sourcescan/cargo-near:0.13.0-rust-1.84.0"
+image_digest = "sha256:deadbeef"
+"#,
+    )?;
+    write(&root.join("contract-a/src/lib.rs"), "")?;
+
+    // contract-b: reproducible build with two named variants, declared out of order.
+    write(
+        &root.join("contract-b/Cargo.toml"),
+        r#"[package]
+name = "contract-b"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[package.metadata.near.reproducible_build]
+image = "sourcescan/cargo-near:0.13.0-rust-1.84.0"
+image_digest = "sha256:deadbeef"
+
+[package.metadata.near.reproducible_build.variant.zebra]
+image = "sourcescan/cargo-near:0.13.0-rust-1.84.0"
+image_digest = "sha256:zebra"
+
+[package.metadata.near.reproducible_build.variant.alpha]
+image = "sourcescan/cargo-near:0.13.0-rust-1.84.0"
+image_digest = "sha256:alpha"
+"#,
+    )?;
+    write(&root.join("contract-b/src/lib.rs"), "")?;
+
+    // plain-lib: no reproducible_build section, so it must be filtered out.
+    write(
+        &root.join("plain-lib/Cargo.toml"),
+        r#"[package]
+name = "plain-lib"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["rlib"]
+"#,
+    )?;
+    write(&root.join("plain-lib/src/lib.rs"), "")?;
+
+    Ok(())
+}
+
+#[test]
+fn list_contracts_discovers_variants_and_filters_non_contracts() -> testresult::TestResult {
+    let tmp = tempfile::tempdir()?;
+    scaffold_workspace(tmp.path())?;
+    let manifest = Utf8PathBuf::from_path_buf(tmp.path().join("Cargo.toml"))
+        .expect("temp path is valid UTF-8");
+
+    let contracts = cargo_near_build::list::list_contracts(Some(manifest.as_path()))?;
+
+    // plain-lib is excluded; the two contracts come back sorted by package name.
+    let names: Vec<&str> = contracts.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(names, ["contract-a", "contract-b"]);
+
+    // contract-a: default variant only.
+    assert_eq!(contracts[0].variants, vec![None]);
+
+    // contract-b: default first, then named variants sorted (alpha before zebra).
+    assert_eq!(
+        contracts[1].variants,
+        vec![None, Some("alpha".to_string()), Some("zebra".to_string())]
+    );
+
+    // Enumeration flattens to one build unit per (contract, variant), with collision-free names.
+    let outputs: Vec<String> = contracts
+        .iter()
+        .flat_map(|c| c.build_units())
+        .map(|unit| unit.output)
+        .collect();
+    assert_eq!(
+        outputs,
+        [
+            "contract-a.wasm",
+            "contract-b.wasm",
+            "contract-b.alpha.wasm",
+            "contract-b.zebra.wasm",
+        ]
+    );
+
+    Ok(())
+}

--- a/integration-tests/tests/build_list.rs
+++ b/integration-tests/tests/build_list.rs
@@ -109,19 +109,21 @@ fn list_contracts_discovers_variants_and_filters_non_contracts() -> testresult::
         vec![None, Some("alpha".to_string()), Some("zebra".to_string())]
     );
 
-    // Enumeration flattens to one build unit per (contract, variant), with collision-free names.
-    let outputs: Vec<String> = contracts
+    // Enumeration flattens to one build unit per (contract, variant).
+    let units: Vec<_> = contracts.iter().flat_map(|c| c.build_units()).collect();
+    let rows: Vec<(&str, Option<&str>, &str)> = units
         .iter()
-        .flat_map(|c| c.build_units())
-        .map(|unit| unit.output)
+        .map(|u| (u.package.as_str(), u.variant.as_deref(), u.output.as_str()))
         .collect();
+    // Output filenames match cargo-near's artifact naming (hyphens become underscores) and do not
+    // depend on the variant, so contract-b's three units all write `contract_b.wasm`.
     assert_eq!(
-        outputs,
+        rows,
         [
-            "contract-a.wasm",
-            "contract-b.wasm",
-            "contract-b.alpha.wasm",
-            "contract-b.zebra.wasm",
+            ("contract-a", None, "contract_a.wasm"),
+            ("contract-b", None, "contract_b.wasm"),
+            ("contract-b", Some("alpha"), "contract_b.wasm"),
+            ("contract-b", Some("zebra"), "contract_b.wasm"),
         ]
     );
 


### PR DESCRIPTION
## Why

Multi-contract workspaces (e.g. `intents`, 8 contracts / 13 variants) build every contract and variant reproducibly and sequentially in CI, ~15 min per run. A `--workspace` one-command build would delete the `cargo metadata | jq` glue but stays sequential (clean container per contract), so it doesn't cut the time. Fanning the builds out across a CI matrix does, and that needs a machine-readable list of the build units.

## What

Adds `cargo near build list [--json] [--variants]`. It walks the workspace and lists members that have a `[package.metadata.near.reproducible_build]` section.

`--json` emits a versioned, self-describing envelope on stdout:

```json
{
  "version": 1,
  "workspace_root": "/abs/path/to/workspace",
  "jobs": [
    { "package": "defuse-poa-token", "variant": null, "output": "defuse_poa_token.wasm", "manifest_path": "contracts/poa/token/Cargo.toml" }
  ]
}
```

- **Envelope, not a bare array.** `version` + `workspace_root` mean the format can evolve and consumers can resolve paths without a breaking change.
- **`manifest_path` is relative to `workspace_root`** (which is absolute), so rows are portable across machines/CI runners; join the two for an absolute path.
- **`output`** is the filename `cargo near build` actually writes (package name with `-` normalized to `_`, no variant suffix, matching `CrateMetadata::formatted_package_name`), so a package's variants share it; jobs stay distinct by `package` + `variant`.
- **`--variants` is opt-in.** By default `list` emits one job per contract (the default variant). Pass `--variants` for the full `(contract, variant)` fan-out. Named variants only apply to reproducible builds, so this keeps the default output honest for consumers that can't honor `--variant`.
- **Skipped members are surfaced, not hidden.** Workspace members without a `reproducible_build` section are reported on stderr (capped for large workspaces), so `list`/`--workspace` never silently drop a crate. stdout stays clean for `| jq`.

The `--json` shape feeds a GitHub Actions matrix via `fromJSON`, so each contract/variant builds on its own runner and wall-clock drops from the sum of all contracts to the slowest one.

The enumeration lives in `cargo-near-build` as `cargo_near_build::list::list_contracts` → `Workspace { root, contracts, skipped }` (feature-free, only needs `cargo metadata --no-deps`), so build scripts and `near-workspaces` can reuse it. The CLI action is a thin wrapper that adds the `--json`/human presentation.

## Try it

```console
$ cargo near build list --manifest-path path/to/workspace/Cargo.toml
$ cargo near build list --manifest-path path/to/workspace/Cargo.toml --json | jq
$ cargo near build list --manifest-path path/to/workspace/Cargo.toml --variants --json | jq
```

Discovery rule is presence of the `reproducible_build` section. An optional `[workspace.metadata.near] members`/`exclude` override is a possible follow-up; context in #407.

## Tests

- Lib unit tests for the output-naming and per-variant fan-out.
- An integration test that runs discovery against a synthesized workspace (variant sorting, default-first, filtering out non-contract members, and asserting the skipped list). No compilation, just `cargo metadata`.
