### PR TITLE
fix: keep `CARGO_NEAR_ABI_PATH` stable across runs and skip no-op ABI copies

### DIFF
--- a/cargo-near-build/src/fs.rs
+++ b/cargo-near-build/src/fs.rs
@@ -3,10 +3,9 @@ use eyre::WrapErr;
 
 /// Copy a file to a destination.
 ///
-/// Does nothing if the destination is the same as the source to avoid truncating the file,
-/// or if the destination already has identical contents — rewriting an unchanged file would
-/// bump its mtime, which spuriously dirties any compilation unit that `include_bytes!`-es it
-/// (e.g. the embedded ABI on platforms where `std::fs::copy` doesn't preserve mtime).
+/// Does nothing if the destination is the same as the source or already has identical
+/// contents — rewriting would bump the mtime and spuriously dirty anything that
+/// `include_bytes!`-es the file.
 #[cfg(feature = "build_internal")]
 pub fn copy(from: &Utf8Path, out_dir: &Utf8Path) -> eyre::Result<Utf8PathBuf> {
     if !out_dir.is_dir() {

--- a/cargo-near-build/src/fs.rs
+++ b/cargo-near-build/src/fs.rs
@@ -3,18 +3,17 @@ use eyre::WrapErr;
 
 /// Copy a file to a destination.
 ///
-/// Does nothing if the destination is the same as the source to avoid truncating the file.
+/// Does nothing if the destination is the same as the source to avoid truncating the file,
+/// or if the destination already has identical contents — rewriting an unchanged file would
+/// bump its mtime, which spuriously dirties any compilation unit that `include_bytes!`-es it
+/// (e.g. the embedded ABI on platforms where `std::fs::copy` doesn't preserve mtime).
 #[cfg(feature = "build_internal")]
 pub fn copy(from: &Utf8Path, out_dir: &Utf8Path) -> eyre::Result<Utf8PathBuf> {
     if !out_dir.is_dir() {
         return Err(eyre::eyre!("`{}` should be a directory", out_dir));
     }
     let out_path = out_dir.join(from.file_name().unwrap());
-    tracing::debug!("Copying file `{}` -> `{}`", from, out_path,);
-    if from != out_path {
-        std::fs::copy(from, &out_path)
-            .wrap_err_with(|| format!("failed to copy `{from}` to `{out_path}`"))?;
-    }
+    copy_to_file(from, &out_path)?;
     Ok(out_path)
 }
 

--- a/cargo-near-build/src/near/build/mod.rs
+++ b/cargo-near-build/src/near/build/mod.rs
@@ -209,6 +209,7 @@ pub fn run(args: Opts) -> eyre::Result<CompilationArtifact> {
 
     let mut abi = None;
     let mut min_abi_path = None;
+    let mut intermediate_min_abi_path = None;
     let builder_version_info = VersionInfo::get_coerced_builder_version()?;
 
     let common_vars_env = buildtime_env::CommonVariables::new(
@@ -265,6 +266,7 @@ pub fn run(args: Opts) -> eyre::Result<CompilationArtifact> {
                 Ok(path)
             })?;
             min_abi_path.replace(crate::fs::copy(&path, output_paths.get_out_dir())?);
+            intermediate_min_abi_path.replace(path);
         }
         abi = Some(contract_abi);
     }
@@ -275,7 +277,14 @@ pub fn run(args: Opts) -> eyre::Result<CompilationArtifact> {
         cargo_args.extend(&["--features", "near-sdk/__abi-embed"]);
     }
 
-    let abi_path_env = buildtime_env::AbiPath::new(args.no_embed_abi, &min_abi_path);
+    // `CARGO_NEAR_ABI_PATH` becomes a compile-time fingerprint of `near-sdk-macros`
+    // (`env!("CARGO_NEAR_ABI_PATH")`) and, through `include_bytes!`, of the contract crate.
+    // It must point at the intermediate file under the resolved target directory — a path
+    // that is identical from run to run — and not at the copy inside `--out-dir`: callers
+    // like near/intents pass a fresh `mktemp -d` out-dir on every invocation, and routing
+    // that path into the env var used to invalidate near-sdk-macros and rebuild the whole
+    // dependency graph on every run.
+    let abi_path_env = buildtime_env::AbiPath::new(args.no_embed_abi, &intermediate_min_abi_path);
 
     // Resolve effective wasm-build rustflags (with `--cfg near` force-appended) as a
     // CARGO_ENCODED_RUSTFLAGS string. See [`encoded_rustflags_with_cfg_near`] for the full

--- a/cargo-near-build/src/near/build/mod.rs
+++ b/cargo-near-build/src/near/build/mod.rs
@@ -277,13 +277,10 @@ pub fn run(args: Opts) -> eyre::Result<CompilationArtifact> {
         cargo_args.extend(&["--features", "near-sdk/__abi-embed"]);
     }
 
-    // `CARGO_NEAR_ABI_PATH` becomes a compile-time fingerprint of `near-sdk-macros`
-    // (`env!("CARGO_NEAR_ABI_PATH")`) and, through `include_bytes!`, of the contract crate.
-    // It must point at the intermediate file under the resolved target directory — a path
-    // that is identical from run to run — and not at the copy inside `--out-dir`: callers
-    // like near/intents pass a fresh `mktemp -d` out-dir on every invocation, and routing
-    // that path into the env var used to invalidate near-sdk-macros and rebuild the whole
-    // dependency graph on every run.
+    // `CARGO_NEAR_ABI_PATH` is a compile-time fingerprint of near-sdk-macros (`env!`) and of
+    // the contract crate (`include_bytes!`), so it must be the run-to-run-stable intermediate
+    // path — pointing it at the `--out-dir` copy rebuilds the whole graph whenever the
+    // out-dir changes (e.g. a fresh `mktemp -d` per invocation).
     let abi_path_env = buildtime_env::AbiPath::new(args.no_embed_abi, &intermediate_min_abi_path);
 
     // Resolve effective wasm-build rustflags (with `--cfg near` force-appended) as a

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -48,6 +48,19 @@ pub fn common_root_for_test_projects_build() -> camino::Utf8PathBuf {
 /// tests in `tests/build/dynamic_max_rustc.rs`.
 const MAX_RUST_VERSION: &str = "1.86.0";
 
+/// Skip the write when the file already has this content: repeated invocations for the same
+/// test project must not bump source mtimes, or every build after the first would spuriously
+/// recompile the fixture (defeating freshness assertions like
+/// `test_build_twice_different_out_dirs_stays_fresh`).
+fn write_if_changed(path: &std::path::Path, content: &[u8]) -> std::io::Result<()> {
+    if let Ok(existing) = std::fs::read(path) {
+        if existing == content {
+            return Ok(());
+        }
+    }
+    std::fs::write(path, content)
+}
+
 pub fn invoke_cargo_near(
     function_name: &str,
     cargo_path: Option<&str>,
@@ -97,11 +110,11 @@ pub fn invoke_cargo_near(
         cargo_toml = cargo_toml.replace(&format!("::{k}::"), &v);
     }
     let cargo_path = crate_dir.join("Cargo.toml");
-    std::fs::write(&cargo_path, cargo_toml)?;
+    write_if_changed(cargo_path.as_std_path(), cargo_toml.as_bytes())?;
 
     let lib_rs = prettyplease::unparse(&lib_rs_file);
     let lib_rs_path = src_dir.join("lib.rs");
-    std::fs::write(lib_rs_path, lib_rs)?;
+    write_if_changed(lib_rs_path.as_std_path(), lib_rs.as_bytes())?;
 
     let cargo_near::CliOpts::Near(cli_args) =
         cargo_near::Opts::try_parse_from(cli_opts.split(" "))?;

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -48,10 +48,8 @@ pub fn common_root_for_test_projects_build() -> camino::Utf8PathBuf {
 /// tests in `tests/build/dynamic_max_rustc.rs`.
 const MAX_RUST_VERSION: &str = "1.86.0";
 
-/// Skip the write when the file already has this content: repeated invocations for the same
-/// test project must not bump source mtimes, or every build after the first would spuriously
-/// recompile the fixture (defeating freshness assertions like
-/// `test_build_twice_different_out_dirs_stays_fresh`).
+/// Skip the write when content is unchanged, so repeated invocations for the same test
+/// project don't bump source mtimes and spuriously recompile the fixture.
 fn write_if_changed(path: &std::path::Path, content: &[u8]) -> std::io::Result<()> {
     if let Ok(existing) = std::fs::read(path)
         && existing == content

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -53,10 +53,10 @@ const MAX_RUST_VERSION: &str = "1.86.0";
 /// recompile the fixture (defeating freshness assertions like
 /// `test_build_twice_different_out_dirs_stays_fresh`).
 fn write_if_changed(path: &std::path::Path, content: &[u8]) -> std::io::Result<()> {
-    if let Ok(existing) = std::fs::read(path) {
-        if existing == content {
-            return Ok(());
-        }
+    if let Ok(existing) = std::fs::read(path)
+        && existing == content
+    {
+        return Ok(());
     }
     std::fs::write(path, content)
 }

--- a/integration-tests/tests/build/opts.rs
+++ b/integration-tests/tests/build/opts.rs
@@ -210,11 +210,9 @@ async fn test_build_both_features_and_abi_features_for_different_targets() -> te
     Ok(())
 }
 
-/// Two builds of the same unchanged contract with different `--out-dir` values must not
-/// recompile anything: nothing about the out-dir may leak into compile-time fingerprints.
-/// Guards against the `CARGO_NEAR_ABI_PATH`-pointing-into-`--out-dir` regression, where
-/// callers passing a fresh temp out-dir per invocation (e.g. near/intents' Makefile) got
-/// the whole dependency graph rebuilt on every run.
+/// Builds differing only in `--out-dir` must stay fully fresh: nothing about the out-dir
+/// may leak into compile-time fingerprints (regression test for `CARGO_NEAR_ABI_PATH`
+/// pointing into `--out-dir`).
 #[test]
 #[named]
 fn test_build_twice_different_out_dirs_stays_fresh() -> testresult::TestResult {
@@ -229,8 +227,7 @@ fn test_build_twice_different_out_dirs_stays_fresh() -> testresult::TestResult {
         }
     };
 
-    // the wasm produced by cargo (before wasm-opt / out-dir copies); any dirtied unit in
-    // the dependency graph re-links this cdylib, so a stable mtime means full freshness
+    // any dirtied unit in the graph re-links this cdylib, so a stable mtime proves freshness
     let cargo_produced_wasm = cargo_near_integration_tests::common_root_for_test_projects_build()
         .join(function_name!())
         .join("target/wasm32-unknown-unknown/release")

--- a/integration-tests/tests/build/opts.rs
+++ b/integration-tests/tests/build/opts.rs
@@ -209,3 +209,52 @@ async fn test_build_both_features_and_abi_features_for_different_targets() -> te
 
     Ok(())
 }
+
+/// Two builds of the same unchanged contract with different `--out-dir` values must not
+/// recompile anything: nothing about the out-dir may leak into compile-time fingerprints.
+/// Guards against the `CARGO_NEAR_ABI_PATH`-pointing-into-`--out-dir` regression, where
+/// callers passing a fresh temp out-dir per invocation (e.g. near/intents' Makefile) got
+/// the whole dependency graph rebuilt on every run.
+#[test]
+#[named]
+fn test_build_twice_different_out_dirs_stays_fresh() -> testresult::TestResult {
+    let out_dir1 = tempfile::tempdir()?;
+    let out_dir2 = tempfile::tempdir()?;
+
+    let _ = build_fn_with! {
+        Opts: format!("--out-dir {}", out_dir1.path().display());
+        Code:
+        pub fn add(&self, a: u32, b: u32) -> u32 {
+            a + b
+        }
+    };
+
+    // the wasm produced by cargo (before wasm-opt / out-dir copies); any dirtied unit in
+    // the dependency graph re-links this cdylib, so a stable mtime means full freshness
+    let cargo_produced_wasm = cargo_near_integration_tests::common_root_for_test_projects_build()
+        .join(function_name!())
+        .join("target/wasm32-unknown-unknown/release")
+        .join(format!("{}.wasm", function_name!()));
+    assert!(
+        cargo_produced_wasm.exists(),
+        "cargo-produced wasm expected at {cargo_produced_wasm}"
+    );
+    let mtime_after_first = fs::metadata(&cargo_produced_wasm)?.modified()?;
+
+    let _ = build_fn_with! {
+        Opts: format!("--out-dir {}", out_dir2.path().display());
+        Code:
+        pub fn add(&self, a: u32, b: u32) -> u32 {
+            a + b
+        }
+    };
+    let mtime_after_second = fs::metadata(&cargo_produced_wasm)?.modified()?;
+
+    assert_eq!(
+        mtime_after_first, mtime_after_second,
+        "changing --out-dir between otherwise identical builds must not recompile or re-link \
+         anything, but the cargo-produced wasm was rewritten"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Problem

Follow-up to #447, which fixed the ABI-generation target-dir collisions but did not stop the full-graph recompilation reported on repos like [near/intents](https://github.com/near/intents) (`make` twice → everything rebuilds).

Root cause: `CARGO_NEAR_ABI_PATH` was set to the embedded-ABI copy inside `--out-dir`. `near-sdk-macros` evaluates `env!("CARGO_NEAR_ABI_PATH")` while compiling **itself** ([abi_embed.rs](https://github.com/near/near-sdk-rs/blob/near-sdk-v5.28.3/near-sdk-macros/src/core_impl/abi/abi_embed.rs#L4-L9)), so rustc records the value in its dep-info:

```
# env-dep:CARGO_NEAR_ABI_PATH=…/target/makenear/tmp.DeThpEM4Mf/defuse_abi.zst
```

near/intents' Makefile passes `--out-dir=$(mktemp -d …)` — a fresh random path on every `make` — so the env value changed every run, dirtying `near-sdk-macros` → `near-sdk` → the entire contract dependency graph, every time.

## Fix

- Point `CARGO_NEAR_ABI_PATH` at the intermediate ABI file under the resolved target directory (`target/near/<pkg>/<pkg>_abi.zst`). That path is identical from run to run, and `abi::write_to_file` already skips rewriting it on identical contents. The copy into `--out-dir` still happens and remains the user-facing artifact/reported path.
- Route `fs::copy` through `copy_to_file` so it inherits the identical-contents skip. Unconditionally rewriting the unchanged `*_abi.zst` bumps its mtime on platforms where `std::fs::copy` doesn't preserve mtime (Linux), which spuriously dirties the contract crate that `include_bytes!`-es it even with a stable out-dir. (Invisible on macOS, where `std::fs::copy` preserves the source mtime.)

## Verification

On near/intents with the defuse contract, using the exact Makefile command with a fresh `mktemp -d` out-dir per run:

| | run 1 | run 2 (new out-dir) |
|---|---|---|
| before | full build | **22 crates recompiled** (near-sdk-macros, near-sdk + downstream) |
| after | full build | **0 crates recompiled** |

Dep-info now records the stable path:
```
# env-dep:CARGO_NEAR_ABI_PATH=…/target/near/defuse/defuse_abi.zst
```

## What this does NOT fix

Alternating between *different* contracts of one workspace (as a full `make` in near/intents does across its 14 contract jobs) still rebuilds `near-sdk-macros` and everything downstream on each switch, because the ABI path legitimately differs per contract while the env var is consumed at `near-sdk-macros`' own compile time (both in its [build.rs](https://github.com/near/near-sdk-rs/blob/near-sdk-v5.28.3/near-sdk-macros/build.rs) via `option_env!` and in `abi_embed.rs` via `env!`). Fixing that requires a near-sdk-rs change: defer the env read into the tokens emitted for the contract crate (e.g. `include_bytes!(env!("CARGO_NEAR_ABI_PATH"))`), so the env-dep lands on each contract crate with its own stable value. This PR is still a prerequisite for that to help: without a stable path, the per-contract env-dep would keep flipping via the random out-dir.