### PR TITLE
fix: clarify git commit progress in cargo near new

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,17 +28,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,7 +87,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -109,7 +98,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -385,28 +374,6 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
-
-[[package]]
-name = "bytecheck"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "byteorder"
@@ -748,7 +715,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1332,7 +1299,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1499,7 +1466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1889,9 +1856,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1911,9 +1878,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2395,7 +2359,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2857,7 +2821,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3559,7 +3523,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3984,26 +3948,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4265,15 +4209,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
-name = "rend"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4373,46 +4308,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "rkyv"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
-dependencies = [
- "bitvec",
- "bytecheck",
- "bytes",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "rust_decimal"
-version = "1.42.1"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
+checksum = "7653272e75dcac41dc199fbea6f5797633994fafd339943c06c9af16bf29cd3a"
 dependencies = [
  "arrayvec",
  "borsh",
  "bytes",
  "num-traits",
  "rand 0.8.6",
- "rkyv",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "wasm-bindgen",
@@ -4449,7 +4355,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4508,7 +4414,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4644,12 +4550,6 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
-
-[[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "secp256k1"
@@ -5117,7 +5017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5362,7 +5262,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6302,7 +6202,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/cargo-near/src/commands/new/mod.rs
+++ b/cargo-near/src/commands/new/mod.rs
@@ -191,9 +191,8 @@ fn execute_git_commands(project_dir: &std::path::Path) -> near_cli_rs::CliResult
         }
     })();
     let retry = format!(
-        "Project files were created at '{}'. To retry the initial commit, run:\n  git -C {} commit -m init --author='nearprotocol-ci <nearprotocol-ci@near.org>'",
+        "Project files were created at '{}'. From that directory, retry the initial commit with:\n  git commit -m init --author=\"nearprotocol-ci <nearprotocol-ci@near.org>\"",
         project_dir.display(),
-        shell_words::quote(&project_dir.to_string_lossy()),
     );
     let status = status
         .wrap_err("Failed to execute the initial Git commit")

--- a/cargo-near/src/commands/new/mod.rs
+++ b/cargo-near/src/commands/new/mod.rs
@@ -84,29 +84,27 @@ impl NewContext {
 
         execute_git_commands(project_dir)?;
 
-        println!("New project is created at '{}'.\n", project_dir.display());
-        println!("Now you can build, test, and deploy your project using cargo-near:");
-        println!(" * `cargo near build`");
-        println!(" * `cargo test`");
-        println!(" * `cargo near deploy`");
-        println!(
-            "Your new project has preconfigured automations for CI and CD, just configure \
+        tracing_indicatif::suspend_tracing_indicatif(|| {
+            println!("New project is created at '{}'.\n", project_dir.display());
+            println!("Now you can build, test, and deploy your project using cargo-near:");
+            println!(" * `cargo near build`");
+            println!(" * `cargo test`");
+            println!(" * `cargo near deploy`");
+            println!(
+                "Your new project has preconfigured automations for CI and CD, just configure \
             `NEAR_CONTRACT_STAGING_*` and `NEAR_CONTRACT_PRODUCTION_*` variables and secrets \
             on GitHub to enable automatic deployment to staging and production. See more \
             details in `.github/workflow/*` files.\n"
-        );
+            );
+        });
 
         Ok(Self)
     }
 }
 
-#[tracing::instrument(
-    target = "tracing_instrument",
-    name = "The process of executing",
-    skip_all
-)]
+#[tracing::instrument(target = "tracing_instrument", name = "Preparing project:", skip_all)]
 fn execute_git_commands(project_dir: &std::path::Path) -> near_cli_rs::CliResult {
-    tracing::Span::current().pb_set_message("`git` commands ...");
+    tracing::Span::current().pb_set_message("Initializing Git repository ...");
     tracing::info!(target: "near_teach_me", parent: &tracing::Span::none(), "Command execution: `git init`");
     let child_result = std::process::Command::new("git")
         .arg("init")
@@ -133,6 +131,7 @@ fn execute_git_commands(project_dir: &std::path::Path) -> near_cli_rs::CliResult
         ));
     }
 
+    tracing::Span::current().pb_set_message("Resolving dependencies (`cargo update`) ...");
     tracing::info!(target: "near_teach_me", parent: &tracing::Span::none(), "Command execution: `cargo update`");
     let child = std::process::Command::new("cargo")
         .arg("update")
@@ -148,6 +147,7 @@ fn execute_git_commands(project_dir: &std::path::Path) -> near_cli_rs::CliResult
         ));
     }
 
+    tracing::Span::current().pb_set_message("Staging project files ...");
     tracing::info!(target: "near_teach_me", parent: &tracing::Span::none(), "Command execution: `git add -A`");
     let status = std::process::Command::new("git")
         .arg("add")
@@ -163,21 +163,46 @@ fn execute_git_commands(project_dir: &std::path::Path) -> near_cli_rs::CliResult
     }
 
     tracing::info!(target: "near_teach_me", parent: &tracing::Span::none(), "Command execution: `git commit -m init --author='nearprotocol-ci <nearprotocol-ci@near.org>'`");
-    let child = std::process::Command::new("git")
-        .arg("commit")
-        .arg("-m")
-        .arg("init")
-        .arg("--author=nearprotocol-ci <nearprotocol-ci@near.org>")
-        .current_dir(project_dir)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()?;
-    let output = child.wait_with_output()?;
-    if !output.status.success() {
-        println!("{}", String::from_utf8_lossy(&output.stderr));
+    tracing::Span::current().pb_set_message("Creating initial git commit ...");
+    let status = (|| -> std::io::Result<std::process::ExitStatus> {
+        let mut child = std::process::Command::new("git")
+            .arg("commit")
+            .arg("-m")
+            .arg("init")
+            .arg("--author=nearprotocol-ci <nearprotocol-ci@near.org>")
+            .current_dir(project_dir)
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::null())
+            .stderr(Stdio::inherit())
+            .spawn()?;
+        let started = std::time::Instant::now();
+        let mut hint_shown = false;
+        loop {
+            if let Some(status) = child.try_wait()? {
+                return Ok(status);
+            }
+            if !hint_shown && started.elapsed() >= std::time::Duration::from_secs(10) {
+                tracing::Span::current().pb_set_message(
+                    "Waiting for git commit — check your signing prompt or security key",
+                );
+                hint_shown = true;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+    })();
+    let retry = format!(
+        "Project files were created at '{}'. To retry the initial commit, run:\n  git -C {} commit -m init --author='nearprotocol-ci <nearprotocol-ci@near.org>'",
+        project_dir.display(),
+        shell_words::quote(&project_dir.to_string_lossy()),
+    );
+    let status = status
+        .wrap_err("Failed to execute the initial Git commit")
+        .note(retry.clone())?;
+    if !status.success() {
         return Err(color_eyre::eyre::eyre!(
-            "Failed to execute process: `git commit -m init --author='nearprotocol-ci <nearprotocol-ci@near.org>'`"
-        ));
+            "Failed to create the initial Git commit ({status})"
+        ))
+        .note(retry);
     }
 
     Ok(())


### PR DESCRIPTION
Show each setup step and update the commit spinner after 10s to suggest checking signing. Preserve Git errors and show a retry command.

Also update `h2` and `rust_decimal` to clear cargo audit.

Tested: signing scenarios, build, formatting and cargo audit.

#### Before/after video (simulated approval).

https://github.com/user-attachments/assets/2299ca37-4262-4951-a9dc-cc5cafb55488



| Before | Waiting after 10s | Completed |
| --- | --- | --- |
| ![Before](https://raw.githubusercontent.com/near/cargo-near/f4afad7ec910b2288ab12e21530eceba514e5f28/before.png) | ![Waiting](https://raw.githubusercontent.com/near/cargo-near/f4afad7ec910b2288ab12e21530eceba514e5f28/waiting.png) | ![Completed](https://raw.githubusercontent.com/near/cargo-near/f4afad7ec910b2288ab12e21530eceba514e5f28/completed.png) |
